### PR TITLE
Align testing utilities with React Testing Library

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -38,8 +38,9 @@
         "src"
     ],
     "scripts": {
-        "build": "tsc -b && cp ../../README.md .",
+        "build": "tsc -b",
         "test": "vitest run",
+        "coverage": "vitest run --coverage",
         "typecheck": "tsc -b --emitDeclarationOnly"
     },
     "dependencies": {

--- a/packages/testing/src/bind-queries.ts
+++ b/packages/testing/src/bind-queries.ts
@@ -1,7 +1,7 @@
 import type * as Gtk from "@gtkx/ffi/gtk";
 import * as queries from "./queries.js";
 import type { Container } from "./traversal.js";
-import type { BoundQueries, ByRoleOptions, TextMatch, TextMatchOptions } from "./types.js";
+import type { BoundQueries, ByRoleOptions, Matcher, MatcherOptions } from "./types.js";
 
 type ContainerOrGetter = Container | (() => Container);
 
@@ -13,40 +13,54 @@ const resolveContainer = (containerOrGetter: ContainerOrGetter): Container =>
  *
  * @param containerOrGetter - The container to bind queries to, or a function that returns it
  * @returns Object with all query methods bound to the container
- *
- * @internal
  */
 export const bindQueries = (containerOrGetter: ContainerOrGetter): BoundQueries => ({
     queryByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) =>
         queries.queryByRole(resolveContainer(containerOrGetter), role, options),
-    queryByLabelText: (text: TextMatch, options?: TextMatchOptions) =>
+    queryByLabelText: (text: Matcher, options?: MatcherOptions) =>
         queries.queryByLabelText(resolveContainer(containerOrGetter), text, options),
-    queryByText: (text: TextMatch, options?: TextMatchOptions) =>
+    queryByText: (text: Matcher, options?: MatcherOptions) =>
         queries.queryByText(resolveContainer(containerOrGetter), text, options),
-    queryByName: (name: TextMatch, options?: TextMatchOptions) =>
+    queryByName: (name: Matcher, options?: MatcherOptions) =>
         queries.queryByName(resolveContainer(containerOrGetter), name, options),
     queryAllByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) =>
         queries.queryAllByRole(resolveContainer(containerOrGetter), role, options),
-    queryAllByLabelText: (text: TextMatch, options?: TextMatchOptions) =>
+    queryAllByLabelText: (text: Matcher, options?: MatcherOptions) =>
         queries.queryAllByLabelText(resolveContainer(containerOrGetter), text, options),
-    queryAllByText: (text: TextMatch, options?: TextMatchOptions) =>
+    queryAllByText: (text: Matcher, options?: MatcherOptions) =>
         queries.queryAllByText(resolveContainer(containerOrGetter), text, options),
-    queryAllByName: (name: TextMatch, options?: TextMatchOptions) =>
+    queryAllByName: (name: Matcher, options?: MatcherOptions) =>
         queries.queryAllByName(resolveContainer(containerOrGetter), name, options),
+    getByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) =>
+        queries.getByRole(resolveContainer(containerOrGetter), role, options),
+    getByLabelText: (text: Matcher, options?: MatcherOptions) =>
+        queries.getByLabelText(resolveContainer(containerOrGetter), text, options),
+    getByText: (text: Matcher, options?: MatcherOptions) =>
+        queries.getByText(resolveContainer(containerOrGetter), text, options),
+    getByName: (name: Matcher, options?: MatcherOptions) =>
+        queries.getByName(resolveContainer(containerOrGetter), name, options),
+    getAllByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) =>
+        queries.getAllByRole(resolveContainer(containerOrGetter), role, options),
+    getAllByLabelText: (text: Matcher, options?: MatcherOptions) =>
+        queries.getAllByLabelText(resolveContainer(containerOrGetter), text, options),
+    getAllByText: (text: Matcher, options?: MatcherOptions) =>
+        queries.getAllByText(resolveContainer(containerOrGetter), text, options),
+    getAllByName: (name: Matcher, options?: MatcherOptions) =>
+        queries.getAllByName(resolveContainer(containerOrGetter), name, options),
     findByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) =>
         queries.findByRole(resolveContainer(containerOrGetter), role, options),
-    findByLabelText: (text: TextMatch, options?: TextMatchOptions) =>
+    findByLabelText: (text: Matcher, options?: MatcherOptions) =>
         queries.findByLabelText(resolveContainer(containerOrGetter), text, options),
-    findByText: (text: TextMatch, options?: TextMatchOptions) =>
+    findByText: (text: Matcher, options?: MatcherOptions) =>
         queries.findByText(resolveContainer(containerOrGetter), text, options),
-    findByName: (name: TextMatch, options?: TextMatchOptions) =>
+    findByName: (name: Matcher, options?: MatcherOptions) =>
         queries.findByName(resolveContainer(containerOrGetter), name, options),
     findAllByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) =>
         queries.findAllByRole(resolveContainer(containerOrGetter), role, options),
-    findAllByLabelText: (text: TextMatch, options?: TextMatchOptions) =>
+    findAllByLabelText: (text: Matcher, options?: MatcherOptions) =>
         queries.findAllByLabelText(resolveContainer(containerOrGetter), text, options),
-    findAllByText: (text: TextMatch, options?: TextMatchOptions) =>
+    findAllByText: (text: Matcher, options?: MatcherOptions) =>
         queries.findAllByText(resolveContainer(containerOrGetter), text, options),
-    findAllByName: (name: TextMatch, options?: TextMatchOptions) =>
+    findAllByName: (name: Matcher, options?: MatcherOptions) =>
         queries.findAllByName(resolveContainer(containerOrGetter), name, options),
 });

--- a/packages/testing/src/error-builder.ts
+++ b/packages/testing/src/error-builder.ts
@@ -3,11 +3,11 @@ import { getConfig } from "./config.js";
 import { prettyWidget } from "./pretty-widget.js";
 import { formatRole, prettyRoles } from "./role-helpers.js";
 import type { Container } from "./traversal.js";
-import type { ByRoleOptions, TextMatch } from "./types.js";
+import type { ByRoleOptions, Matcher } from "./types.js";
 
 type QueryType = "role" | "text" | "labelText" | "name";
 
-const formatTextMatcher = (text: TextMatch): string => {
+const formatTextMatcher = (text: Matcher): string => {
     if (typeof text === "function") {
         return "custom function";
     }
@@ -28,43 +28,38 @@ const formatByRoleDescription = (role: Gtk.AccessibleRole, options?: ByRoleOptio
     return parts.join(" and ");
 };
 
-const formatQueryDescription = (
-    queryType: QueryType,
-    args: { role?: Gtk.AccessibleRole; text?: TextMatch; name?: TextMatch; options?: ByRoleOptions },
-): string => {
+type QueryArgs = { role?: Gtk.AccessibleRole; text?: Matcher; name?: Matcher; options?: ByRoleOptions };
+
+const formatQueryDescription = (queryType: QueryType, args: QueryArgs): string => {
     switch (queryType) {
         case "role":
-            return formatByRoleDescription(args.role as Gtk.AccessibleRole, args.options);
+            if (args.role === undefined) return "role";
+            return formatByRoleDescription(args.role, args.options);
         case "text":
-            return `text ${formatTextMatcher(args.text as TextMatch)}`;
+            if (args.text === undefined) return "text";
+            return `text ${formatTextMatcher(args.text)}`;
         case "labelText":
-            return `label text ${formatTextMatcher(args.text as TextMatch)}`;
+            if (args.text === undefined) return "label text";
+            return `label text ${formatTextMatcher(args.text)}`;
         case "name":
-            return `name ${formatTextMatcher(args.name as TextMatch)}`;
+            if (args.name === undefined) return "name";
+            return `name ${formatTextMatcher(args.name)}`;
     }
 };
 
 /**
  * Builds an error for when no elements match a query.
  */
-export const buildNotFoundError = (
-    container: Container,
-    queryType: QueryType,
-    args: { role?: Gtk.AccessibleRole; text?: TextMatch; name?: TextMatch; options?: ByRoleOptions },
-): Error => {
+export const buildNotFoundError = (container: Container, queryType: QueryType, args: QueryArgs): Error => {
     const config = getConfig();
     const description = formatQueryDescription(queryType, args);
     const lines: string[] = [`Unable to find an element with ${description}`];
 
     if (config.showSuggestions && queryType === "role") {
-        lines.push("");
-        lines.push("Here are the accessible roles:");
-        lines.push("");
-        lines.push(prettyRoles(container));
+        lines.push("", "Here are the accessible roles:", "", prettyRoles(container));
     }
 
-    lines.push("");
-    lines.push(prettyWidget(container, { highlight: false }));
+    lines.push("", prettyWidget(container, { highlight: false }));
 
     const message = lines.join("\n");
     return config.getElementError(message, container);
@@ -76,15 +71,16 @@ export const buildNotFoundError = (
 export const buildMultipleFoundError = (
     container: Container,
     queryType: QueryType,
-    args: { role?: Gtk.AccessibleRole; text?: TextMatch; name?: TextMatch; options?: ByRoleOptions },
+    args: QueryArgs,
     count: number,
 ): Error => {
     const config = getConfig();
     const description = formatQueryDescription(queryType, args);
-    const lines: string[] = [`Found ${count} elements with ${description}, but expected only one`];
-
-    lines.push("");
-    lines.push(prettyWidget(container, { highlight: false }));
+    const lines: string[] = [
+        `Found ${count} elements with ${description}, but expected only one`,
+        "",
+        prettyWidget(container, { highlight: false }),
+    ];
 
     const message = lines.join("\n");
     return config.getElementError(message, container);

--- a/packages/testing/src/fire-event.ts
+++ b/packages/testing/src/fire-event.ts
@@ -1,43 +1,37 @@
-import { type Object as GObject, signalEmitv, signalLookup, typeFromName, Value } from "@gtkx/ffi/gobject";
-import type * as Gtk from "@gtkx/ffi/gtk";
-import { tick } from "./timing.js";
+import type * as GObject from "@gtkx/ffi/gobject";
+import { act } from "./timing.js";
 
 /**
- * Emits a GTK signal on a widget or event controller.
+ * Emits a signal on any GObject — widgets, event controllers, selection models,
+ * and other signal-emitting objects.
  *
  * Low-level utility for triggering signals directly. Prefer {@link userEvent}
  * for common interactions like clicking and typing.
  *
- * @param element - The widget or event controller to emit the signal on
+ * @param element - The GObject to emit the signal on
  * @param signalName - GTK signal name (e.g., "clicked", "activate", "drag-begin")
- * @param args - Additional signal arguments as GValues
+ * @param args - Signal arguments as plain JavaScript values; each is
+ *   auto-marshalled to the signal's GIR-defined parameter type
  *
  * @example
  * ```tsx
  * import { fireEvent } from "@gtkx/testing";
- * import { Value } from "@gtkx/ffi/gobject";
  *
  * // Emit signal on widget
  * await fireEvent(widget, "clicked");
  *
  * // Emit signal on gesture controller
  * const gesture = widget.observeControllers().getObject(0) as Gtk.GestureDrag;
- * await fireEvent(gesture, "drag-begin", Value.newFromDouble(100), Value.newFromDouble(100));
+ * await fireEvent(gesture, "drag-begin", 100, 100);
+ *
+ * // Emit signal on a selection model
+ * await fireEvent(listView.getModel(), "selection-changed", 0, 1);
  * ```
  *
  * @see {@link userEvent} for high-level user interactions
  */
-export const fireEvent = async (
-    element: Gtk.Widget | Gtk.EventController,
-    signalName: string,
-    ...args: Value[]
-): Promise<void> => {
-    const gtype = typeFromName((element.constructor as typeof GObject).glibTypeName);
-    const signalId = signalLookup(signalName, gtype);
-
-    const instanceValue = Value.newFromObject(element as GObject);
-
-    signalEmitv([instanceValue, ...args], signalId, 0);
-
-    await tick();
+export const fireEvent = async (element: GObject.Object, signalName: string, ...args: unknown[]): Promise<void> => {
+    await act(() => {
+        element.emit(signalName, ...args);
+    });
 };

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -12,6 +12,14 @@ export {
     findByName,
     findByRole,
     findByText,
+    getAllByLabelText,
+    getAllByName,
+    getAllByRole,
+    getAllByText,
+    getByLabelText,
+    getByName,
+    getByRole,
+    getByText,
     queryAllByLabelText,
     queryAllByName,
     queryAllByRole,
@@ -25,27 +33,27 @@ export { cleanup, render } from "./render.js";
 export { renderHook } from "./render-hook.js";
 export type { RoleInfo } from "./role-helpers.js";
 export { getRoles, logRoles, prettyRoles } from "./role-helpers.js";
-export { screen } from "./screen.js";
+export { logScreenshotPath, screen } from "./screen.js";
 export type { ScreenshotOptions } from "./screenshot.js";
 export { screenshot } from "./screenshot.js";
-export { tick } from "./timing.js";
+export { act } from "./timing.js";
 export type { Container } from "./traversal.js";
 export type {
     BoundQueries,
     ByRoleOptions,
+    Matcher,
+    MatcherFunction,
+    MatcherOptions,
     NormalizerOptions,
     RenderHookOptions,
     RenderHookResult,
     RenderOptions,
     RenderResult,
     ScreenshotResult,
-    TextMatch,
-    TextMatchFunction,
-    TextMatchOptions,
     WaitForOptions,
     WrapperComponent,
 } from "./types.js";
-export type { PointerInput, TabOptions } from "./user-event.js";
+export type { PointerInput, TabOptions, UserEventInstance } from "./user-event.js";
 export { userEvent } from "./user-event.js";
 export { waitFor, waitForElementToBeRemoved } from "./wait-for.js";
 export { within } from "./within.js";

--- a/packages/testing/src/pretty-widget.ts
+++ b/packages/testing/src/pretty-widget.ts
@@ -30,51 +30,7 @@ export type PrettyWidgetOptions = {
     includeIds?: boolean;
 };
 
-type HighlightColors = {
-    tag: (s: string) => string;
-    attr: (s: string) => string;
-    value: (s: string) => string;
-    text: (s: string) => string;
-    reset: string;
-};
-
-const shouldHighlight = (): boolean => {
-    if (typeof process === "undefined") return false;
-    if (process.env.COLORS === "false" || process.env.NO_COLOR) return false;
-    if (process.env.COLORS === "true" || process.env.FORCE_COLOR) return true;
-    return process.stdout?.isTTY ?? false;
-};
-
-const ansi = {
-    cyan: "\x1b[36m",
-    yellow: "\x1b[33m",
-    green: "\x1b[32m",
-    reset: "\x1b[0m",
-};
-
-const createColors = (enabled: boolean): HighlightColors => {
-    if (!enabled) {
-        const identity = (s: string): string => s;
-        return { tag: identity, attr: identity, value: identity, text: identity, reset: "" };
-    }
-    return {
-        tag: (s) => `${ansi.cyan}${s}${ansi.reset}`,
-        attr: (s) => `${ansi.yellow}${s}${ansi.reset}`,
-        value: (s) => `${ansi.green}${s}${ansi.reset}`,
-        text: (s) => s,
-        reset: ansi.reset,
-    };
-};
-
-const formatTagName = (widget: Gtk.Widget): string => {
-    return widget.constructor.name;
-};
-
-const escapeAttrValue = (value: string): string => {
-    return value.replace(/"/g, "&quot;");
-};
-
-const formatAttributes = (widget: Gtk.Widget, colors: HighlightColors, includeIds: boolean): string => {
+const buildAttrs = (widget: Gtk.Widget, includeIds: boolean): ReadonlyArray<readonly [string, string]> => {
     const attrs: [string, string][] = [];
 
     if (includeIds) {
@@ -99,66 +55,75 @@ const formatAttributes = (widget: Gtk.Widget, colors: HighlightColors, includeId
         attrs.push(["aria-hidden", "true"]);
     }
 
-    if (attrs.length === 0) return "";
-
-    return attrs
-        .sort(([a], [b]) => {
-            if (a === "id") return -1;
-            if (b === "id") return 1;
-            return a.localeCompare(b);
-        })
-        .map(([key, value]) => ` ${colors.attr(key)}=${colors.value(`"${escapeAttrValue(value)}"`)}`)
-        .join("");
+    return attrs.toSorted(([a], [b]) => {
+        if (a === "id") return -1;
+        if (b === "id") return 1;
+        return a.localeCompare(b);
+    });
 };
 
-const hasChildren = (widget: Gtk.Widget): boolean => {
-    return widget.getFirstChild() !== null;
+type Colors = {
+    tag: (s: string) => string;
+    attr: (s: string) => string;
+    value: (s: string) => string;
 };
 
-const printWidget = (widget: Gtk.Widget, colors: HighlightColors, depth: number, includeIds: boolean): string => {
-    const indent = INDENT.repeat(depth);
-    const tagName = formatTagName(widget);
-    const attributes = formatAttributes(widget, colors, includeIds);
-    const text = getWidgetPropertyText(widget);
-    const children: string[] = [];
+const ansi = {
+    cyan: "\x1b[36m",
+    yellow: "\x1b[33m",
+    green: "\x1b[32m",
+    reset: "\x1b[0m",
+};
 
-    let child = widget.getFirstChild();
-    while (child) {
-        children.push(printWidget(child, colors, depth + 1, includeIds));
-        child = child.getNextSibling();
+const shouldHighlight = (): boolean => {
+    if (typeof process === "undefined") return false;
+    if (process.env.COLORS === "false" || process.env.NO_COLOR) return false;
+    if (process.env.COLORS === "true" || process.env.FORCE_COLOR) return true;
+    return process.stdout?.isTTY ?? false;
+};
+
+const createColors = (enabled: boolean): Colors => {
+    if (!enabled) {
+        const identity = (s: string): string => s;
+        return { tag: identity, attr: identity, value: identity };
     }
+    return {
+        tag: (s) => `${ansi.cyan}${s}${ansi.reset}`,
+        attr: (s) => `${ansi.yellow}${s}${ansi.reset}`,
+        value: (s) => `${ansi.green}${s}${ansi.reset}`,
+    };
+};
 
-    const openTag = `${colors.tag("<")}${colors.tag(tagName)}${attributes}${colors.tag(">")}`;
+const escapeAttrValue = (value: string): string => value.replaceAll('"', "&quot;");
 
-    if (!hasChildren(widget) && !text) {
+const formatAttrs = (attrs: ReadonlyArray<readonly [string, string]>, colors: Colors): string =>
+    attrs.map(([key, value]) => ` ${colors.attr(key)}=${colors.value(`"${escapeAttrValue(value)}"`)}`).join("");
+
+const formatWidget = (widget: Gtk.Widget, depth: number, includeIds: boolean, colors: Colors): string => {
+    const indent = INDENT.repeat(depth);
+    const tag = widget.constructor.name;
+    const attrs = formatAttrs(buildAttrs(widget, includeIds), colors);
+    const openTag = `${colors.tag("<")}${colors.tag(tag)}${attrs}${colors.tag(">")}`;
+    const closeTag = `${colors.tag("</")}${colors.tag(tag)}${colors.tag(">")}`;
+
+    const text = getWidgetPropertyText(widget);
+    const firstChild = widget.getFirstChild();
+
+    if (!text && !firstChild) {
         return `${indent}${openTag}\n`;
     }
 
-    const closeTag = `${colors.tag("</")}${colors.tag(tagName)}${colors.tag(">")}`;
-
-    if (text && !hasChildren(widget)) {
-        const textContent = colors.text(text);
-        return `${indent}${openTag}\n${indent}${INDENT}${textContent}\n${indent}${closeTag}\n`;
-    }
-
-    let result = `${indent}${openTag}\n`;
+    let output = `${indent}${openTag}\n`;
     if (text) {
-        result += `${indent}${INDENT}${colors.text(text)}\n`;
+        output += `${indent}${INDENT}${text}\n`;
     }
-    for (const childOutput of children) {
-        result += childOutput;
+    let child = firstChild;
+    while (child) {
+        output += formatWidget(child, depth + 1, includeIds, colors);
+        child = child.getNextSibling();
     }
-    result += `${indent}${closeTag}\n`;
-
-    return result;
-};
-
-const printContainer = (container: Container, colors: HighlightColors, includeIds: boolean): string => {
-    if (isApplication(container)) {
-        const windows = Gtk.Window.listToplevels();
-        return windows.map((window) => printWidget(window, colors, 0, includeIds)).join("");
-    }
-    return printWidget(container, colors, 0, includeIds);
+    output += `${indent}${closeTag}\n`;
+    return output;
 };
 
 /**
@@ -187,15 +152,23 @@ const printContainer = (container: Container, colors: HighlightColors, includeId
 export const prettyWidget = (container: Container, options: PrettyWidgetOptions = {}): string => {
     const envLimit = process.env.DEBUG_PRINT_LIMIT ? Number(process.env.DEBUG_PRINT_LIMIT) : DEFAULT_MAX_LENGTH;
     const maxLength = options.maxLength ?? envLimit;
-    const highlight = options.highlight ?? shouldHighlight();
-    const includeIds = options.includeIds ?? false;
 
     if (maxLength === 0) {
         return "";
     }
 
+    const highlight = options.highlight ?? shouldHighlight();
+    const includeIds = options.includeIds ?? false;
     const colors = createColors(highlight);
-    const output = printContainer(container, colors, includeIds);
+
+    let output = "";
+    if (isApplication(container)) {
+        for (const window of Gtk.Window.listToplevels()) {
+            output += formatWidget(window, 0, includeIds, colors);
+        }
+    } else if (container instanceof Gtk.Widget) {
+        output += formatWidget(container, 0, includeIds, colors);
+    }
 
     if (output.length > maxLength) {
         return `${output.slice(0, maxLength)}...`;

--- a/packages/testing/src/queries.ts
+++ b/packages/testing/src/queries.ts
@@ -1,8 +1,8 @@
 import * as Gtk from "@gtkx/ffi/gtk";
 import { buildMultipleFoundError, buildNotFoundError } from "./error-builder.js";
+import { buildQueries } from "./query-helpers.js";
 import { type Container, findAll, traverse } from "./traversal.js";
-import type { ByRoleOptions, TextMatch, TextMatchOptions } from "./types.js";
-import { waitFor } from "./wait-for.js";
+import type { ByRoleOptions, Matcher, MatcherOptions } from "./types.js";
 import {
     getWidgetAccessibleName,
     getWidgetCheckedState,
@@ -13,7 +13,7 @@ import {
     getWidgetText,
 } from "./widget-text.js";
 
-const buildNormalizer = (options?: TextMatchOptions): ((text: string) => string) => {
+const buildNormalizer = (options?: MatcherOptions): ((text: string) => string) => {
     if (options?.normalizer) {
         return options.normalizer;
     }
@@ -28,24 +28,19 @@ const buildNormalizer = (options?: TextMatchOptions): ((text: string) => string)
         }
 
         if (collapseWhitespace) {
-            result = result.replace(/\s+/g, " ");
+            result = result.replaceAll(/\s+/g, " ");
         }
 
         return result;
     };
 };
 
-const normalizeText = (text: string, options?: TextMatchOptions): string => {
+const normalizeText = (text: string, options?: MatcherOptions): string => {
     const normalizer = buildNormalizer(options);
     return normalizer(text);
 };
 
-const matchText = (
-    actual: string | null,
-    expected: TextMatch,
-    widget: Gtk.Widget,
-    options?: TextMatchOptions,
-): boolean => {
+const matchText = (actual: string | null, expected: Matcher, widget: Gtk.Widget, options?: MatcherOptions): boolean => {
     if (actual === null) return false;
 
     const normalizedActual = normalizeText(actual, options);
@@ -66,35 +61,23 @@ const matchText = (
         : normalizedActual.toLowerCase().includes(normalizedExpected.toLowerCase());
 };
 
+const matchAccessibleName = (widget: Gtk.Widget, options: ByRoleOptions): boolean => {
+    if (options.name === undefined) return true;
+    const text = getWidgetAccessibleName(widget);
+    return matchText(text, options.name, widget, options);
+};
+
+const matchAccessibleStates = (widget: Gtk.Widget, options: ByRoleOptions): boolean => {
+    if (options.checked !== undefined && getWidgetCheckedState(widget) !== options.checked) return false;
+    if (options.pressed !== undefined && getWidgetPressedState(widget) !== options.pressed) return false;
+    if (options.expanded !== undefined && getWidgetExpandedState(widget) !== options.expanded) return false;
+    if (options.selected !== undefined && getWidgetSelectedState(widget) !== options.selected) return false;
+    return true;
+};
+
 const matchByRoleOptions = (widget: Gtk.Widget, options?: ByRoleOptions): boolean => {
     if (!options) return true;
-
-    if (options.name !== undefined) {
-        const text = getWidgetAccessibleName(widget);
-        if (!matchText(text, options.name, widget, options)) return false;
-    }
-
-    if (options.checked !== undefined) {
-        const checked = getWidgetCheckedState(widget);
-        if (checked !== options.checked) return false;
-    }
-
-    if (options.pressed !== undefined) {
-        const pressed = getWidgetPressedState(widget);
-        if (pressed !== options.pressed) return false;
-    }
-
-    if (options.expanded !== undefined) {
-        const expanded = getWidgetExpandedState(widget);
-        if (expanded !== options.expanded) return false;
-    }
-
-    if (options.selected !== undefined) {
-        const selected = getWidgetSelectedState(widget);
-        if (selected !== options.selected) return false;
-    }
-
-    return true;
+    return matchAccessibleName(widget, options) && matchAccessibleStates(widget, options);
 };
 
 /**
@@ -105,57 +88,30 @@ const matchByRoleOptions = (widget: Gtk.Widget, options?: ByRoleOptions): boolea
  * @param options - Query options including name and state filters
  * @returns Array of matching widgets (empty if none found)
  */
-export const queryAllByRole = (
-    container: Container,
-    role: Gtk.AccessibleRole,
-    options?: ByRoleOptions,
-): Gtk.Widget[] => {
-    return findAll(container, (node) => {
+export const queryAllByRole = (container: Container, role: Gtk.AccessibleRole, options?: ByRoleOptions): Gtk.Widget[] =>
+    findAll(container, (node) => {
         if (node.getAccessibleRole() !== role) return false;
         return matchByRoleOptions(node, options);
     });
-};
+
+const roleVariants = buildQueries<[role: Gtk.AccessibleRole, options?: ByRoleOptions]>(
+    queryAllByRole,
+    (container, count, role, options) => buildMultipleFoundError(container, "role", { role, options }, count),
+    (container, role, options) => buildNotFoundError(container, "role", { role, options }),
+);
 
 /**
- * Finds a single element matching a role without throwing.
- *
- * @param container - The container to search within
- * @param role - The GTK accessible role to match
- * @param options - Query options including name and state filters
- * @returns The matching widget or null if not found
- * @throws Error if multiple elements match
- */
-export const queryByRole = (
-    container: Container,
-    role: Gtk.AccessibleRole,
-    options?: ByRoleOptions,
-): Gtk.Widget | null => {
-    const matches = queryAllByRole(container, role, options);
-
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "role", { role, options }, matches.length);
-    }
-
-    return matches[0] ?? null;
-};
-
-/**
- * Finds all elements that are labelled by a GtkLabel whose text matches.
+ * Finds all elements that are labeled by a GtkLabel whose text matches.
  *
  * Uses GtkLabel's mnemonic widget association to find form elements
- * by their label text. Only returns widgets that are properly labelled
- * via GtkLabel's mnemonic-widget property.
+ * by their label text.
  *
  * @param container - The container to search within
  * @param text - Label text to match (string, RegExp, or custom matcher)
  * @param options - Query options including normalization
- * @returns Array of labelled widgets (empty if none found)
+ * @returns Array of labeled widgets (empty if none found)
  */
-export const queryAllByLabelText = (
-    container: Container,
-    text: TextMatch,
-    options?: TextMatchOptions,
-): Gtk.Widget[] => {
+export const queryAllByLabelText = (container: Container, text: Matcher, options?: MatcherOptions): Gtk.Widget[] => {
     const results: Gtk.Widget[] = [];
 
     for (const node of traverse(container)) {
@@ -174,28 +130,11 @@ export const queryAllByLabelText = (
     return results;
 };
 
-/**
- * Finds a single element matching label text without throwing.
- *
- * @param container - The container to search within
- * @param text - Text to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization
- * @returns The matching widget or null if not found
- * @throws Error if multiple elements match
- */
-export const queryByLabelText = (
-    container: Container,
-    text: TextMatch,
-    options?: TextMatchOptions,
-): Gtk.Widget | null => {
-    const matches = queryAllByLabelText(container, text, options);
-
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "labelText", { text, options }, matches.length);
-    }
-
-    return matches[0] ?? null;
-};
+const labelTextVariants = buildQueries<[text: Matcher, options?: MatcherOptions]>(
+    queryAllByLabelText,
+    (container, count, text, options) => buildMultipleFoundError(container, "labelText", { text, options }, count),
+    (container, text, options) => buildNotFoundError(container, "labelText", { text, options }),
+);
 
 /**
  * Finds all elements matching text content without throwing.
@@ -205,30 +144,14 @@ export const queryByLabelText = (
  * @param options - Query options including normalization
  * @returns Array of matching widgets (empty if none found)
  */
-export const queryAllByText = (container: Container, text: TextMatch, options?: TextMatchOptions): Gtk.Widget[] => {
-    return findAll(container, (node) => {
-        return matchText(getWidgetText(node), text, node, options);
-    });
-};
+export const queryAllByText = (container: Container, text: Matcher, options?: MatcherOptions): Gtk.Widget[] =>
+    findAll(container, (node) => matchText(getWidgetText(node), text, node, options));
 
-/**
- * Finds a single element matching text content without throwing.
- *
- * @param container - The container to search within
- * @param text - Text to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization
- * @returns The matching widget or null if not found
- * @throws Error if multiple elements match
- */
-export const queryByText = (container: Container, text: TextMatch, options?: TextMatchOptions): Gtk.Widget | null => {
-    const matches = queryAllByText(container, text, options);
-
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "text", { text, options }, matches.length);
-    }
-
-    return matches[0] ?? null;
-};
+const textVariants = buildQueries<[text: Matcher, options?: MatcherOptions]>(
+    queryAllByText,
+    (container, count, text, options) => buildMultipleFoundError(container, "text", { text, options }, count),
+    (container, text, options) => buildNotFoundError(container, "text", { text, options }),
+);
 
 /**
  * Finds all elements matching a widget name without throwing.
@@ -238,270 +161,55 @@ export const queryByText = (container: Container, text: TextMatch, options?: Tex
  * @param options - Query options including normalization
  * @returns Array of matching widgets (empty if none found)
  */
-export const queryAllByName = (container: Container, name: TextMatch, options?: TextMatchOptions): Gtk.Widget[] => {
-    return findAll(container, (node) => {
-        const widgetName = getWidgetName(node);
-        return matchText(widgetName, name, node, options);
-    });
-};
+export const queryAllByName = (container: Container, name: Matcher, options?: MatcherOptions): Gtk.Widget[] =>
+    findAll(container, (node) => matchText(getWidgetName(node), name, node, options));
 
-/**
- * Finds a single element matching a widget name without throwing.
- *
- * @param container - The container to search within
- * @param name - Widget name to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization
- * @returns The matching widget or null if not found
- * @throws Error if multiple elements match
- */
-export const queryByName = (container: Container, name: TextMatch, options?: TextMatchOptions): Gtk.Widget | null => {
-    const matches = queryAllByName(container, name, options);
+const nameVariants = buildQueries<[name: Matcher, options?: MatcherOptions]>(
+    queryAllByName,
+    (container, count, name, options) => buildMultipleFoundError(container, "name", { name, options }, count),
+    (container, name, options) => buildNotFoundError(container, "name", { name, options }),
+);
 
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "name", { name, options }, matches.length);
-    }
+/** Finds a single element matching a role without throwing. Returns `null` if not found; throws if multiple match. */
+export const queryByRole = roleVariants.queryBy;
+/** Finds a single element matching a role. Throws if not found or if multiple match. */
+export const getByRole = roleVariants.getBy;
+/** Finds all elements matching a role. Throws if none found. */
+export const getAllByRole = roleVariants.getAllBy;
+/** Finds a single element matching a role, waiting until it appears. Throws if not found or if multiple match. */
+export const findByRole = roleVariants.findBy;
+/** Finds all elements matching a role, waiting until any appear. Throws if none found. */
+export const findAllByRole = roleVariants.findAllBy;
 
-    return matches[0] ?? null;
-};
+/** Finds a single element by label text without throwing. Returns `null` if not found; throws if multiple match. */
+export const queryByLabelText = labelTextVariants.queryBy;
+/** Finds a single element by label text. Throws if not found or if multiple match. */
+export const getByLabelText = labelTextVariants.getBy;
+/** Finds all elements matching label text. Throws if none found. */
+export const getAllByLabelText = labelTextVariants.getAllBy;
+/** Finds a single element by label text, waiting until it appears. Throws if not found or if multiple match. */
+export const findByLabelText = labelTextVariants.findBy;
+/** Finds all elements matching label text, waiting until any appear. Throws if none found. */
+export const findAllByLabelText = labelTextVariants.findAllBy;
 
-const getAllByRole = (container: Container, role: Gtk.AccessibleRole, options?: ByRoleOptions): Gtk.Widget[] => {
-    const matches = queryAllByRole(container, role, options);
+/** Finds a single element by visible text without throwing. Returns `null` if not found; throws if multiple match. */
+export const queryByText = textVariants.queryBy;
+/** Finds a single element by visible text. Throws if not found or if multiple match. */
+export const getByText = textVariants.getBy;
+/** Finds all elements matching visible text. Throws if none found. */
+export const getAllByText = textVariants.getAllBy;
+/** Finds a single element by visible text, waiting until it appears. Throws if not found or if multiple match. */
+export const findByText = textVariants.findBy;
+/** Finds all elements matching visible text, waiting until any appear. Throws if none found. */
+export const findAllByText = textVariants.findAllBy;
 
-    if (matches.length === 0) {
-        throw buildNotFoundError(container, "role", { role, options });
-    }
-
-    return matches;
-};
-
-const getByRole = (container: Container, role: Gtk.AccessibleRole, options?: ByRoleOptions): Gtk.Widget => {
-    const matches = getAllByRole(container, role, options);
-
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "role", { role, options }, matches.length);
-    }
-
-    return matches[0] as Gtk.Widget;
-};
-
-const getAllByLabelText = (container: Container, text: TextMatch, options?: TextMatchOptions): Gtk.Widget[] => {
-    const matches = queryAllByLabelText(container, text, options);
-
-    if (matches.length === 0) {
-        throw buildNotFoundError(container, "labelText", { text, options });
-    }
-
-    return matches;
-};
-
-const getByLabelText = (container: Container, text: TextMatch, options?: TextMatchOptions): Gtk.Widget => {
-    const matches = getAllByLabelText(container, text, options);
-
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "labelText", { text, options }, matches.length);
-    }
-
-    return matches[0] as Gtk.Widget;
-};
-
-const getAllByText = (container: Container, text: TextMatch, options?: TextMatchOptions): Gtk.Widget[] => {
-    const matches = queryAllByText(container, text, options);
-
-    if (matches.length === 0) {
-        throw buildNotFoundError(container, "text", { text, options });
-    }
-
-    return matches;
-};
-
-const getByText = (container: Container, text: TextMatch, options?: TextMatchOptions): Gtk.Widget => {
-    const matches = getAllByText(container, text, options);
-
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "text", { text, options }, matches.length);
-    }
-
-    return matches[0] as Gtk.Widget;
-};
-
-const getAllByName = (container: Container, name: TextMatch, options?: TextMatchOptions): Gtk.Widget[] => {
-    const matches = queryAllByName(container, name, options);
-
-    if (matches.length === 0) {
-        throw buildNotFoundError(container, "name", { name, options });
-    }
-
-    return matches;
-};
-
-const getByName = (container: Container, name: TextMatch, options?: TextMatchOptions): Gtk.Widget => {
-    const matches = getAllByName(container, name, options);
-
-    if (matches.length > 1) {
-        throw buildMultipleFoundError(container, "name", { name, options }, matches.length);
-    }
-
-    return matches[0] as Gtk.Widget;
-};
-
-/**
- * Finds a single element by accessible role.
- *
- * Waits for the element to appear, throwing if not found within timeout.
- *
- * @param container - The container to search within
- * @param role - The GTK accessible role to match
- * @param options - Query options including name, state filters, and timeout
- * @returns Promise resolving to the matching widget
- *
- * @example
- * ```tsx
- * const button = await findByRole(container, Gtk.AccessibleRole.BUTTON, { name: "Submit" });
- * ```
- */
-export const findByRole = async (
-    container: Container,
-    role: Gtk.AccessibleRole,
-    options?: ByRoleOptions,
-): Promise<Gtk.Widget> =>
-    waitFor(() => getByRole(container, role, options), {
-        timeout: options?.timeout,
-    });
-
-/**
- * Finds all elements matching an accessible role.
- *
- * @param container - The container to search within
- * @param role - The GTK accessible role to match
- * @param options - Query options including name, state filters, and timeout
- * @returns Promise resolving to array of matching widgets
- */
-export const findAllByRole = async (
-    container: Container,
-    role: Gtk.AccessibleRole,
-    options?: ByRoleOptions,
-): Promise<Gtk.Widget[]> =>
-    waitFor(() => getAllByRole(container, role, options), {
-        timeout: options?.timeout,
-    });
-
-/**
- * Finds a single element that is labelled by a GtkLabel whose text matches.
- *
- * Waits for the element to appear, throwing if not found within timeout.
- * Uses GtkLabel's mnemonic widget association to find form elements.
- *
- * @param container - The container to search within
- * @param text - Label text to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization and timeout
- * @returns Promise resolving to the labelled widget
- *
- * @example
- * ```tsx
- * const input = await findByLabelText(container, "Username");
- * ```
- */
-export const findByLabelText = async (
-    container: Container,
-    text: TextMatch,
-    options?: TextMatchOptions,
-): Promise<Gtk.Widget> =>
-    waitFor(() => getByLabelText(container, text, options), {
-        timeout: options?.timeout,
-    });
-
-/**
- * Finds all elements matching label or text content.
- *
- * @param container - The container to search within
- * @param text - Text to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization and timeout
- * @returns Promise resolving to array of matching widgets
- */
-export const findAllByLabelText = async (
-    container: Container,
-    text: TextMatch,
-    options?: TextMatchOptions,
-): Promise<Gtk.Widget[]> =>
-    waitFor(() => getAllByLabelText(container, text, options), {
-        timeout: options?.timeout,
-    });
-
-/**
- * Finds a single element by visible text content.
- *
- * Similar to {@link findByLabelText} but focuses on directly visible text.
- *
- * @param container - The container to search within
- * @param text - Text to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization and timeout
- * @returns Promise resolving to the matching widget
- */
-export const findByText = async (
-    container: Container,
-    text: TextMatch,
-    options?: TextMatchOptions,
-): Promise<Gtk.Widget> =>
-    waitFor(() => getByText(container, text, options), {
-        timeout: options?.timeout,
-    });
-
-/**
- * Finds all elements matching visible text content.
- *
- * @param container - The container to search within
- * @param text - Text to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization and timeout
- * @returns Promise resolving to array of matching widgets
- */
-export const findAllByText = async (
-    container: Container,
-    text: TextMatch,
-    options?: TextMatchOptions,
-): Promise<Gtk.Widget[]> =>
-    waitFor(() => getAllByText(container, text, options), {
-        timeout: options?.timeout,
-    });
-
-/**
- * Finds a single element by widget name.
- *
- * Uses the widget's `name` property (gtk_widget_get_name).
- * Set via the `name` prop on GTKX components.
- *
- * @param container - The container to search within
- * @param name - Widget name to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization and timeout
- * @returns Promise resolving to the matching widget
- *
- * @example
- * ```tsx
- * // In component: <GtkButton name="submit-btn" />
- * const button = await findByName(container, "submit-btn");
- * ```
- */
-export const findByName = async (
-    container: Container,
-    name: TextMatch,
-    options?: TextMatchOptions,
-): Promise<Gtk.Widget> =>
-    waitFor(() => getByName(container, name, options), {
-        timeout: options?.timeout,
-    });
-
-/**
- * Finds all elements matching a widget name pattern.
- *
- * @param container - The container to search within
- * @param name - Widget name to match (string, RegExp, or custom matcher)
- * @param options - Query options including normalization and timeout
- * @returns Promise resolving to array of matching widgets
- */
-export const findAllByName = async (
-    container: Container,
-    name: TextMatch,
-    options?: TextMatchOptions,
-): Promise<Gtk.Widget[]> =>
-    waitFor(() => getAllByName(container, name, options), {
-        timeout: options?.timeout,
-    });
+/** Finds a single element by widget name without throwing. Returns `null` if not found; throws if multiple match. */
+export const queryByName = nameVariants.queryBy;
+/** Finds a single element by widget name. Throws if not found or if multiple match. */
+export const getByName = nameVariants.getBy;
+/** Finds all elements matching a widget name. Throws if none found. */
+export const getAllByName = nameVariants.getAllBy;
+/** Finds a single element by widget name, waiting until it appears. Throws if not found or if multiple match. */
+export const findByName = nameVariants.findBy;
+/** Finds all elements matching a widget name, waiting until any appear. Throws if none found. */
+export const findAllByName = nameVariants.findAllBy;

--- a/packages/testing/src/query-helpers.ts
+++ b/packages/testing/src/query-helpers.ts
@@ -1,0 +1,83 @@
+import type * as Gtk from "@gtkx/ffi/gtk";
+import type { Container } from "./traversal.js";
+import { waitFor } from "./wait-for.js";
+
+/**
+ * A query that returns every widget matching a search predicate.
+ */
+export type QueryAllBy<Args extends unknown[]> = (container: Container, ...args: Args) => Gtk.Widget[];
+
+type MultipleErrorBuilder<Args extends unknown[]> = (container: Container, count: number, ...args: Args) => Error;
+type MissingErrorBuilder<Args extends unknown[]> = (container: Container, ...args: Args) => Error;
+
+/**
+ * The five derived variants every search predicate expands into.
+ */
+export type BuiltQueries<Args extends unknown[]> = {
+    queryBy: (container: Container, ...args: Args) => Gtk.Widget | null;
+    getAllBy: QueryAllBy<Args>;
+    getBy: (container: Container, ...args: Args) => Gtk.Widget;
+    findAllBy: (container: Container, ...args: Args) => Promise<Gtk.Widget[]>;
+    findBy: (container: Container, ...args: Args) => Promise<Gtk.Widget>;
+};
+
+const extractTimeout = (args: readonly unknown[]): number | undefined => {
+    const last = args[args.length - 1];
+    if (last && typeof last === "object" && "timeout" in last) {
+        const t = (last as { timeout?: number }).timeout;
+        return typeof t === "number" ? t : undefined;
+    }
+    return undefined;
+};
+
+/**
+ * Expands a single `queryAllBy*` predicate into the six query-variant family
+ * (`queryAllBy*`, `queryBy*`, `getAllBy*`, `getBy*`, `findAllBy*`, `findBy*`).
+ *
+ * Mirrors the `buildQueries` helper from `@testing-library/dom`.
+ *
+ * @param queryAllBy - The search predicate that returns every matching widget.
+ * @param getMultipleError - Builds the error thrown when more than one widget matches.
+ * @param getMissingError - Builds the error thrown when no widgets match.
+ */
+export const buildQueries = <Args extends unknown[]>(
+    queryAllBy: QueryAllBy<Args>,
+    getMultipleError: MultipleErrorBuilder<Args>,
+    getMissingError: MissingErrorBuilder<Args>,
+): BuiltQueries<Args> => {
+    const queryBy = (container: Container, ...args: Args): Gtk.Widget | null => {
+        const matches = queryAllBy(container, ...args);
+        if (matches.length > 1) {
+            throw getMultipleError(container, matches.length, ...args);
+        }
+        return matches[0] ?? null;
+    };
+
+    const getAllBy = (container: Container, ...args: Args): Gtk.Widget[] => {
+        const matches = queryAllBy(container, ...args);
+        if (matches.length === 0) {
+            throw getMissingError(container, ...args);
+        }
+        return matches;
+    };
+
+    const getBy = (container: Container, ...args: Args): Gtk.Widget => {
+        const matches = getAllBy(container, ...args);
+        if (matches.length > 1) {
+            throw getMultipleError(container, matches.length, ...args);
+        }
+        const [first] = matches;
+        if (first === undefined) {
+            throw getMissingError(container, ...args);
+        }
+        return first;
+    };
+
+    const findAllBy = (container: Container, ...args: Args): Promise<Gtk.Widget[]> =>
+        waitFor(() => getAllBy(container, ...args), { timeout: extractTimeout(args) });
+
+    const findBy = (container: Container, ...args: Args): Promise<Gtk.Widget> =>
+        waitFor(() => getBy(container, ...args), { timeout: extractTimeout(args) });
+
+    return { queryBy, getAllBy, getBy, findAllBy, findBy };
+};

--- a/packages/testing/src/react-internals-instrumentation.ts
+++ b/packages/testing/src/react-internals-instrumentation.ts
@@ -1,0 +1,125 @@
+/**
+ * Runtime probe that monitors React 19's `ReactSharedInternals.actQueue`
+ * pointer and the per-queue `push` operations responsible for adopting state
+ * updates into an in-flight `act`. Loaded by {@link ./timing.ts} so that every
+ * test process emits structured logs describing how the queue evolves across
+ * iterations of `recursivelyFlushAsyncActWork`.
+ *
+ * Emits compact events to `stderr` with the `[gtkx:react-act]` prefix:
+ * - `actQueue installed id=N len=K` — assignment of a non-null queue to the
+ *   global pointer (the moment `setState` calls start being adopted).
+ * - `actQueue cleared id=N pushes=P maxLen=M nonzeroSamples=S` — assignment
+ *   back to `null`, with per-queue totals: how many entries were ever pushed,
+ *   the high-water mark length, and how many sampler ticks observed the queue
+ *   non-empty.
+ * - `sampler-nonempty tick=T id=N len=M` — emitted only when the
+ *   `setImmediate` sampler observes a non-empty queue. A non-empty observation
+ *   indicates a state update landed between `recursivelyFlushAsyncActWork`
+ *   iterations and is the signature of the runaway loop we suspect.
+ */
+
+import * as React from "react";
+
+declare module "react" {
+    const __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE: {
+        actQueue: unknown[] | null;
+    };
+}
+
+interface QueueStats {
+    id: number;
+    pushes: number;
+    maxLen: number;
+    nonzeroSamples: number;
+}
+
+const internals = React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+const instrumentationOrigin = Date.now();
+const queueStatsByQueue = new WeakMap<unknown[], QueueStats>();
+const wrappedQueues = new WeakSet<unknown[]>();
+
+let queueCounter = 0;
+let samplerCounter = 0;
+let currentQueue: unknown[] | null = internals.actQueue;
+let samplerScheduled = false;
+
+const logEvent = (event: string, details?: string): void => {
+    const elapsed = Date.now() - instrumentationOrigin;
+    const suffix = details ? ` ${details}` : "";
+    console.error(`[gtkx:react-act] +${elapsed}ms ${event}${suffix}`);
+};
+
+const wrapQueue = (queue: unknown[]): QueueStats => {
+    const existing = queueStatsByQueue.get(queue);
+    if (existing) return existing;
+    const stats: QueueStats = {
+        id: ++queueCounter,
+        pushes: 0,
+        maxLen: queue.length,
+        nonzeroSamples: 0,
+    };
+    queueStatsByQueue.set(queue, stats);
+    if (!wrappedQueues.has(queue)) {
+        wrappedQueues.add(queue);
+        const originalPush = queue.push.bind(queue);
+        queue.push = (...items: unknown[]): number => {
+            const newLen = originalPush(...items);
+            stats.pushes += items.length;
+            if (newLen > stats.maxLen) stats.maxLen = newLen;
+            return newLen;
+        };
+    }
+    return stats;
+};
+
+const sampleQueueLength = (): void => {
+    samplerScheduled = false;
+    const queue = currentQueue;
+    if (!queue) return;
+    const stats = queueStatsByQueue.get(queue);
+    const tick = ++samplerCounter;
+    if (queue.length > 0 && stats) {
+        stats.nonzeroSamples++;
+        logEvent("sampler-nonempty", `tick=${tick} id=${stats.id} len=${queue.length}`);
+    }
+    scheduleSampler();
+};
+
+const scheduleSampler = (): void => {
+    if (samplerScheduled || !currentQueue) return;
+    samplerScheduled = true;
+    setImmediate(sampleQueueLength);
+};
+
+if (currentQueue) {
+    wrapQueue(currentQueue);
+    scheduleSampler();
+}
+
+Object.defineProperty(internals, "actQueue", {
+    configurable: true,
+    get(): unknown[] | null {
+        return currentQueue;
+    },
+    set(newValue: unknown[] | null): void {
+        if (newValue === currentQueue) return;
+        if (newValue === null && currentQueue) {
+            const stats = queueStatsByQueue.get(currentQueue);
+            if (stats) {
+                logEvent(
+                    "actQueue cleared",
+                    `id=${stats.id} pushes=${stats.pushes} maxLen=${stats.maxLen} nonzeroSamples=${stats.nonzeroSamples}`,
+                );
+            } else {
+                logEvent("actQueue cleared", "id=? (untracked)");
+            }
+        } else if (newValue) {
+            const stats = wrapQueue(newValue);
+            logEvent("actQueue installed", `id=${stats.id} len=${newValue.length}`);
+        }
+        currentQueue = newValue;
+        scheduleSampler();
+    },
+});
+
+logEvent("react internals instrumentation active");

--- a/packages/testing/src/render-hook.tsx
+++ b/packages/testing/src/render-hook.tsx
@@ -8,6 +8,9 @@ import type { RenderHookOptions, RenderHookResult } from "./types.js";
  * Creates a test component that executes the hook and provides utilities
  * for accessing the result, re-rendering with new props, and cleanup.
  *
+ * When the hook callback takes props, `initialProps` is required at the
+ * type level. When it takes none, `options` may be omitted entirely.
+ *
  * @param callback - Function that calls the hook and returns its result
  * @param options - Render options including initialProps and wrapper
  * @returns A promise resolving to the hook result and utilities
@@ -40,12 +43,22 @@ import type { RenderHookOptions, RenderHookResult } from "./types.js";
  * });
  * ```
  */
-export const renderHook = async <Result, Props>(
+export function renderHook<Result>(
+    callback: () => Result,
+    options?: RenderHookOptions<undefined>,
+): Promise<RenderHookResult<Result, undefined>>;
+export function renderHook<Result, Props>(
+    callback: (props: Props) => Result,
+    options: RenderHookOptions<Props>,
+): Promise<RenderHookResult<Result, Props>>;
+export async function renderHook<Result, Props>(
     callback: (props: Props) => Result,
     options?: RenderHookOptions<Props>,
-): Promise<RenderHookResult<Result, Props>> => {
-    const resultRef = { current: undefined as Result };
-    let currentProps = options?.initialProps as Props;
+): Promise<RenderHookResult<Result, Props>> {
+    const wrapper = options?.wrapper ?? true;
+    const initialProps = (options as { initialProps?: Props } | undefined)?.initialProps as Props;
+    const resultRef: { current: Result | undefined } = { current: undefined };
+    let currentProps: Props = initialProps;
 
     const TestComponent = ({ props }: { props: Props }): null => {
         const result = callback(props);
@@ -54,12 +67,10 @@ export const renderHook = async <Result, Props>(
         return null;
     };
 
-    const renderResult = await render(<TestComponent props={currentProps} />, {
-        wrapper: options?.wrapper ?? true,
-    });
+    const renderResult = await render(<TestComponent props={currentProps} />, { wrapper });
 
     return {
-        result: resultRef,
+        result: resultRef as { current: Result },
         rerender: async (newProps?: Props) => {
             if (newProps !== undefined) {
                 currentProps = newProps;
@@ -68,4 +79,4 @@ export const renderHook = async <Result, Props>(
         },
         unmount: renderResult.unmount,
     };
-};
+}

--- a/packages/testing/src/render.tsx
+++ b/packages/testing/src/render.tsx
@@ -1,13 +1,13 @@
-import { start, stop } from "@gtkx/ffi";
+import { stop } from "@gtkx/ffi";
 import * as Gio from "@gtkx/ffi/gio";
-import type * as Gtk from "@gtkx/ffi/gtk";
+import * as Gtk from "@gtkx/ffi/gtk";
 import { ApplicationContext, GtkApplicationWindow, reconciler } from "@gtkx/react";
-import { createRef, type ReactNode, type Ref } from "react";
+import type { ReactNode } from "react";
 import type Reconciler from "react-reconciler";
 import { bindQueries } from "./bind-queries.js";
 import { prettyWidget } from "./pretty-widget.js";
 import { setScreenRoot } from "./screen.js";
-import { tick } from "./timing.js";
+import { act } from "./timing.js";
 import { type Container, isApplication, traverse } from "./traversal.js";
 import type { RenderOptions, RenderResult, WrapperComponent } from "./types.js";
 
@@ -15,21 +15,30 @@ let application: Gtk.Application | null = null;
 let container: Reconciler.FiberRoot | null = null;
 let lastRenderError: Error | null = null;
 
-type ReconcilerInstance = ReturnType<typeof reconciler.getInstance>;
+const renderInstrumentationOrigin = Date.now();
+let updateCallCounter = 0;
+const logRenderEvent = (id: number, event: string, details?: string): void => {
+    const elapsed = Date.now() - renderInstrumentationOrigin;
+    const suffix = details ? ` ${details}` : "";
+    console.error(`[gtkx:render#${id}] +${elapsed}ms ${event}${suffix}`);
+};
 
-const update = async (
-    instance: ReconcilerInstance,
-    element: ReactNode,
-    fiberRoot: Reconciler.FiberRoot,
-): Promise<void> => {
-    lastRenderError = null;
-    instance.updateContainer(element, fiberRoot, null, () => {});
-    await tick();
+const update = async (element: ReactNode, fiberRoot: Reconciler.FiberRoot): Promise<void> => {
+    const id = ++updateCallCounter;
+    const startTime = Date.now();
+    logRenderEvent(id, "update enter", `element=${element === null ? "null" : "node"}`);
+    await act(() => {
+        logRenderEvent(id, "calling reconciler.updateContainer");
+        reconciler.updateContainer(element, fiberRoot, null, () => {});
+        logRenderEvent(id, "reconciler.updateContainer returned");
+    });
+    logRenderEvent(id, "act resolved", `total=${Date.now() - startTime}ms`);
 
     if (lastRenderError) {
-        const error = lastRenderError;
+        const captured = lastRenderError;
         lastRenderError = null;
-        throw error;
+        logRenderEvent(id, "throwing captured render error", captured.message);
+        throw captured;
     }
 };
 
@@ -38,11 +47,17 @@ const handleError = (error: Error): void => {
 };
 
 const ensureInitialized = (): { app: Gtk.Application; container: Reconciler.FiberRoot } => {
-    application = start("org.gtkx.testing", Gio.ApplicationFlags.NON_UNIQUE);
+    if (!application) {
+        application = new Gtk.Application({
+            application_id: "org.gtkx.testing",
+            flags: Gio.ApplicationFlags.NON_UNIQUE,
+        });
+        application.register(null);
+        application.activate();
+    }
 
     if (!container) {
-        const instance = reconciler.getInstance();
-        container = instance.createContainer(
+        container = reconciler.createContainer(
             application,
             1,
             null,
@@ -59,43 +74,29 @@ const ensureInitialized = (): { app: Gtk.Application; container: Reconciler.Fibe
     return { app: application, container };
 };
 
-const DefaultWrapper: WrapperComponent = ({ children, ref }) => (
-    <GtkApplicationWindow ref={ref as Ref<Gtk.ApplicationWindow>} defaultWidth={800} defaultHeight={600}>
+const DefaultWrapper: WrapperComponent = ({ children }) => (
+    <GtkApplicationWindow defaultWidth={800} defaultHeight={600}>
         {children}
     </GtkApplicationWindow>
 );
 
-const findFirstWidget = (root: Container): Gtk.Widget | null => {
-    for (const widget of traverse(root)) {
-        if (isApplication(root)) return widget;
-        return root;
-    }
-    return null;
-};
-
-const wrapElement = (
-    element: ReactNode,
-    wrapperRef: React.RefObject<Gtk.Widget | null>,
-    wrapper: RenderOptions["wrapper"],
-): ReactNode => {
-    if (wrapper === false || wrapper === undefined) return element;
-    const Wrapper = wrapper === true ? DefaultWrapper : wrapper;
-    return <Wrapper ref={wrapperRef}>{element}</Wrapper>;
-};
-
-const resolveContainer = (
-    wrapper: RenderOptions["wrapper"],
-    wrapperRef: React.RefObject<Gtk.Widget | null>,
-    baseElement: Container,
-): Gtk.Widget => {
-    if (wrapper !== false && wrapper !== undefined && wrapperRef.current) {
-        return wrapperRef.current;
-    }
-    const firstWidget = findFirstWidget(baseElement);
-    if (!firstWidget) {
+const resolveContainer = (baseElement: Container): Gtk.Widget => {
+    if (isApplication(baseElement)) {
+        const [firstWindow] = baseElement.getWindows();
+        if (firstWindow) return firstWindow;
+        const iterator = traverse(baseElement)[Symbol.iterator]();
+        const first = iterator.next();
+        if (!first.done) return first.value;
         throw new Error("render() produced no widgets: ensure the element renders visible content");
     }
-    return firstWidget;
+    if (baseElement instanceof Gtk.Widget) return baseElement;
+    throw new Error("render() produced no widgets: ensure the element renders visible content");
+};
+
+const wrapElement = (element: ReactNode, wrapper: RenderOptions["wrapper"]): ReactNode => {
+    if (wrapper === false || wrapper === undefined) return element;
+    const Wrapper = wrapper === true ? DefaultWrapper : wrapper;
+    return <Wrapper>{element}</Wrapper>;
 };
 
 /**
@@ -113,9 +114,9 @@ const resolveContainer = (
  * import { render, screen } from "@gtkx/testing";
  *
  * test("button click", async () => {
- * await render(<MyButton />);
- * const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON);
- * await userEvent.click(button);
+ *   await render(<MyButton />);
+ *   const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON);
+ *   await userEvent.click(button);
  * });
  * ```
  *
@@ -124,27 +125,24 @@ const resolveContainer = (
  */
 export const render = async (element: ReactNode, options?: RenderOptions): Promise<RenderResult> => {
     const { app: application, container: fiberRoot } = ensureInitialized();
-    const instance = reconciler.getInstance();
     const baseElement: Container = options?.baseElement ?? application;
     const wrapper = options?.wrapper ?? true;
 
-    const wrapperRef = createRef<Gtk.Widget>();
-    const wrappedElement = wrapElement(element, wrapperRef, wrapper);
+    const wrappedElement = wrapElement(element, wrapper);
     const withContext = <ApplicationContext.Provider value={application}>{wrappedElement}</ApplicationContext.Provider>;
-    await update(instance, withContext, fiberRoot);
+    await update(withContext, fiberRoot);
 
     setScreenRoot(application);
 
     return {
-        container: resolveContainer(wrapper, wrapperRef, baseElement),
+        container: resolveContainer(baseElement),
         baseElement,
         ...bindQueries(baseElement),
-        unmount: () => update(instance, null, fiberRoot),
+        unmount: () => update(null, fiberRoot),
         rerender: async (newElement: ReactNode) => {
-            const newWrapperRef = createRef<Gtk.Widget>();
-            const wrapped = wrapElement(newElement, newWrapperRef, wrapper);
+            const wrapped = wrapElement(newElement, wrapper);
             const withCtx = <ApplicationContext.Provider value={application}>{wrapped}</ApplicationContext.Provider>;
-            await update(instance, withCtx, fiberRoot);
+            await update(withCtx, fiberRoot);
         },
         debug: () => {
             console.log(prettyWidget(application));
@@ -163,28 +161,24 @@ export const render = async (element: ReactNode, options?: RenderOptions): Promi
  * import { render, cleanup } from "@gtkx/testing";
  *
  * afterEach(async () => {
- * await cleanup();
+ *   await cleanup();
  * });
  *
  * test("my test", async () => {
- * await render(<MyComponent />);
- * // ...
+ *   await render(<MyComponent />);
  * });
  * ```
  */
 export const cleanup = async (): Promise<void> => {
     if (container && application) {
-        const instance = reconciler.getInstance();
-        await update(instance, null, container);
+        await update(null, container);
     }
     container = null;
     setScreenRoot(null);
 };
 
 const handleSignal = (): void => {
-    try {
-        stop();
-    } catch {}
+    stop().catch(() => {});
     process.exit(0);
 };
 

--- a/packages/testing/src/role-helpers.ts
+++ b/packages/testing/src/role-helpers.ts
@@ -16,9 +16,13 @@ export type RoleInfo = {
  * @param role - The GTK accessible role
  * @returns Lowercase role name (e.g., "button", "checkbox")
  */
+const ROLE_NAMES_BY_VALUE = new Map<number, string>(
+    Object.entries(Gtk.AccessibleRole).map(([name, value]) => [value as number, name]),
+);
+
 export const formatRole = (role: Gtk.AccessibleRole | undefined): string => {
     if (role === undefined) return "unknown";
-    const name = Gtk.AccessibleRole[role];
+    const name = ROLE_NAMES_BY_VALUE.get(role);
     if (!name) return String(role);
     return name.toLowerCase();
 };

--- a/packages/testing/src/screen.ts
+++ b/packages/testing/src/screen.ts
@@ -5,29 +5,12 @@ import * as Gtk from "@gtkx/ffi/gtk";
 import { bindQueries } from "./bind-queries.js";
 import { prettyWidget } from "./pretty-widget.js";
 import { logRoles } from "./role-helpers.js";
-import { type ScreenshotOptions, screenshot as screenshotWidget } from "./screenshot.js";
+import { screenshot as captureScreenshot, type ScreenshotOptions } from "./screenshot.js";
 import type { ScreenshotResult } from "./types.js";
-
-const getScreenshotDir = (): string => {
-    const dir = join(tmpdir(), "gtkx-screenshots");
-    if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
-    }
-    return dir;
-};
-
-const saveAndLogScreenshot = (result: ScreenshotResult): void => {
-    const dir = getScreenshotDir();
-    const filename = `${Date.now()}-screenshot.png`;
-    const filepath = join(dir, filename);
-    const buffer = Buffer.from(result.data, "base64");
-    writeFileSync(filepath, buffer);
-    console.log(`Screenshot saved: file://${filepath}`);
-};
 
 let currentRoot: Gtk.Application | null = null;
 
-/** @internal */
+/** Sets the application the `screen` queries operate against; called by `render`. */
 export const setScreenRoot = (root: Gtk.Application | null): void => {
     currentRoot = root;
 };
@@ -38,6 +21,62 @@ const getRoot = (): Gtk.Application => {
     }
 
     return currentRoot;
+};
+
+type WindowSelector = number | string | RegExp | undefined;
+
+const resolveWindow = (selector?: WindowSelector): Gtk.Window => {
+    const windows = Gtk.Window.listToplevels();
+
+    if (windows.length === 0) {
+        throw new Error("No windows available for screenshot");
+    }
+
+    if (selector === undefined) {
+        const [first] = windows;
+        if (!(first instanceof Gtk.Window)) {
+            throw new TypeError("First toplevel is not a Window");
+        }
+        return first;
+    }
+
+    if (typeof selector === "number") {
+        const indexed = windows[selector];
+        if (!(indexed instanceof Gtk.Window)) {
+            throw new TypeError(`Window at index ${selector} not found`);
+        }
+        return indexed;
+    }
+
+    const isRegex = selector instanceof RegExp;
+    const found = windows.find((w): w is Gtk.Window => {
+        if (!(w instanceof Gtk.Window)) return false;
+        const title = w.getTitle() ?? "";
+        return isRegex ? selector.test(title) : title.includes(selector);
+    });
+
+    if (!found) {
+        const pattern = isRegex ? selector.toString() : `"${selector}"`;
+        throw new Error(`No window found with title matching ${pattern}`);
+    }
+    return found;
+};
+
+const saveScreenshotToTempFile = (result: ScreenshotResult): string => {
+    const dir = join(tmpdir(), "gtkx-screenshots");
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+    const filepath = join(dir, `${Date.now()}-screenshot.png`);
+    writeFileSync(filepath, Buffer.from(result.data, "base64"));
+    return filepath;
+};
+
+/**
+ * Logs a `file://` URI for the given screenshot path to the console.
+ */
+export const logScreenshotPath = (filepath: string): void => {
+    console.log(`Screenshot saved: file://${filepath}`);
 };
 
 const boundQueries = bindQueries(getRoot);
@@ -73,13 +112,13 @@ export const screen = {
         logRoles(getRoot());
     },
     /**
-     * Capture a screenshot of the application window, saving it to a temporary file and logging the file path.
+     * Capture a screenshot of a toplevel window, save it to a temp file, and
+     * log a clickable `file://` URI.
      *
      * @param selector - Window selector: index (number), title substring (string), or title pattern (RegExp).
      *                   If omitted, captures the first window.
      * @param options - Optional timeout and interval configuration for waiting on widget rendering.
      * @returns Screenshot result containing base64-encoded PNG data
-     * @throws Error if no windows are available or no matching window is found
      *
      * @example
      * ```tsx
@@ -89,37 +128,11 @@ export const screen = {
      * await screen.screenshot(/^My App/);     // Window with title matching regex
      * ```
      */
-    screenshot: async (selector?: number | string | RegExp, options?: ScreenshotOptions): Promise<ScreenshotResult> => {
-        const windows = Gtk.Window.listToplevels();
-
-        if (windows.length === 0) {
-            throw new Error("No windows available for screenshot");
-        }
-
-        let targetWindow: Gtk.Window | undefined;
-
-        if (selector === undefined) {
-            targetWindow = windows[0] as Gtk.Window;
-        } else if (typeof selector === "number") {
-            targetWindow = windows[selector] as Gtk.Window | undefined;
-            if (!targetWindow) {
-                throw new Error(`Window at index ${selector} not found`);
-            }
-        } else {
-            const isRegex = selector instanceof RegExp;
-            targetWindow = windows.find((w) => {
-                const title = (w as Gtk.Window).getTitle() ?? "";
-                return isRegex ? selector.test(title) : title.includes(selector);
-            }) as Gtk.Window | undefined;
-
-            if (!targetWindow) {
-                const pattern = isRegex ? selector.toString() : `"${selector}"`;
-                throw new Error(`No window found with title matching ${pattern}`);
-            }
-        }
-
-        const result = await screenshotWidget(targetWindow, options);
-        saveAndLogScreenshot(result);
+    screenshot: async (selector?: WindowSelector, options?: ScreenshotOptions): Promise<ScreenshotResult> => {
+        const target = resolveWindow(selector);
+        const result = await captureScreenshot(target, options);
+        const filepath = saveScreenshotToTempFile(result);
+        logScreenshotPath(filepath);
         return result;
     },
 };

--- a/packages/testing/src/screenshot.ts
+++ b/packages/testing/src/screenshot.ts
@@ -1,7 +1,6 @@
-import { createRef } from "@gtkx/ffi";
 import * as Gsk from "@gtkx/ffi/gsk";
 import * as Gtk from "@gtkx/ffi/gtk";
-import { tick } from "./timing.js";
+import { act } from "./timing.js";
 import type { ScreenshotResult, WaitForOptions } from "./types.js";
 import { waitFor } from "./wait-for.js";
 
@@ -13,7 +12,7 @@ const DEFAULT_SCREENSHOT_TIMEOUT = 100;
 const DEFAULT_SCREENSHOT_INTERVAL = 10;
 
 const captureSnapshot = (widget: Gtk.Widget): ScreenshotResult => {
-    const paintable = new Gtk.WidgetPaintable(widget);
+    const paintable = new Gtk.WidgetPaintable({ widget });
     const width = paintable.getIntrinsicWidth();
     const height = paintable.getIntrinsicHeight();
 
@@ -38,10 +37,9 @@ const captureSnapshot = (widget: Gtk.Widget): ScreenshotResult => {
     renderer.realizeForDisplay(display);
 
     try {
-        const texture = renderer.renderTexture(renderNode);
+        const texture = renderer.renderTexture(renderNode, null);
         const pngBytes = texture.saveToPngBytes();
-        const sizeRef = createRef(0);
-        const data = pngBytes.getData(sizeRef);
+        const data = pngBytes.getData();
 
         if (!data) {
             throw new Error("Failed to serialize screenshot to PNG");
@@ -86,13 +84,13 @@ export type ScreenshotOptions = Pick<WaitForOptions, "timeout" | "interval">;
  * ```
  */
 export const screenshot = async (widget: Gtk.Widget, options?: ScreenshotOptions): Promise<ScreenshotResult> => {
-    await tick();
+    await act(() => {});
 
     return waitFor(() => captureSnapshot(widget), {
         timeout: options?.timeout ?? DEFAULT_SCREENSHOT_TIMEOUT,
         interval: options?.interval ?? DEFAULT_SCREENSHOT_INTERVAL,
         onTimeout: (error) => {
-            const paintable = new Gtk.WidgetPaintable(widget);
+            const paintable = new Gtk.WidgetPaintable({ widget });
             const width = paintable.getIntrinsicWidth();
             const height = paintable.getIntrinsicHeight();
 

--- a/packages/testing/src/timing.ts
+++ b/packages/testing/src/timing.ts
@@ -1,17 +1,128 @@
+import { act as reactAct } from "react";
+import "./react-internals-instrumentation.js";
+
+declare global {
+    var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 /**
- * Yields to the event loop, allowing pending GTK events to process.
+ * Returns the current `IS_REACT_ACT_ENVIRONMENT` flag.
  *
- * Use this after actions that trigger async widget updates.
+ * Async utilities such as {@link waitFor} call this to remember the caller's
+ * environment before clearing the flag for the duration of the poll.
+ */
+export const getIsReactActEnvironment = (): boolean | undefined => globalThis.IS_REACT_ACT_ENVIRONMENT;
+
+/**
+ * Sets the `IS_REACT_ACT_ENVIRONMENT` flag.
  *
- * @returns Promise that resolves on the next event loop tick
+ * Used by {@link act} and the async utilities to toggle React's act tracking
+ * around scopes that should — or should not — capture state updates.
+ */
+export const setIsReactActEnvironment = (value: boolean | undefined): void => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = value;
+};
+
+type ActImplementation = <T>(callback: () => T | Promise<T>) => PromiseLike<T>;
+
+const isThenable = (value: unknown): value is PromiseLike<unknown> =>
+    value !== null && typeof value === "object" && typeof (value as { then?: unknown }).then === "function";
+
+const instrumentationOrigin = Date.now();
+let actCallCounter = 0;
+const formatActEvent = (id: number, event: string, details?: string): string => {
+    const elapsed = Date.now() - instrumentationOrigin;
+    const suffix = details ? ` ${details}` : "";
+    return `[gtkx:act#${id}] +${elapsed}ms ${event}${suffix}`;
+};
+const logActEvent = (id: number, event: string, details?: string): void => {
+    console.error(formatActEvent(id, event, details));
+};
+
+const withGlobalActEnvironment =
+    (actImplementation: ActImplementation) =>
+    <T>(callback: () => T | Promise<T>): PromiseLike<T> => {
+        const id = ++actCallCounter;
+        const startTime = Date.now();
+        logActEvent(id, "enter");
+        const previousActEnvironment = getIsReactActEnvironment();
+        setIsReactActEnvironment(true);
+        try {
+            let callbackNeedsToBeAwaited = false;
+            const actResult = actImplementation<T>(() => {
+                const callbackStart = Date.now();
+                logActEvent(id, "callback start");
+                const result = callback();
+                if (isThenable(result)) {
+                    callbackNeedsToBeAwaited = true;
+                    logActEvent(id, "callback returned thenable", `sync=${Date.now() - callbackStart}ms`);
+                } else {
+                    logActEvent(id, "callback returned sync", `dur=${Date.now() - callbackStart}ms`);
+                }
+                return result;
+            });
+            if (callbackNeedsToBeAwaited) {
+                logActEvent(id, "awaiting react act (async branch)");
+                return new Promise<T>((resolve, reject) => {
+                    actResult.then(
+                        (returnValue) => {
+                            logActEvent(id, "react act resolved", `total=${Date.now() - startTime}ms`);
+                            setIsReactActEnvironment(previousActEnvironment);
+                            logActEvent(id, "env restored");
+                            resolve(returnValue);
+                        },
+                        (error) => {
+                            logActEvent(
+                                id,
+                                "react act rejected",
+                                `total=${Date.now() - startTime}ms err=${(error as Error)?.message ?? error}`,
+                            );
+                            setIsReactActEnvironment(previousActEnvironment);
+                            reject(error);
+                        },
+                    );
+                });
+            }
+            setIsReactActEnvironment(previousActEnvironment);
+            logActEvent(id, "sync branch done", `total=${Date.now() - startTime}ms`);
+            return actResult;
+        } catch (error) {
+            logActEvent(
+                id,
+                "threw synchronously",
+                `total=${Date.now() - startTime}ms err=${(error as Error)?.message ?? error}`,
+            );
+            setIsReactActEnvironment(previousActEnvironment);
+            throw error;
+        }
+    };
+
+/**
+ * GTK-flavored mirror of `@testing-library/react`'s `act`.
+ *
+ * Sets `IS_REACT_ACT_ENVIRONMENT` for the duration of the call and runs the
+ * callback inside a single React `act` scope. Sync callbacks execute and
+ * commit synchronously; the returned thenable carries any remaining work and
+ * may be awaited if the caller needs to observe its result. Async callbacks
+ * return a thenable that resolves after React has settled and the previous
+ * environment value has been restored.
+ *
+ * Mirrors {@link https://github.com/testing-library/react-testing-library/blob/main/src/act-compat.js | RTL's act-compat} almost verbatim: it is a transparent wrapper around the React `act`
+ * implementation that only manages the act-environment flag — it does not
+ * drive the GLib runloop, schedule timers, or wait on frame-clock callbacks.
+ * Asynchronous settlement is the responsibility of {@link waitFor} and the
+ * `findBy*` queries that use it.
  *
  * @example
  * ```tsx
- * import { tick } from "@gtkx/testing";
+ * await act(() => widget.setSensitive(false));
  *
- * widget.setSensitive(false);
- * await tick(); // Wait for GTK to process the change
- * expect(widget.getSensitive()).toBe(false);
+ * await act(async () => {
+ *     widget.activate();
+ *     await screen.findByText("Done");
+ * });
  * ```
  */
-export const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+export const act = withGlobalActEnvironment(reactAct as ActImplementation);

--- a/packages/testing/src/traversal.ts
+++ b/packages/testing/src/traversal.ts
@@ -1,16 +1,10 @@
 import * as Gtk from "@gtkx/ffi/gtk";
+import type { Container } from "@gtkx/react";
 
-/**
- * Root element for scoping queries.
- *
- * When a `Gtk.Application` is provided, queries search across all toplevel
- * windows. When a `Gtk.Widget` is provided, queries are scoped to that
- * widget's subtree.
- */
-export type Container = Gtk.Application | Gtk.Widget;
+export type { Container };
 
 export const isApplication = (container: Container): container is Gtk.Application =>
-    "getWindows" in container && typeof container.getWindows === "function";
+    container instanceof Gtk.Application;
 
 const traverseWidgetTree = function* (root: Gtk.Widget): Generator<Gtk.Widget> {
     yield root;
@@ -29,18 +23,27 @@ const traverseWindows = function* (): Generator<Gtk.Widget> {
     }
 };
 
+const resolveRoot = (container: Container): Gtk.Widget | null => {
+    if (container instanceof Gtk.Widget) return container;
+    if (container instanceof Gtk.EventController) return container.getWidget();
+    if (container instanceof Gtk.ListItem || container instanceof Gtk.ListHeader) return container.getChild();
+    return null;
+};
+
 export const traverse = function* (container: Container): Generator<Gtk.Widget> {
     if (isApplication(container)) {
         yield* traverseWindows();
-    } else {
-        yield* traverseWidgetTree(container);
+        return;
+    }
+    const root = resolveRoot(container);
+    if (root) {
+        yield* traverseWidgetTree(root);
     }
 };
 
 export const findAll = (container: Container, predicate: (node: Gtk.Widget) => boolean): Gtk.Widget[] => {
     const results: Gtk.Widget[] = [];
     for (const node of traverse(container)) {
-        if (node.getAccessibleRole?.() === Gtk.AccessibleRole.LABEL) continue;
         if (predicate(node)) {
             results.push(node);
         }

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -1,5 +1,5 @@
 import type * as Gtk from "@gtkx/ffi/gtk";
-import type { ComponentType, ReactNode, Ref } from "react";
+import type { ComponentType, ReactNode } from "react";
 import type { Container } from "./traversal.js";
 
 /**
@@ -9,7 +9,7 @@ import type { Container } from "./traversal.js";
  * @param widget - The widget being tested
  * @returns `true` if the content matches
  */
-export type TextMatchFunction = (content: string, widget: Gtk.Widget) => boolean;
+export type MatcherFunction = (content: string, widget: Gtk.Widget) => boolean;
 
 /**
  * Text matching pattern.
@@ -17,7 +17,7 @@ export type TextMatchFunction = (content: string, widget: Gtk.Widget) => boolean
  * Can be a string for exact/substring matching, a RegExp for pattern matching,
  * or a custom function for advanced matching logic.
  */
-export type TextMatch = string | RegExp | TextMatchFunction;
+export type Matcher = string | RegExp | MatcherFunction;
 
 /**
  * Options for text normalization before matching.
@@ -32,7 +32,7 @@ export type NormalizerOptions = {
 /**
  * Options for text-based queries.
  */
-export type TextMatchOptions = {
+export type MatcherOptions = {
     /** Require exact match vs substring match (default: true) */
     exact?: boolean;
     /** Custom text normalizer function */
@@ -50,9 +50,9 @@ export type TextMatchOptions = {
  *
  * Extends text matching options with accessible state filters.
  */
-export type ByRoleOptions = TextMatchOptions & {
+export type ByRoleOptions = MatcherOptions & {
     /** Filter by accessible name/label */
-    name?: TextMatch;
+    name?: Matcher;
     /** Filter by checked state (checkboxes, radios, toggles) */
     checked?: boolean;
     /** Filter by pressed state */
@@ -81,9 +81,18 @@ export type WaitForOptions = {
  * A wrapper component that exposes its root GTK widget via `ref`.
  * Accept `ref` as a prop and pass it through to the root intrinsic element.
  */
+/**
+ * A wrapper component that receives the rendered tree as children.
+ */
+/**
+ * A wrapper component that exposes its root GTK widget via `ref`.
+ * Accept `ref` as a prop and pass it through to the root intrinsic element.
+ */
+/**
+ * A wrapper component that receives the rendered tree as children.
+ */
 export type WrapperComponent = ComponentType<{
     children: ReactNode;
-    ref?: Ref<Gtk.Widget>;
 }>;
 
 /**
@@ -115,35 +124,51 @@ export type BoundQueries = {
     /** Query single element by accessible role (returns null if not found) */
     queryByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) => Gtk.Widget | null;
     /** Query single element by label/text content (returns null if not found) */
-    queryByLabelText: (text: TextMatch, options?: TextMatchOptions) => Gtk.Widget | null;
+    queryByLabelText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget | null;
     /** Query single element by visible text (returns null if not found) */
-    queryByText: (text: TextMatch, options?: TextMatchOptions) => Gtk.Widget | null;
+    queryByText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget | null;
     /** Query single element by widget name (returns null if not found) */
-    queryByName: (name: TextMatch, options?: TextMatchOptions) => Gtk.Widget | null;
+    queryByName: (name: Matcher, options?: MatcherOptions) => Gtk.Widget | null;
     /** Query all elements by accessible role (returns empty array if none found) */
     queryAllByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) => Gtk.Widget[];
     /** Query all elements by label/text content (returns empty array if none found) */
-    queryAllByLabelText: (text: TextMatch, options?: TextMatchOptions) => Gtk.Widget[];
+    queryAllByLabelText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget[];
     /** Query all elements by visible text (returns empty array if none found) */
-    queryAllByText: (text: TextMatch, options?: TextMatchOptions) => Gtk.Widget[];
+    queryAllByText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget[];
     /** Query all elements by widget name (returns empty array if none found) */
-    queryAllByName: (name: TextMatch, options?: TextMatchOptions) => Gtk.Widget[];
+    queryAllByName: (name: Matcher, options?: MatcherOptions) => Gtk.Widget[];
+    /** Get single element by accessible role (throws if not found or multiple match) */
+    getByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) => Gtk.Widget;
+    /** Get single element by label/text content (throws if not found or multiple match) */
+    getByLabelText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget;
+    /** Get single element by visible text (throws if not found or multiple match) */
+    getByText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget;
+    /** Get single element by widget name (throws if not found or multiple match) */
+    getByName: (name: Matcher, options?: MatcherOptions) => Gtk.Widget;
+    /** Get all elements by accessible role (throws if none found) */
+    getAllByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) => Gtk.Widget[];
+    /** Get all elements by label/text content (throws if none found) */
+    getAllByLabelText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget[];
+    /** Get all elements by visible text (throws if none found) */
+    getAllByText: (text: Matcher, options?: MatcherOptions) => Gtk.Widget[];
+    /** Get all elements by widget name (throws if none found) */
+    getAllByName: (name: Matcher, options?: MatcherOptions) => Gtk.Widget[];
     /** Find single element by accessible role (waits and throws if not found) */
     findByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) => Promise<Gtk.Widget>;
     /** Find single element by label/text content (waits and throws if not found) */
-    findByLabelText: (text: TextMatch, options?: TextMatchOptions) => Promise<Gtk.Widget>;
+    findByLabelText: (text: Matcher, options?: MatcherOptions) => Promise<Gtk.Widget>;
     /** Find single element by visible text (waits and throws if not found) */
-    findByText: (text: TextMatch, options?: TextMatchOptions) => Promise<Gtk.Widget>;
+    findByText: (text: Matcher, options?: MatcherOptions) => Promise<Gtk.Widget>;
     /** Find single element by widget name (waits and throws if not found) */
-    findByName: (name: TextMatch, options?: TextMatchOptions) => Promise<Gtk.Widget>;
+    findByName: (name: Matcher, options?: MatcherOptions) => Promise<Gtk.Widget>;
     /** Find all elements by accessible role (waits and throws if none found) */
     findAllByRole: (role: Gtk.AccessibleRole, options?: ByRoleOptions) => Promise<Gtk.Widget[]>;
     /** Find all elements by label/text content (waits and throws if none found) */
-    findAllByLabelText: (text: TextMatch, options?: TextMatchOptions) => Promise<Gtk.Widget[]>;
+    findAllByLabelText: (text: Matcher, options?: MatcherOptions) => Promise<Gtk.Widget[]>;
     /** Find all elements by visible text (waits and throws if none found) */
-    findAllByText: (text: TextMatch, options?: TextMatchOptions) => Promise<Gtk.Widget[]>;
+    findAllByText: (text: Matcher, options?: MatcherOptions) => Promise<Gtk.Widget[]>;
     /** Find all elements by widget name (waits and throws if none found) */
-    findAllByName: (name: TextMatch, options?: TextMatchOptions) => Promise<Gtk.Widget[]>;
+    findAllByName: (name: Matcher, options?: MatcherOptions) => Promise<Gtk.Widget[]>;
 };
 
 /**
@@ -180,12 +205,11 @@ export type ScreenshotResult = {
 
 /**
  * Options for {@link renderHook}.
+ *
+ * `initialProps` is required when `Props` is a non-optional type, and optional
+ * when `Props` accepts `undefined`. The `wrapper` field is always optional.
  */
 export type RenderHookOptions<Props> = {
-    /**
-     * Initial props passed to the hook callback.
-     */
-    initialProps?: Props;
     /**
      * Wrapper component or boolean.
      * - `true` (default): Wrap in GtkApplicationWindow
@@ -193,7 +217,19 @@ export type RenderHookOptions<Props> = {
      * - Component: Custom wrapper that passes `ref` to its root element
      */
     wrapper?: boolean | WrapperComponent;
-};
+} & (undefined extends Props
+    ? {
+          /**
+           * Initial props passed to the hook callback.
+           */
+          initialProps?: Props;
+      }
+    : {
+          /**
+           * Initial props passed to the hook callback.
+           */
+          initialProps: Props;
+      });
 
 /**
  * Result returned by {@link renderHook}.

--- a/packages/testing/src/user-event.ts
+++ b/packages/testing/src/user-event.ts
@@ -1,8 +1,7 @@
 import * as Gdk from "@gtkx/ffi/gdk";
-import { type Object as GObject, signalEmitv, signalLookup, typeFromName, Value } from "@gtkx/ffi/gobject";
 import * as Gtk from "@gtkx/ffi/gtk";
 import { fireEvent } from "./fire-event.js";
-import { tick } from "./timing.js";
+import { act } from "./timing.js";
 import { isEditable } from "./widget.js";
 
 /**
@@ -14,68 +13,61 @@ export type TabOptions = {
 };
 
 const click = async (element: Gtk.Widget): Promise<void> => {
-    element.activate();
-    await tick();
+    await act(() => {
+        element.activate();
+    });
 };
 
 const emitClickSequence = async (element: Gtk.Widget, nPress: number): Promise<void> => {
-    const controller = getOrCreateController(element, Gtk.GestureClick);
+    await act(() => {
+        const controller = getOrCreateController(element, Gtk.GestureClick);
 
-    for (let i = 1; i <= nPress; i++) {
-        const args = [
-            Value.newFromObject(controller),
-            Value.newFromInt(i),
-            Value.newFromDouble(0),
-            Value.newFromDouble(0),
-        ];
-        signalEmitv(args, getSignalId(controller, "pressed"), 0);
-        signalEmitv(args, getSignalId(controller, "released"), 0);
-    }
-
-    await tick();
+        for (let i = 1; i <= nPress; i++) {
+            controller.emit("pressed", i, 0, 0);
+            controller.emit("released", i, 0, 0);
+        }
+    });
 };
 
-const dblClick = async (element: Gtk.Widget): Promise<void> => {
-    await emitClickSequence(element, 2);
-};
+const dblClick = (element: Gtk.Widget): Promise<void> => emitClickSequence(element, 2);
 
-const tripleClick = async (element: Gtk.Widget): Promise<void> => {
-    await emitClickSequence(element, 3);
-};
+const tripleClick = (element: Gtk.Widget): Promise<void> => emitClickSequence(element, 3);
 
 const tab = async (element: Gtk.Widget, options?: TabOptions): Promise<void> => {
-    const direction = options?.shift ? Gtk.DirectionType.TAB_BACKWARD : Gtk.DirectionType.TAB_FORWARD;
-    const root = element.getRoot();
+    await act(() => {
+        const direction = options?.shift ? Gtk.DirectionType.TAB_BACKWARD : Gtk.DirectionType.TAB_FORWARD;
+        const root = element.getRoot();
 
-    if (root && root instanceof Gtk.Widget) {
-        root.childFocus(direction);
-    }
-
-    await tick();
+        if (root && root instanceof Gtk.Widget) {
+            root.childFocus(direction);
+        }
+    });
 };
 
 const type = async (element: Gtk.Widget, text: string): Promise<void> => {
-    if (!isEditable(element)) {
-        throw new Error("Cannot type into element: expected editable widget (TEXT_BOX, SEARCH_BOX, or SPIN_BUTTON)");
-    }
+    await act(() => {
+        if (!isEditable(element)) {
+            throw new Error(
+                "Cannot type into element: expected editable widget (TEXT_BOX, SEARCH_BOX, or SPIN_BUTTON)",
+            );
+        }
 
-    const currentText = element.getText();
-    element.setText(currentText + text);
-
-    await tick();
+        const currentText = element.getText();
+        element.setText(currentText + text);
+    });
 };
 
 const clear = async (element: Gtk.Widget): Promise<void> => {
-    if (!isEditable(element)) {
-        throw new Error("Cannot clear element: expected editable widget (TEXT_BOX, SEARCH_BOX, or SPIN_BUTTON)");
-    }
+    await act(() => {
+        if (!isEditable(element)) {
+            throw new Error("Cannot clear element: expected editable widget (TEXT_BOX, SEARCH_BOX, or SPIN_BUTTON)");
+        }
 
-    element.setText("");
-
-    await tick();
+        element.setText("");
+    });
 };
 
-const SELECTABLE_ROLES = new Set([Gtk.AccessibleRole.COMBO_BOX, Gtk.AccessibleRole.LIST]);
+const SELECTABLE_ROLES = new Set<Gtk.AccessibleRole>([Gtk.AccessibleRole.COMBO_BOX, Gtk.AccessibleRole.LIST]);
 
 const isSelectable = (widget: Gtk.Widget): boolean => {
     if (!widget) return false;
@@ -88,13 +80,14 @@ const selectListViewItems = (selectionModel: Gtk.SelectionModel, positions: numb
         return;
     }
 
-    if (exclusive && positions.length === 1) {
-        selectionModel.selectItem(positions[0] as number, true);
+    const [first] = positions;
+    if (exclusive && positions.length === 1 && first !== undefined) {
+        selectionModel.selectItem(first, true);
         return;
     }
 
     const nItems = selectionModel.getNItems();
-    const selected = new Gtk.Bitset();
+    const selected = Gtk.Bitset.newEmpty();
     const mask = Gtk.Bitset.newRange(0, nItems);
 
     for (const pos of positions) {
@@ -108,79 +101,93 @@ const isListView = (widget: Gtk.Widget): widget is Gtk.ListView | Gtk.GridView |
     return widget instanceof Gtk.ListView || widget instanceof Gtk.GridView || widget instanceof Gtk.ColumnView;
 };
 
-const selectOptions = async (element: Gtk.Widget, values: number | number[]): Promise<void> => {
-    const valueArray = Array.isArray(values) ? values : [values];
-
-    if (isListView(element)) {
-        const selectionModel = element.getModel() as Gtk.SelectionModel;
-        const isMultiSelection = selectionModel instanceof Gtk.MultiSelection;
-        selectListViewItems(selectionModel, valueArray, !isMultiSelection);
-        await tick();
-        return;
+const selectComboBoxOption = (element: Gtk.Widget, values: number | number[], valueArray: number[]): void => {
+    if (Array.isArray(values) && values.length > 1) {
+        throw new Error("Cannot select multiple options: ComboBox only supports single selection");
     }
+    const [selection] = valueArray;
+    if (selection === undefined) return;
+    if (element instanceof Gtk.DropDown) {
+        element.setSelected(selection);
+    } else if (element instanceof Gtk.ComboBox) {
+        element.setActive(selection);
+    }
+};
 
+const selectListBoxOptions = (element: Gtk.ListBox, valueArray: number[]): void => {
+    for (const value of valueArray) {
+        const row = element.getRowAtIndex(value);
+        if (row) {
+            element.selectRow(row);
+            row.activate();
+        }
+    }
+};
+
+const selectInListView = (element: Gtk.ListView | Gtk.GridView | Gtk.ColumnView, valueArray: number[]): void => {
+    const selectionModel = element.getModel();
+    if (selectionModel === null) {
+        throw new Error("Cannot select options: list view has no selection model");
+    }
+    const isMultiSelection = selectionModel instanceof Gtk.MultiSelection;
+    selectListViewItems(selectionModel, valueArray, !isMultiSelection);
+};
+
+const selectByRole = (element: Gtk.Widget, values: number | number[], valueArray: number[]): void => {
     if (!isSelectable(element)) {
         throw new Error("Cannot select options: expected selectable widget (COMBO_BOX or LIST)");
     }
 
     const role = element.getAccessibleRole();
-
     if (role === Gtk.AccessibleRole.COMBO_BOX) {
-        if (Array.isArray(values) && values.length > 1) {
-            throw new Error("Cannot select multiple options: ComboBox only supports single selection");
-        }
-        if (element instanceof Gtk.DropDown) {
-            (element as Gtk.DropDown).setSelected(valueArray[0] as number);
-        } else {
-            (element as Gtk.ComboBox).setActive(valueArray[0] as number);
-        }
+        selectComboBoxOption(element, values, valueArray);
     } else if (role === Gtk.AccessibleRole.LIST) {
-        const listBox = element as Gtk.ListBox;
+        selectListBoxOptions(element as Gtk.ListBox, valueArray);
+    }
+};
 
-        for (const value of valueArray) {
-            const row = listBox.getRowAtIndex(value);
+const selectOptions = async (element: Gtk.Widget, values: number | number[]): Promise<void> => {
+    await act(() => {
+        const valueArray = Array.isArray(values) ? values : [values];
+        if (isListView(element)) {
+            selectInListView(element, valueArray);
+            return;
+        }
+        selectByRole(element, values, valueArray);
+    });
+};
 
-            if (row) {
-                listBox.selectRow(row);
-                row.activate();
-            }
+const deselectInListView = (element: Gtk.ListView | Gtk.GridView | Gtk.ColumnView, valueArray: number[]): void => {
+    const selectionModel = element.getModel();
+    if (selectionModel === null) {
+        throw new Error("Cannot deselect options: list view has no selection model");
+    }
+    for (const pos of valueArray) {
+        selectionModel.unselectItem(pos);
+    }
+};
+
+const deselectInListBox = (listBox: Gtk.ListBox, valueArray: number[]): void => {
+    for (const value of valueArray) {
+        const row = listBox.getRowAtIndex(value);
+        if (row) {
+            listBox.unselectRow(row);
         }
     }
-
-    await tick();
 };
 
 const deselectOptions = async (element: Gtk.Widget, values: number | number[]): Promise<void> => {
-    const valueArray = Array.isArray(values) ? values : [values];
-
-    if (isListView(element)) {
-        const selectionModel = element.getModel() as Gtk.SelectionModel;
-
-        for (const pos of valueArray) {
-            selectionModel.unselectItem(pos);
+    await act(() => {
+        const valueArray = Array.isArray(values) ? values : [values];
+        if (isListView(element)) {
+            deselectInListView(element, valueArray);
+            return;
         }
-
-        await tick();
-        return;
-    }
-
-    const role = element.getAccessibleRole();
-
-    if (role !== Gtk.AccessibleRole.LIST) {
-        throw new Error("Cannot deselect options: only ListBox supports deselection");
-    }
-
-    const listBox = element as Gtk.ListBox;
-
-    for (const value of valueArray) {
-        const row = listBox.getRowAtIndex(value);
-
-        if (row) {
-            listBox.unselectRow(row as Gtk.ListBoxRow);
+        if (element.getAccessibleRole() !== Gtk.AccessibleRole.LIST) {
+            throw new Error("Cannot deselect options: only ListBox supports deselection");
         }
-    }
-
-    await tick();
+        deselectInListBox(element as Gtk.ListBox, valueArray);
+    });
 };
 
 const getOrCreateController = <T extends Gtk.EventController>(element: Gtk.Widget, controllerType: new () => T): T => {
@@ -188,9 +195,9 @@ const getOrCreateController = <T extends Gtk.EventController>(element: Gtk.Widge
     const nItems = controllers.getNItems();
 
     for (let i = 0; i < nItems; i++) {
-        const controller = controllers.getObject(i);
+        const controller = controllers.getItem(i);
         if (controller instanceof controllerType) {
-            return controller as T;
+            return controller;
         }
     }
 
@@ -199,25 +206,18 @@ const getOrCreateController = <T extends Gtk.EventController>(element: Gtk.Widge
     return controller;
 };
 
-const getSignalId = (target: Gtk.EventController, signalName: string): number => {
-    const gtype = typeFromName((target.constructor as typeof GObject).glibTypeName);
-    return signalLookup(signalName, gtype);
-};
-
 const hover = async (element: Gtk.Widget): Promise<void> => {
-    const controller = getOrCreateController(element, Gtk.EventControllerMotion);
-    signalEmitv(
-        [Value.newFromObject(controller), Value.newFromDouble(0), Value.newFromDouble(0)],
-        getSignalId(controller, "enter"),
-        0,
-    );
-    await tick();
+    await act(() => {
+        const controller = getOrCreateController(element, Gtk.EventControllerMotion);
+        controller.emit("enter", 0, 0);
+    });
 };
 
 const unhover = async (element: Gtk.Widget): Promise<void> => {
-    const controller = getOrCreateController(element, Gtk.EventControllerMotion);
-    signalEmitv([Value.newFromObject(controller)], getSignalId(controller, "leave"), 0);
-    await tick();
+    await act(() => {
+        const controller = getOrCreateController(element, Gtk.EventControllerMotion);
+        controller.emit("leave");
+    });
 };
 
 const KEY_MAP: Record<string, number> = {
@@ -241,41 +241,48 @@ const KEY_MAP: Record<string, number> = {
     Meta: Gdk.KEY_Meta_L,
 };
 
-const parseKeyboardInput = (input: string): Array<{ keyval: number; press: boolean }> => {
-    const actions: Array<{ keyval: number; press: boolean }> = [];
+type KeyAction = { keyval: number; press: boolean };
+
+const parseKeyToken = (token: string): { keyval: number; press: boolean; release: boolean } => {
+    let keyName = token;
+    let press = true;
+    let release = true;
+
+    if (keyName.startsWith("/")) {
+        keyName = keyName.slice(1);
+        press = false;
+    } else if (keyName.endsWith(">")) {
+        keyName = keyName.slice(0, -1);
+        release = false;
+    }
+
+    const keyval = KEY_MAP[keyName];
+    if (keyval === undefined) {
+        throw new Error(`Unknown key: {${keyName}}`);
+    }
+    return { keyval, press, release };
+};
+
+const parseKeyboardInput = (input: string): KeyAction[] => {
+    const actions: KeyAction[] = [];
     let i = 0;
 
     while (i < input.length) {
-        if (input[i] === "{") {
-            const endBrace = input.indexOf("}", i);
-            if (endBrace === -1) break;
-
-            let keyName = input.slice(i + 1, endBrace);
-            let press = true;
-            let release = true;
-
-            if (keyName.startsWith("/")) {
-                keyName = keyName.slice(1);
-                press = false;
-            } else if (keyName.endsWith(">")) {
-                keyName = keyName.slice(0, -1);
-                release = false;
-            }
-
-            const keyval = KEY_MAP[keyName];
-            if (keyval === undefined) {
-                throw new Error(`Unknown key: {${keyName}}`);
-            }
-            if (press) actions.push({ keyval, press: true });
-            if (release) actions.push({ keyval, press: false });
-
-            i = endBrace + 1;
-        } else {
-            const keyval = input.charCodeAt(i);
-            actions.push({ keyval, press: true });
-            actions.push({ keyval, press: false });
+        if (input[i] !== "{") {
+            const keyval = input.codePointAt(i) ?? 0;
+            actions.push({ keyval, press: true }, { keyval, press: false });
             i++;
+            continue;
         }
+
+        const endBrace = input.indexOf("}", i);
+        if (endBrace === -1) break;
+
+        const { keyval, press, release } = parseKeyToken(input.slice(i + 1, endBrace));
+        if (press) actions.push({ keyval, press: true });
+        if (release) actions.push({ keyval, press: false });
+
+        i = endBrace + 1;
     }
 
     return actions;
@@ -292,46 +299,50 @@ const MODIFIER_KEYVAL_TO_MASK: Record<number, number> = {
     [Gdk.KEY_Meta_R]: Gdk.ModifierType.META_MASK,
 };
 
-let gdkModifierType: number | null = null;
-
-const keyboard = async (element: Gtk.Widget, input: string): Promise<void> => {
-    gdkModifierType ??= typeFromName("GdkModifierType");
-    const controller = getOrCreateController(element, Gtk.EventControllerKey);
-    const actions = parseKeyboardInput(input);
-    let modifierState = 0;
-
-    for (const action of actions) {
-        const mask = MODIFIER_KEYVAL_TO_MASK[action.keyval];
-
-        if (mask) {
-            if (action.press) {
-                modifierState |= mask;
-            } else {
-                modifierState &= ~mask;
-            }
-        }
-
-        const signalName = action.press ? "key-pressed" : "key-released";
-        const returnValue = action.press ? Value.newFromBoolean(false) : undefined;
-        signalEmitv(
-            [
-                Value.newFromObject(controller),
-                Value.newFromUint(action.keyval),
-                Value.newFromUint(0),
-                Value.newFromFlags(gdkModifierType, modifierState),
-            ],
-            getSignalId(controller, signalName),
-            0,
-            returnValue,
-        );
-
-        if (action.press && action.keyval === Gdk.KEY_Return && isEditable(element)) {
-            await fireEvent(element, "activate");
-        }
-    }
-
-    await tick();
+type UserEventState = {
+    modifierState: number;
+    mouseLeftDown: boolean;
 };
+
+const createInitialState = (): UserEventState => ({ modifierState: 0, mouseLeftDown: false });
+
+const updateModifierState = (state: UserEventState, action: KeyAction): void => {
+    const mask = MODIFIER_KEYVAL_TO_MASK[action.keyval];
+    if (!mask) return;
+    if (action.press) {
+        state.modifierState |= mask;
+    } else {
+        state.modifierState &= ~mask;
+    }
+};
+
+const applyKeyAction = async (
+    element: Gtk.Widget,
+    controller: Gtk.EventControllerKey,
+    state: UserEventState,
+    action: KeyAction,
+): Promise<void> => {
+    updateModifierState(state, action);
+    const signalName = action.press ? "key-pressed" : "key-released";
+    controller.emit(signalName, action.keyval, 0, state.modifierState);
+    if (action.press && action.keyval === Gdk.KEY_Return && isEditable(element)) {
+        await fireEvent(element, "activate");
+    }
+};
+
+const keyboardWith =
+    (state: UserEventState) =>
+    async (element: Gtk.Widget, input: string): Promise<void> => {
+        await act(async () => {
+            const controller = getOrCreateController(element, Gtk.EventControllerKey);
+            for (const action of parseKeyboardInput(input)) {
+                await applyKeyAction(element, controller, state, action);
+            }
+        });
+    };
+
+const keyboard = (element: Gtk.Widget, input: string): Promise<void> =>
+    keyboardWith(createInitialState())(element, input);
 
 /**
  * Pointer input actions for simulating mouse interactions.
@@ -342,32 +353,39 @@ const keyboard = async (element: Gtk.Widget, input: string): Promise<void> => {
  */
 export type PointerInput = "click" | "down" | "up" | "[MouseLeft]" | "[MouseLeft>]" | "[/MouseLeft]";
 
-const pointer = async (element: Gtk.Widget, input: PointerInput): Promise<void> => {
-    const controller = getOrCreateController(element, Gtk.GestureClick);
-    const pressedArgs = [
-        Value.newFromObject(controller),
-        Value.newFromInt(1),
-        Value.newFromDouble(0),
-        Value.newFromDouble(0),
-    ];
-    const releasedArgs = [
-        Value.newFromObject(controller),
-        Value.newFromInt(1),
-        Value.newFromDouble(0),
-        Value.newFromDouble(0),
-    ];
+const PRESS_INPUTS = new Set<PointerInput>(["[MouseLeft>]", "down"]);
+const RELEASE_INPUTS = new Set<PointerInput>(["[/MouseLeft]", "up"]);
+const CLICK_INPUTS = new Set<PointerInput>(["[MouseLeft]", "click"]);
 
-    if (input === "[MouseLeft]" || input === "click") {
-        signalEmitv(pressedArgs, getSignalId(controller, "pressed"), 0);
-        signalEmitv(releasedArgs, getSignalId(controller, "released"), 0);
-    } else if (input === "[MouseLeft>]" || input === "down") {
-        signalEmitv(pressedArgs, getSignalId(controller, "pressed"), 0);
-    } else if (input === "[/MouseLeft]" || input === "up") {
-        signalEmitv(releasedArgs, getSignalId(controller, "released"), 0);
+const applyPointerInput = (controller: Gtk.GestureClick, state: UserEventState, input: PointerInput): void => {
+    if (CLICK_INPUTS.has(input)) {
+        controller.emit("pressed", 1, 0, 0);
+        controller.emit("released", 1, 0, 0);
+        state.mouseLeftDown = false;
+        return;
     }
-
-    await tick();
+    if (PRESS_INPUTS.has(input) && !state.mouseLeftDown) {
+        controller.emit("pressed", 1, 0, 0);
+        state.mouseLeftDown = true;
+        return;
+    }
+    if (RELEASE_INPUTS.has(input) && state.mouseLeftDown) {
+        controller.emit("released", 1, 0, 0);
+        state.mouseLeftDown = false;
+    }
 };
+
+const pointerWith =
+    (state: UserEventState) =>
+    async (element: Gtk.Widget, input: PointerInput): Promise<void> => {
+        await act(() => {
+            const controller = getOrCreateController(element, Gtk.GestureClick);
+            applyPointerInput(controller, state, input);
+        });
+    };
+
+const pointer = (element: Gtk.Widget, input: PointerInput): Promise<void> =>
+    pointerWith(createInitialState())(element, input);
 
 /**
  * User interaction utilities for testing.
@@ -489,4 +507,54 @@ export const userEvent = {
      * ```
      */
     pointer,
+    /**
+     * Creates an isolated user-event instance whose `keyboard` and `pointer`
+     * helpers retain modifier and pointer-down state across calls.
+     *
+     * Mirrors `@testing-library/user-event` v14's `userEvent.setup()`.
+     *
+     * @example
+     * ```tsx
+     * const user = userEvent.setup();
+     * await user.keyboard("{Shift>}"); // Shift held
+     * await user.keyboard("a");        // arrives with Shift still held
+     * await user.keyboard("{/Shift}"); // Shift released
+     * ```
+     */
+    setup: (): UserEventInstance => {
+        const state = createInitialState();
+        return {
+            click,
+            dblClick,
+            tripleClick,
+            tab,
+            type,
+            clear,
+            selectOptions,
+            deselectOptions,
+            hover,
+            unhover,
+            keyboard: keyboardWith(state),
+            pointer: pointerWith(state),
+        };
+    },
+};
+
+/**
+ * Result of {@link userEvent.setup}: the same helpers as {@link userEvent},
+ * but with persistent keyboard/pointer state across calls.
+ */
+export type UserEventInstance = {
+    click: typeof click;
+    dblClick: typeof dblClick;
+    tripleClick: typeof tripleClick;
+    tab: typeof tab;
+    type: typeof type;
+    clear: typeof clear;
+    selectOptions: typeof selectOptions;
+    deselectOptions: typeof deselectOptions;
+    hover: typeof hover;
+    unhover: typeof unhover;
+    keyboard: (element: Gtk.Widget, input: string) => Promise<void>;
+    pointer: (element: Gtk.Widget, input: PointerInput) => Promise<void>;
 };

--- a/packages/testing/src/wait-for.ts
+++ b/packages/testing/src/wait-for.ts
@@ -1,9 +1,40 @@
 import type * as Gtk from "@gtkx/ffi/gtk";
 import { getConfig } from "./config.js";
 import { buildTimeoutError } from "./error-builder.js";
+import { getIsReactActEnvironment, setIsReactActEnvironment } from "./timing.js";
 import type { WaitForOptions } from "./types.js";
 
 const DEFAULT_INTERVAL = 50;
+
+/**
+ * Drains the JS microtask queue by yielding one `setTimeout(0)` round.
+ *
+ * Mirrors {@link https://github.com/testing-library/react-testing-library/blob/main/src/pure.js | RTL's `asyncWrapper`} drain step: any in-flight promises scheduled while
+ * `IS_REACT_ACT_ENVIRONMENT` was cleared get a chance to settle before the
+ * caller re-enters an act-tracked scope.
+ */
+const drainMicrotasks = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Runs an async callback with `IS_REACT_ACT_ENVIRONMENT` cleared, draining the
+ * microtask queue once it resolves before restoring the previous flag value.
+ *
+ * Direct port of {@link https://github.com/testing-library/react-testing-library/blob/main/src/pure.js | RTL's `asyncWrapper`}; used by every async utility in this package so
+ * that polling code does not capture React state updates as part of an
+ * accidental act scope, and so callers regain control with a clean microtask
+ * queue.
+ */
+const asyncWrapper = async <T>(callback: () => Promise<T>): Promise<T> => {
+    const previousActEnvironment = getIsReactActEnvironment();
+    setIsReactActEnvironment(false);
+    try {
+        const result = await callback();
+        await drainMicrotasks();
+        return result;
+    } finally {
+        setIsReactActEnvironment(previousActEnvironment);
+    }
+};
 
 /**
  * Waits for a callback to succeed.
@@ -24,27 +55,28 @@ const DEFAULT_INTERVAL = 50;
  * }, { timeout: 2000 });
  * ```
  */
-export const waitFor = async <T>(callback: () => T | Promise<T>, options?: WaitForOptions): Promise<T> => {
-    const config = getConfig();
-    const { timeout = config.asyncUtilTimeout, interval = DEFAULT_INTERVAL, onTimeout } = options ?? {};
-    const startTime = Date.now();
-    let lastError: Error | null = null;
+export const waitFor = <T>(callback: () => T | Promise<T>, options?: WaitForOptions): Promise<T> =>
+    asyncWrapper(async () => {
+        const config = getConfig();
+        const { timeout = config.asyncUtilTimeout, interval = DEFAULT_INTERVAL, onTimeout } = options ?? {};
+        const startTime = Date.now();
+        let lastError: Error | null = null;
 
-    while (Date.now() - startTime < timeout) {
-        try {
-            return await callback();
-        } catch (error) {
-            lastError = error as Error;
-            await new Promise((resolve) => setTimeout(resolve, interval));
+        while (Date.now() - startTime < timeout) {
+            try {
+                return await callback();
+            } catch (error) {
+                lastError = error as Error;
+                await new Promise((resolve) => setTimeout(resolve, interval));
+            }
         }
-    }
 
-    const timeoutError = buildTimeoutError(timeout, lastError);
-    if (onTimeout) {
-        throw onTimeout(timeoutError);
-    }
-    throw timeoutError;
-};
+        const timeoutError = buildTimeoutError(timeout, lastError);
+        if (onTimeout) {
+            throw onTimeout(timeoutError);
+        }
+        throw timeoutError;
+    });
 
 /** @internal */
 type ElementOrCallback = Gtk.Widget | (() => Gtk.Widget | null);
@@ -84,33 +116,34 @@ const isElementRemoved = (element: Gtk.Widget | null): boolean => {
  * // Loader is now gone
  * ```
  */
-export const waitForElementToBeRemoved = async (
+export const waitForElementToBeRemoved = (
     elementOrCallback: ElementOrCallback,
     options?: WaitForOptions,
-): Promise<void> => {
-    const config = getConfig();
-    const { timeout = config.asyncUtilTimeout, interval = DEFAULT_INTERVAL, onTimeout } = options ?? {};
+): Promise<void> =>
+    asyncWrapper(async () => {
+        const config = getConfig();
+        const { timeout = config.asyncUtilTimeout, interval = DEFAULT_INTERVAL, onTimeout } = options ?? {};
 
-    const initialElement = getElement(elementOrCallback);
-    if (initialElement === null || isElementRemoved(initialElement)) {
-        throw new Error(
-            "Element already removed: waitForElementToBeRemoved requires the element to be present initially",
-        );
-    }
-
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < timeout) {
-        const element = getElement(elementOrCallback);
-        if (isElementRemoved(element)) {
-            return;
+        const initialElement = getElement(elementOrCallback);
+        if (initialElement === null || isElementRemoved(initialElement)) {
+            throw new Error(
+                "Element already removed: waitForElementToBeRemoved requires the element to be present initially",
+            );
         }
-        await new Promise((resolve) => setTimeout(resolve, interval));
-    }
 
-    const timeoutError = new Error(`Timed out after ${timeout}ms waiting for element to be removed`);
-    if (onTimeout) {
-        throw onTimeout(timeoutError);
-    }
-    throw timeoutError;
-};
+        const startTime = Date.now();
+
+        while (Date.now() - startTime < timeout) {
+            const element = getElement(elementOrCallback);
+            if (isElementRemoved(element)) {
+                return;
+            }
+            await new Promise((resolve) => setTimeout(resolve, interval));
+        }
+
+        const timeoutError = new Error(`Timed out after ${timeout}ms waiting for element to be removed`);
+        if (onTimeout) {
+            throw onTimeout(timeoutError);
+        }
+        throw timeoutError;
+    });

--- a/packages/testing/src/widget-text.ts
+++ b/packages/testing/src/widget-text.ts
@@ -1,5 +1,5 @@
-import { getNativeInterface } from "@gtkx/ffi";
 import * as Gtk from "@gtkx/ffi/gtk";
+import { getAccessibleMetadata } from "@gtkx/react";
 
 const getLabelText = (widget: Gtk.Widget): string | null => {
     const asLabel = widget as Gtk.Label;
@@ -7,23 +7,19 @@ const getLabelText = (widget: Gtk.Widget): string | null => {
     return asLabel.getLabel?.() ?? asInscription.getText?.() ?? null;
 };
 
+const DEFAULT_TEXT_GETTERS = ["getLabel", "getText", "getTitle"] as const;
+
 const getDefaultText = (widget: Gtk.Widget): string | null => {
-    if ("getLabel" in widget && typeof widget.getLabel === "function") {
-        return (widget.getLabel() as string) || null;
+    for (const getter of DEFAULT_TEXT_GETTERS) {
+        const fn: unknown = Reflect.get(widget, getter);
+        if (typeof fn !== "function") continue;
+        const value = (fn as () => string).call(widget);
+        if (value) return value;
     }
-
-    if ("getText" in widget && typeof widget.getText === "function") {
-        return (widget.getText() as string) || null;
-    }
-
-    if ("getTitle" in widget && typeof widget.getTitle === "function") {
-        return (widget.getTitle() as string) || null;
-    }
-
-    return getNativeInterface(widget, Gtk.Editable)?.getText() || null;
+    return null;
 };
 
-const collectDirectChildLabels = (widget: Gtk.Widget): string[] => {
+const collectLabels = (widget: Gtk.Widget, recursive: boolean): string[] => {
     const labels: string[] = [];
     let child = widget.getFirstChild();
 
@@ -32,23 +28,7 @@ const collectDirectChildLabels = (widget: Gtk.Widget): string[] => {
             const labelText = getLabelText(child);
             if (labelText) labels.push(labelText);
         }
-        child = child.getNextSibling();
-    }
-
-    return labels;
-};
-
-const collectChildLabels = (widget: Gtk.Widget): string[] => {
-    const labels: string[] = [];
-    let child = widget.getFirstChild();
-
-    while (child) {
-        if (child.getAccessibleRole() === Gtk.AccessibleRole.LABEL) {
-            const labelText = getLabelText(child);
-            if (labelText) labels.push(labelText);
-        }
-
-        labels.push(...collectChildLabels(child));
+        if (recursive) labels.push(...collectLabels(child, true));
         child = child.getNextSibling();
     }
 
@@ -69,8 +49,8 @@ export const getWidgetText = (widget: Gtk.Widget): string | null => {
     const role = widget.getAccessibleRole();
     if (role === undefined) return null;
 
-    const childLabels = collectDirectChildLabels(widget);
-    return childLabels.length > 0 ? childLabels.join("") : null;
+    const childLabels = collectLabels(widget, false);
+    return childLabels.length > 0 ? childLabels.join(" ") : null;
 };
 
 /**
@@ -112,10 +92,13 @@ export const getWidgetAccessibleName = (widget: Gtk.Widget): string | null => {
         return null;
     }
 
+    const accessibleLabel = getAccessibleMetadata<string>(widget, "accessibleLabel");
+    if (accessibleLabel) return accessibleLabel;
+
     const ownText = getDefaultText(widget);
     if (ownText) return ownText;
 
-    const childLabels = collectChildLabels(widget);
+    const childLabels = collectLabels(widget, true);
     return childLabels.length > 0 ? childLabels.join(" ") : null;
 };
 

--- a/packages/testing/src/widget.ts
+++ b/packages/testing/src/widget.ts
@@ -1,6 +1,6 @@
 import * as Gtk from "@gtkx/ffi/gtk";
 
-const EDITABLE_ROLES = new Set([
+const EDITABLE_ROLES = new Set<Gtk.AccessibleRole>([
     Gtk.AccessibleRole.TEXT_BOX,
     Gtk.AccessibleRole.SEARCH_BOX,
     Gtk.AccessibleRole.SPIN_BUTTON,

--- a/packages/testing/tests/config.test.tsx
+++ b/packages/testing/tests/config.test.tsx
@@ -4,10 +4,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resetConfig } from "../src/config.js";
 import { configure, findByRole, getConfig, render } from "../src/index.js";
 
-describe("configure", () => {
+function setupConfigReset() {
     afterEach(() => {
         resetConfig();
     });
+}
+
+describe("configure defaults", () => {
+    setupConfigReset();
 
     it("has default configuration", () => {
         const config = getConfig();
@@ -15,6 +19,10 @@ describe("configure", () => {
         expect(config.showSuggestions).toBe(true);
         expect(config.getElementError).toBeDefined();
     });
+});
+
+describe("configure updates", () => {
+    setupConfigReset();
 
     it("updates configuration with partial object", () => {
         configure({ showSuggestions: false });
@@ -31,6 +39,10 @@ describe("configure", () => {
         const config = getConfig();
         expect(config.showSuggestions).toBe(false);
     });
+});
+
+describe("configure suggestions", () => {
+    setupConfigReset();
 
     it("disables suggestions in error messages when showSuggestions is false", async () => {
         configure({ showSuggestions: false });
@@ -57,6 +69,10 @@ describe("configure", () => {
             expect(message).toContain("Here are the accessible roles:");
         }
     });
+});
+
+describe("configure error factory", () => {
+    setupConfigReset();
 
     it("allows custom error factory for query errors", async () => {
         class CustomError extends Error {

--- a/packages/testing/tests/queries.test.tsx
+++ b/packages/testing/tests/queries.test.tsx
@@ -9,6 +9,7 @@ import {
     GtkSwitch,
     GtkToggleButton,
 } from "@gtkx/react";
+import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import {
     findAllByLabelText,
@@ -22,6 +23,10 @@ import {
     render,
 } from "../src/index.js";
 
+const VBox = ({ children }: { children: ReactNode }) => (
+    <GtkBox orientation={Gtk.Orientation.VERTICAL}>{children}</GtkBox>
+);
+
 describe("findByRole", () => {
     it("finds element by accessible role", async () => {
         const { container } = await render(<GtkButton label="Test" />);
@@ -31,10 +36,10 @@ describe("findByRole", () => {
 
     it("filters by name option", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkButton label="Save" />
                 <GtkButton label="Cancel" />
-            </GtkBox>,
+            </VBox>,
         );
 
         const saveButton = await findByRole(container, Gtk.AccessibleRole.BUTTON, { name: "Save" });
@@ -43,10 +48,10 @@ describe("findByRole", () => {
 
     it("filters by checked state for checkboxes", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkCheckButton label="Unchecked" />
                 <GtkCheckButton label="Checked" active />
-            </GtkBox>,
+            </VBox>,
         );
 
         const checkedBox = await findByRole(container, Gtk.AccessibleRole.CHECKBOX, { checked: true });
@@ -55,10 +60,10 @@ describe("findByRole", () => {
 
     it("filters by checked state for toggle buttons", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkToggleButton label="Inactive" />
                 <GtkToggleButton label="Active" active />
-            </GtkBox>,
+            </VBox>,
         );
 
         const activeToggle = await findByRole(container, Gtk.AccessibleRole.TOGGLE_BUTTON, { checked: true });
@@ -67,24 +72,26 @@ describe("findByRole", () => {
 
     it("filters by checked state for switches", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkSwitch />
                 <GtkSwitch active />
-            </GtkBox>,
+            </VBox>,
         );
 
         const activeSwitch = await findByRole(container, Gtk.AccessibleRole.SWITCH, { checked: true });
         expect(activeSwitch).toBeDefined();
     });
+});
 
+describe("findByRole matchers", () => {
     it("finds expander by label", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkExpander label="Collapsed">Content</GtkExpander>
                 <GtkExpander label="Expanded" expanded>
                     Content
                 </GtkExpander>
-            </GtkBox>,
+            </VBox>,
         );
 
         const expandedButton = await findByRole(container, Gtk.AccessibleRole.BUTTON, { name: "Expanded" });
@@ -104,37 +111,37 @@ describe("findByRole", () => {
         });
         expect(button).toBeDefined();
     });
+});
 
-    describe("error handling", () => {
-        it("throws when element not found with role suggestions", async () => {
-            const { container } = await render(<GtkLabel label="Test" />);
-            await expect(
-                findByRole(container, Gtk.AccessibleRole.BUTTON, { name: "NonexistentButton", timeout: 100 }),
-            ).rejects.toThrow(/Unable to find an element with role 'BUTTON'/);
-        });
+describe("findByRole error handling", () => {
+    it("throws when element not found with role suggestions", async () => {
+        const { container } = await render(<GtkLabel label="Test" />);
+        await expect(
+            findByRole(container, Gtk.AccessibleRole.BUTTON, { name: "NonexistentButton", timeout: 100 }),
+        ).rejects.toThrow(/Unable to find an element with role 'BUTTON'/);
+    });
 
-        it("throws when multiple elements found", async () => {
-            const { container } = await render(
-                <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                    <GtkButton label="Same" />
-                    <GtkButton label="Same" />
-                </GtkBox>,
-            );
-            await expect(findByText(container, "Same", { timeout: 100 })).rejects.toThrow(
-                /Found 2 elements with text 'Same'/,
-            );
-        });
+    it("throws when multiple elements found", async () => {
+        const { container } = await render(
+            <VBox>
+                <GtkButton label="Same" />
+                <GtkButton label="Same" />
+            </VBox>,
+        );
+        await expect(findByText(container, "Same", { timeout: 100 })).rejects.toThrow(
+            /Found 2 elements with text 'Same'/,
+        );
     });
 });
 
 describe("findAllByRole", () => {
     it("finds all elements with matching role", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkButton label="First" />
                 <GtkButton label="Second" />
                 <GtkLabel label="Text" />
-            </GtkBox>,
+            </VBox>,
         );
 
         const buttons = await findAllByRole(container, Gtk.AccessibleRole.BUTTON, { name: /First|Second/ });
@@ -191,11 +198,11 @@ describe("findByText", () => {
 describe("findAllByText", () => {
     it("finds all elements with matching text", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkButton label="Same" />
                 <GtkButton label="Same" />
                 <GtkButton label="Different" />
-            </GtkBox>,
+            </VBox>,
         );
 
         const buttons = await findAllByText(container, "Same");
@@ -211,10 +218,10 @@ describe("findByLabelText", () => {
                 entryRef.current = el;
             };
             return (
-                <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+                <VBox>
                     <GtkLabel label="Username" mnemonicWidget={entryRef.current} />
                     <GtkEntry ref={ref} />
-                </GtkBox>
+                </VBox>
             );
         };
 
@@ -234,11 +241,11 @@ describe("findByLabelText", () => {
 });
 
 describe("findAllByLabelText", () => {
-    it("finds all elements labelled by matching GtkLabels", async () => {
+    it("finds all elements labeled by matching GtkLabels", async () => {
         const ref1 = { current: null as Gtk.Entry | null };
         const ref2 = { current: null as Gtk.Entry | null };
         const Form = () => (
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkLabel label="Field" mnemonicWidget={ref1.current} />
                 <GtkEntry
                     ref={(el) => {
@@ -251,7 +258,7 @@ describe("findAllByLabelText", () => {
                         ref2.current = el;
                     }}
                 />
-            </GtkBox>
+            </VBox>
         );
 
         const { container, rerender } = await render(<Form />);
@@ -279,13 +286,72 @@ describe("findByName", () => {
 describe("findAllByName", () => {
     it("finds all elements with matching widget name", async () => {
         const { container } = await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+            <VBox>
                 <GtkEntry name="field" />
                 <GtkEntry name="field" />
-            </GtkBox>,
+            </VBox>,
         );
 
         const entries = await findAllByName(container, "field");
         expect(entries.length).toBe(2);
+    });
+
+    it("throws a name-formatted error when no widget matches", async () => {
+        const { container } = await render(<GtkEntry name="real-name" />);
+
+        await expect(findByName(container, "missing", { timeout: 100 })).rejects.toThrow(
+            /Unable to find an element with name 'missing'/,
+        );
+    });
+
+    it("throws a regex-formatted name error when no widget matches", async () => {
+        const { container } = await render(<GtkEntry name="real-name" />);
+
+        await expect(findByName(container, /^missing/, { timeout: 100 })).rejects.toThrow(
+            /Unable to find an element with name \/\^missing\//,
+        );
+    });
+
+    it("matches a GtkLabel widget by its widget name", async () => {
+        const { container } = await render(<GtkLabel name="title-label" label="Hi" />);
+        const label = await findByName(container, "title-label");
+        expect(label).toBeInstanceOf(Gtk.Label);
+    });
+});
+
+describe("findByRole(LABEL)", () => {
+    it("matches a GtkLabel by its accessible role", async () => {
+        const { container } = await render(<GtkLabel label="visible" />);
+        const label = await findByRole(container, Gtk.AccessibleRole.LABEL, { name: "visible" });
+        expect(label).toBeInstanceOf(Gtk.Label);
+    });
+});
+
+describe("findByText joins adjacent labels with a space", () => {
+    it("inserts a space between sibling labels of the same parent", async () => {
+        const { container } = await render(
+            <VBox>
+                <GtkLabel label="Searching for:" />
+                <GtkLabel label="rocket" />
+            </VBox>,
+        );
+        const match = await findByText(container, "Searching for: rocket");
+        expect(match).toBeInstanceOf(Gtk.Widget);
+    });
+});
+
+describe("findByRole accessible name", () => {
+    it("matches a widget by its accessibleLabel JSX prop", async () => {
+        const { container } = await render(
+            <GtkButton accessibleLabel="Close dialog" iconName="window-close-symbolic" />,
+        );
+        const button = await findByRole(container, Gtk.AccessibleRole.BUTTON, { name: "Close dialog" });
+        expect(button).toBeInstanceOf(Gtk.Button);
+    });
+
+    it("prefers accessibleLabel over visible label text", async () => {
+        const { container } = await render(<GtkButton accessibleLabel="Submit form" label="OK" />);
+        const button = await findByRole(container, Gtk.AccessibleRole.BUTTON, { name: "Submit form" });
+        expect(button).toBeInstanceOf(Gtk.Button);
     });
 });

--- a/packages/testing/tests/render-hook.test.tsx
+++ b/packages/testing/tests/render-hook.test.tsx
@@ -2,7 +2,7 @@ import { GtkApplicationWindow } from "@gtkx/react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { describe, expect, it } from "vitest";
-import { renderHook } from "../src/index.js";
+import { act, renderHook } from "../src/index.js";
 
 describe("renderHook", () => {
     it("renders a hook and returns its result", async () => {
@@ -11,245 +11,242 @@ describe("renderHook", () => {
     });
 
     it("updates result when hook state changes", async () => {
-        const { result, rerender } = await renderHook(() => useState(0));
+        const { result } = await renderHook(() => useState(0));
 
         expect(result.current[0]).toBe(0);
 
         const [, setState] = result.current;
-        setState(10);
-        await rerender();
+        await act(() => setState(10));
 
         expect(result.current[0]).toBe(10);
     });
+});
 
-    describe("initialProps", () => {
-        it("passes initialProps to the hook callback", async () => {
-            const { result } = await renderHook(({ value }: { value: number }) => value * 2, {
-                initialProps: { value: 5 },
-            });
-
-            expect(result.current).toBe(10);
+describe("renderHook initialProps", () => {
+    it("passes initialProps to the hook callback", async () => {
+        const { result } = await renderHook(({ value }: { value: number }) => value * 2, {
+            initialProps: { value: 5 },
         });
 
-        it("works without initialProps", async () => {
-            const { result } = await renderHook(() => "no props");
-            expect(result.current).toBe("no props");
-        });
+        expect(result.current).toBe(10);
     });
 
-    describe("rerender", () => {
-        it("re-renders the hook with the same props", async () => {
-            let renderCount = 0;
-            const { result, rerender } = await renderHook(() => {
-                renderCount++;
-                return renderCount;
-            });
+    it("works without initialProps", async () => {
+        const { result } = await renderHook(() => "no props");
+        expect(result.current).toBe("no props");
+    });
+});
 
-            expect(result.current).toBe(1);
-
-            await rerender();
-            expect(result.current).toBe(2);
+describe("renderHook rerender", () => {
+    it("re-renders the hook with the same props", async () => {
+        let renderCount = 0;
+        const { result, rerender } = await renderHook(() => {
+            renderCount++;
+            return renderCount;
         });
 
-        it("re-renders the hook with new props", async () => {
-            const { result, rerender } = await renderHook(({ multiplier }: { multiplier: number }) => 10 * multiplier, {
-                initialProps: { multiplier: 2 },
-            });
+        expect(result.current).toBe(1);
 
-            expect(result.current).toBe(20);
-
-            await rerender({ multiplier: 5 });
-            expect(result.current).toBe(50);
-        });
-
-        it("preserves hook state across rerenders", async () => {
-            const { result, rerender } = await renderHook(() => {
-                const [count, setCount] = useState(0);
-                return { count, increment: () => setCount((c) => c + 1) };
-            });
-
-            expect(result.current.count).toBe(0);
-
-            result.current.increment();
-            await rerender();
-
-            expect(result.current.count).toBe(1);
-        });
+        await rerender();
+        expect(result.current).toBe(2);
     });
 
-    describe("unmount", () => {
-        it("unmounts the component containing the hook", async () => {
-            let unmounted = false;
-            const { unmount } = await renderHook(() => {
-                useEffect(() => {
-                    return () => {
-                        unmounted = true;
-                    };
-                }, []);
-            });
-
-            expect(unmounted).toBe(false);
-            await unmount();
-            expect(unmounted).toBe(true);
+    it("re-renders the hook with new props", async () => {
+        const { result, rerender } = await renderHook(({ multiplier }: { multiplier: number }) => 10 * multiplier, {
+            initialProps: { multiplier: 2 },
         });
 
-        it("cleans up after unmount", async () => {
-            const cleanup: (() => void)[] = [];
-            const { unmount } = await renderHook(() => {
-                useEffect(() => {
-                    return () => {
-                        cleanup.push(() => {});
-                    };
-                }, []);
-            });
+        expect(result.current).toBe(20);
 
-            await unmount();
-            expect(cleanup.length).toBe(1);
-        });
+        await rerender({ multiplier: 5 });
+        expect(result.current).toBe(50);
     });
 
-    describe("wrapper option", () => {
-        it("does not wrap by default (wrapper: false)", async () => {
-            const { result } = await renderHook(() => useState("test"));
-            expect(result.current[0]).toBe("test");
+    it("preserves hook state across rerenders", async () => {
+        const { result } = await renderHook(() => {
+            const [count, setCount] = useState(0);
+            return { count, increment: () => setCount((c) => c + 1) };
         });
 
-        it("wraps in GtkApplicationWindow when wrapper is true", async () => {
-            const { result } = await renderHook(() => useState("wrapped"), { wrapper: true });
-            expect(result.current[0]).toBe("wrapped");
-        });
+        expect(result.current.count).toBe(0);
 
-        it("uses custom wrapper component", async () => {
-            let wrapperRendered = false;
+        await act(() => result.current.increment());
 
-            const CustomWrapper = ({ children }: { children: ReactNode }) => {
-                wrapperRendered = true;
-                return <GtkApplicationWindow>{children}</GtkApplicationWindow>;
-            };
-
-            await renderHook(() => useState(0), { wrapper: CustomWrapper });
-
-            expect(wrapperRendered).toBe(true);
-        });
+        expect(result.current.count).toBe(1);
     });
+});
 
-    describe("error handling", () => {
-        it("throws when hook throws on initial render", async () => {
-            const errorHook = () => {
-                throw new Error("Hook error");
-            };
-
-            await expect(renderHook(errorHook)).rejects.toThrow("Hook error");
-        });
-
-        it("throws when hook throws on rerender", async () => {
-            let shouldThrow = false;
-            const conditionalErrorHook = () => {
-                if (shouldThrow) {
-                    throw new Error("Rerender error");
-                }
-                return "ok";
-            };
-
-            const { result, rerender } = await renderHook(conditionalErrorHook);
-            expect(result.current).toBe("ok");
-
-            shouldThrow = true;
-            await expect(rerender()).rejects.toThrow("Rerender error");
-        });
-    });
-
-    describe("complex hooks", () => {
-        it("works with useState", async () => {
-            const { result, rerender } = await renderHook(() => useState({ count: 0 }));
-
-            expect(result.current[0]).toEqual({ count: 0 });
-
-            const [, setState] = result.current;
-            setState({ count: 5 });
-            await rerender();
-
-            expect(result.current[0]).toEqual({ count: 5 });
-        });
-
-        it("works with useCallback", async () => {
-            const { result, rerender } = await renderHook(
-                ({ value }: { value: number }) => useCallback(() => value, [value]),
-                {
-                    initialProps: { value: 1 },
-                },
-            );
-
-            const callback1 = result.current;
-            expect(callback1()).toBe(1);
-
-            await rerender({ value: 2 });
-            const callback2 = result.current;
-            expect(callback2()).toBe(2);
-            expect(callback1).not.toBe(callback2);
-        });
-
-        it("works with useRef", async () => {
-            const { result, rerender } = await renderHook(() => {
-                const ref = useRef(0);
-                ref.current++;
-                return ref;
-            });
-
-            expect(result.current.current).toBe(1);
-
-            await rerender();
-            expect(result.current.current).toBe(2);
-        });
-
-        it("works with useEffect", async () => {
-            const effects: string[] = [];
-
-            const { rerender, unmount } = await renderHook(
-                ({ value }: { value: string }) => {
-                    useEffect(() => {
-                        effects.push(`effect:${value}`);
-                        return () => {
-                            effects.push(`cleanup:${value}`);
-                        };
-                    }, [value]);
-                },
-                { initialProps: { value: "a" } },
-            );
-
-            expect(effects).toEqual(["effect:a"]);
-
-            await rerender({ value: "b" });
-            expect(effects).toEqual(["effect:a", "cleanup:a", "effect:b"]);
-
-            await unmount();
-            expect(effects).toEqual(["effect:a", "cleanup:a", "effect:b", "cleanup:b"]);
-        });
-
-        it("works with custom hooks", async () => {
-            const useCounter = (initial: number) => {
-                const [count, setCount] = useState(initial);
-                return {
-                    count,
-                    increment: () => setCount((c) => c + 1),
-                    decrement: () => setCount((c) => c - 1),
+describe("renderHook unmount", () => {
+    it("unmounts the component containing the hook", async () => {
+        let unmounted = false;
+        const { unmount } = await renderHook(() => {
+            useEffect(() => {
+                return () => {
+                    unmounted = true;
                 };
-            };
-
-            const { result, rerender } = await renderHook(({ initial }: { initial: number }) => useCounter(initial), {
-                initialProps: { initial: 10 },
-            });
-
-            expect(result.current.count).toBe(10);
-
-            result.current.increment();
-            await rerender();
-            expect(result.current.count).toBe(11);
-
-            result.current.decrement();
-            result.current.decrement();
-            await rerender();
-            expect(result.current.count).toBe(9);
+            }, []);
         });
+
+        expect(unmounted).toBe(false);
+        await unmount();
+        expect(unmounted).toBe(true);
+    });
+
+    it("cleans up after unmount", async () => {
+        const cleanup: (() => void)[] = [];
+        const { unmount } = await renderHook(() => {
+            useEffect(() => {
+                return () => {
+                    cleanup.push(() => {});
+                };
+            }, []);
+        });
+
+        await unmount();
+        expect(cleanup.length).toBe(1);
+    });
+});
+
+describe("renderHook wrapper option", () => {
+    it("does not wrap by default (wrapper: false)", async () => {
+        const { result } = await renderHook(() => useState("test"));
+        expect(result.current[0]).toBe("test");
+    });
+
+    it("wraps in GtkApplicationWindow when wrapper is true", async () => {
+        const { result } = await renderHook(() => useState("wrapped"), { wrapper: true });
+        expect(result.current[0]).toBe("wrapped");
+    });
+
+    it("uses custom wrapper component", async () => {
+        let wrapperRendered = false;
+
+        const CustomWrapper = ({ children }: { children: ReactNode }) => {
+            wrapperRendered = true;
+            return <GtkApplicationWindow>{children}</GtkApplicationWindow>;
+        };
+
+        await renderHook(() => useState(0), { wrapper: CustomWrapper });
+
+        expect(wrapperRendered).toBe(true);
+    });
+});
+
+describe("renderHook error handling", () => {
+    it("throws when hook throws on initial render", async () => {
+        const errorHook = () => {
+            throw new Error("Hook error");
+        };
+
+        await expect(renderHook(errorHook)).rejects.toThrow("Hook error");
+    });
+
+    it("throws when hook throws on rerender", async () => {
+        let shouldThrow = false;
+        const conditionalErrorHook = () => {
+            if (shouldThrow) {
+                throw new Error("Rerender error");
+            }
+            return "ok";
+        };
+
+        const { result, rerender } = await renderHook(conditionalErrorHook);
+        expect(result.current).toBe("ok");
+
+        shouldThrow = true;
+        await expect(rerender()).rejects.toThrow("Rerender error");
+    });
+});
+
+describe("renderHook complex hooks state", () => {
+    it("works with useState", async () => {
+        const { result } = await renderHook(() => useState({ count: 0 }));
+
+        expect(result.current[0]).toEqual({ count: 0 });
+
+        const [, setState] = result.current;
+        await act(() => setState({ count: 5 }));
+
+        expect(result.current[0]).toEqual({ count: 5 });
+    });
+
+    it("works with useCallback", async () => {
+        const { result, rerender } = await renderHook(
+            ({ value }: { value: number }) => useCallback(() => value, [value]),
+            {
+                initialProps: { value: 1 },
+            },
+        );
+
+        const callback1 = result.current;
+        expect(callback1()).toBe(1);
+
+        await rerender({ value: 2 });
+        const callback2 = result.current;
+        expect(callback2()).toBe(2);
+        expect(callback1).not.toBe(callback2);
+    });
+
+    it("works with useRef", async () => {
+        const { result, rerender } = await renderHook(() => {
+            const ref = useRef(0);
+            ref.current++;
+            return ref;
+        });
+
+        expect(result.current.current).toBe(1);
+
+        await rerender();
+        expect(result.current.current).toBe(2);
+    });
+});
+
+describe("renderHook complex hooks effects", () => {
+    it("works with useEffect", async () => {
+        const effects: string[] = [];
+
+        const { rerender, unmount } = await renderHook(
+            ({ value }: { value: string }) => {
+                useEffect(() => {
+                    effects.push(`effect:${value}`);
+                    return () => {
+                        effects.push(`cleanup:${value}`);
+                    };
+                }, [value]);
+            },
+            { initialProps: { value: "a" } },
+        );
+
+        expect(effects).toEqual(["effect:a"]);
+
+        await rerender({ value: "b" });
+        expect(effects).toEqual(["effect:a", "cleanup:a", "effect:b"]);
+
+        await unmount();
+        expect(effects).toEqual(["effect:a", "cleanup:a", "effect:b", "cleanup:b"]);
+    });
+
+    it("works with custom hooks", async () => {
+        const useCounter = (initial: number) => {
+            const [count, setCount] = useState(initial);
+            return {
+                count,
+                increment: () => setCount((c) => c + 1),
+                decrement: () => setCount((c) => c - 1),
+            };
+        };
+
+        const { result } = await renderHook(({ initial }: { initial: number }) => useCounter(initial), {
+            initialProps: { initial: 10 },
+        });
+
+        expect(result.current.count).toBe(10);
+
+        await act(() => result.current.increment());
+        expect(result.current.count).toBe(11);
+
+        await act(() => result.current.decrement());
+        await act(() => result.current.decrement());
+        expect(result.current.count).toBe(9);
     });
 });

--- a/packages/testing/tests/render.test.tsx
+++ b/packages/testing/tests/render.test.tsx
@@ -1,10 +1,9 @@
 import * as Gtk from "@gtkx/ffi/gtk";
 import { GtkApplicationWindow, GtkBox, GtkButton } from "@gtkx/react";
-import type { Ref } from "react";
 import { describe, expect, it } from "vitest";
 import { cleanup, render, type WrapperComponent } from "../src/index.js";
 
-describe("render", () => {
+describe("render basics", () => {
     it("renders a simple element", async () => {
         const { findByRole } = await render(<GtkButton label="Click me" />);
         const button = await findByRole(Gtk.AccessibleRole.BUTTON, { name: "Click me" });
@@ -37,7 +36,9 @@ describe("render", () => {
         expect(baseElement).toBeDefined();
         expect((baseElement as Gtk.Application).getApplicationId()).toMatch(/org\.gtkx\.testing/);
     });
+});
 
+describe("render wrapper", () => {
     it("wraps element in ApplicationWindow by default", async () => {
         const { findByRole } = await render(<GtkButton label="Test" />);
         const window = await findByRole(Gtk.AccessibleRole.WINDOW);
@@ -57,10 +58,8 @@ describe("render", () => {
     });
 
     it("uses custom wrapper component", async () => {
-        const CustomWrapper: WrapperComponent = ({ children, ref }) => (
-            <GtkApplicationWindow ref={ref as Ref<Gtk.ApplicationWindow>} title="Custom Title">
-                {children}
-            </GtkApplicationWindow>
+        const CustomWrapper: WrapperComponent = ({ children }) => (
+            <GtkApplicationWindow title="Custom Title">{children}</GtkApplicationWindow>
         );
 
         const { findByRole, container } = await render(<GtkButton label="Test" />, { wrapper: CustomWrapper });
@@ -68,7 +67,9 @@ describe("render", () => {
         expect(window).toBeDefined();
         expect(container).toBeInstanceOf(Gtk.ApplicationWindow);
     });
+});
 
+describe("render lifecycle", () => {
     it("provides rerender function to update content", async () => {
         const { findByText, rerender } = await render("Initial");
 

--- a/packages/testing/tests/screen.test.tsx
+++ b/packages/testing/tests/screen.test.tsx
@@ -1,119 +1,118 @@
 import * as Gtk from "@gtkx/ffi/gtk";
-import { GtkBox, GtkButton, GtkEntry, GtkLabel } from "@gtkx/react";
-import type { ReactNode } from "react";
+import { GtkApplicationWindow, GtkBox, GtkButton, GtkLabel } from "@gtkx/react";
 import { describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "../src/index.js";
 
-describe("screen", () => {
-    it("finds element by role", async () => {
-        await render(<GtkButton label="Test" />);
-        const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Test" });
-        expect(button).toBeDefined();
-    });
-
-    it("finds element by text", async () => {
-        await render("Hello World");
-        const label = await screen.findByText("Hello World");
-        expect(label).toBeDefined();
-    });
-
-    it("finds element by label text", async () => {
-        const entryRef = { current: null as Gtk.Entry | null };
-        const LabelledEntry = (): ReactNode => (
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                <GtkLabel label="Click Me" mnemonicWidget={entryRef.current} />
-                <GtkEntry
-                    ref={(el) => {
-                        entryRef.current = el;
-                    }}
-                />
-            </GtkBox>
-        );
-
-        const { rerender } = await render(<LabelledEntry />);
-        await rerender(<LabelledEntry />);
-
-        const entry = await screen.findByLabelText("Click Me");
-        expect(entry).toBeDefined();
-        expect(entry.getAccessibleRole()).toBe(Gtk.AccessibleRole.TEXT_BOX);
-    });
-
-    it("finds element by widget name", async () => {
-        await render(<GtkEntry name="my-input" />);
-        const entry = await screen.findByName("my-input");
-        expect(entry).toBeDefined();
-    });
-
-    it("finds all elements by role", async () => {
+describe("screen binding", () => {
+    it("routes queries through the global application container", async () => {
         await render(
             <GtkBox orientation={Gtk.Orientation.VERTICAL}>
                 <GtkButton label="First" />
                 <GtkButton label="Second" />
-                <GtkButton label="Third" />
             </GtkBox>,
         );
 
-        const buttons = await screen.findAllByRole(Gtk.AccessibleRole.BUTTON, { name: /First|Second|Third/ });
-        expect(buttons.length).toBe(3);
+        const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "First" });
+        const all = await screen.findAllByRole(Gtk.AccessibleRole.BUTTON, { name: /First|Second/ });
+
+        expect(button).toBeDefined();
+        expect(all.length).toBe(2);
     });
 
-    it("finds all elements by text", async () => {
-        await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                <GtkButton label="Item" />
-                <GtkButton label="Item" />
-            </GtkBox>,
+    it("throws when no render has been performed", async () => {
+        await cleanup();
+        expect(() => screen.findByRole(Gtk.AccessibleRole.BUTTON, { timeout: 100 })).toThrow(
+            "No render has been performed",
         );
+    });
+});
 
-        const buttons = await screen.findAllByText("Item");
-        expect(buttons.length).toBe(2);
+describe("screen screenshot capture", () => {
+    it("captures the first window when no selector is provided", async () => {
+        await render(<GtkLabel label="Snapshot" />);
+
+        const result = await screen.screenshot();
+
+        expect(result.mimeType).toBe("image/png");
+        expect(result.data.length).toBeGreaterThan(0);
+        expect(result.width).toBeGreaterThan(0);
+        expect(result.height).toBeGreaterThan(0);
     });
 
-    it("finds all elements by label text", async () => {
-        const ref1 = { current: null as Gtk.Entry | null };
-        const ref2 = { current: null as Gtk.Entry | null };
-        const LabelledEntries = (): ReactNode => (
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                <GtkLabel label="Action" mnemonicWidget={ref1.current} />
-                <GtkEntry
-                    ref={(el) => {
-                        ref1.current = el;
-                    }}
-                />
-                <GtkLabel label="Action" mnemonicWidget={ref2.current} />
-                <GtkEntry
-                    ref={(el) => {
-                        ref2.current = el;
-                    }}
-                />
-            </GtkBox>
-        );
+    it("captures the window at the requested index", async () => {
+        await render(<GtkLabel label="Indexed" />);
 
-        const { rerender } = await render(<LabelledEntries />);
-        await rerender(<LabelledEntries />);
+        const result = await screen.screenshot(0);
 
-        const entries = await screen.findAllByLabelText("Action");
-        expect(entries.length).toBe(2);
+        expect(result.mimeType).toBe("image/png");
+        expect(result.data.length).toBeGreaterThan(0);
     });
 
-    it("finds all elements by widget name", async () => {
-        await render(
-            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                <GtkEntry name="field" />
-                <GtkEntry name="field" />
-            </GtkBox>,
-        );
+    it("throws when the index is out of range", async () => {
+        await render(<GtkLabel label="Bounds" />);
 
-        const entries = await screen.findAllByName("field");
-        expect(entries.length).toBe(2);
+        await expect(screen.screenshot(99)).rejects.toThrow(/Window at index 99 not found/);
     });
+});
 
-    describe("error handling", () => {
-        it("throws when no render has been performed", async () => {
-            await cleanup();
-            expect(() => screen.findByRole(Gtk.AccessibleRole.BUTTON, { timeout: 100 })).toThrow(
-                "No render has been performed",
-            );
+describe("screen screenshot selectors", () => {
+    it("captures a window matching a title substring", async () => {
+        await render(<GtkLabel label="Titled" />, {
+            wrapper: ({ children }) => (
+                <GtkApplicationWindow title="Settings Window" defaultWidth={120} defaultHeight={80}>
+                    {children}
+                </GtkApplicationWindow>
+            ),
         });
+
+        const result = await screen.screenshot("Settings");
+
+        expect(result.mimeType).toBe("image/png");
+    });
+
+    it("captures a window matching a title regex", async () => {
+        await render(<GtkLabel label="Pattern" />, {
+            wrapper: ({ children }) => (
+                <GtkApplicationWindow title="Demo Pattern App" defaultWidth={120} defaultHeight={80}>
+                    {children}
+                </GtkApplicationWindow>
+            ),
+        });
+
+        const result = await screen.screenshot(/^Demo/);
+
+        expect(result.mimeType).toBe("image/png");
+    });
+});
+
+describe("screen screenshot errors", () => {
+    it("throws when no window matches a string selector", async () => {
+        await render(<GtkLabel label="Unmatched" />, {
+            wrapper: ({ children }) => (
+                <GtkApplicationWindow title="Real Title" defaultWidth={120} defaultHeight={80}>
+                    {children}
+                </GtkApplicationWindow>
+            ),
+        });
+
+        await expect(screen.screenshot("Nonexistent")).rejects.toThrow(/No window found with title matching/);
+    });
+
+    it("throws when no window matches a regex selector", async () => {
+        await render(<GtkLabel label="Unmatched" />, {
+            wrapper: ({ children }) => (
+                <GtkApplicationWindow title="Real Title" defaultWidth={120} defaultHeight={80}>
+                    {children}
+                </GtkApplicationWindow>
+            ),
+        });
+
+        await expect(screen.screenshot(/^Bogus/)).rejects.toThrow(/No window found with title matching/);
+    });
+
+    it("throws when no windows are available", async () => {
+        await cleanup();
+
+        await expect(screen.screenshot()).rejects.toThrow(/No windows available for screenshot/);
     });
 });

--- a/packages/testing/tests/setup.ts
+++ b/packages/testing/tests/setup.ts
@@ -1,6 +1,12 @@
 import { afterEach } from "vitest";
-import { cleanup } from "../src/index.js";
 
+/**
+ * `@gtkx/testing` transitively imports `@gtkx/ffi`, whose module evaluation
+ * runs `gtk_init()`. Importing it inside the hook — which runs after the
+ * `@gtkx/vitest` worker setup has brought up Xvfb — keeps a display-less
+ * `gtk_init()` from aborting the worker while setup files load.
+ */
 afterEach(async () => {
+    const { cleanup } = await import("../src/index.js");
     await cleanup();
 });

--- a/packages/testing/tests/timing.test.ts
+++ b/packages/testing/tests/timing.test.ts
@@ -1,40 +1,106 @@
 import { describe, expect, it } from "vitest";
-import { tick } from "../src/index.js";
+import { act } from "../src/index.js";
+import { getIsReactActEnvironment, setIsReactActEnvironment } from "../src/timing.js";
 
-describe("tick", () => {
-    it("returns a promise", () => {
-        const result = tick();
-        expect(result).toBeInstanceOf(Promise);
+describe("act / sync callback", () => {
+    it("returns a thenable", async () => {
+        const result = act(() => {});
+        expect(typeof (result as { then?: unknown }).then).toBe("function");
+        await result;
     });
 
-    it("resolves on the next event loop tick", async () => {
-        let resolved = false;
-        const promise = tick().then(() => {
-            resolved = true;
+    it("runs the callback synchronously", () => {
+        let ran = false;
+        act(() => {
+            ran = true;
         });
-
-        expect(resolved).toBe(false);
-        await promise;
-        expect(resolved).toBe(true);
+        expect(ran).toBe(true);
     });
 
-    it("can be used to yield control", async () => {
+    it("resolves with the callback result", async () => {
+        const value = await act(() => 42);
+        expect(value).toBe(42);
+    });
+
+    it("drains queued microtasks before resolving", async () => {
         const order: number[] = [];
-
-        const first = async () => {
+        await act(() => {
+            queueMicrotask(() => order.push(2));
             order.push(1);
-            await tick();
-            order.push(3);
-        };
-
-        const second = async () => {
-            order.push(2);
-        };
-
-        const p1 = first();
-        await second();
-        await p1;
-
+        });
+        order.push(3);
         expect(order).toEqual([1, 2, 3]);
+    });
+});
+
+describe("act / async callback", () => {
+    it("awaits async callbacks before resolving", async () => {
+        const order: number[] = [];
+        await act(async () => {
+            order.push(1);
+            await Promise.resolve();
+            order.push(2);
+        });
+        order.push(3);
+        expect(order).toEqual([1, 2, 3]);
+    });
+
+    it("propagates the resolved value", async () => {
+        const value = await act(async () => "ready");
+        expect(value).toBe("ready");
+    });
+});
+
+describe("act / IS_REACT_ACT_ENVIRONMENT", () => {
+    it("sets the flag inside a sync callback and restores it synchronously", () => {
+        const before = getIsReactActEnvironment();
+        setIsReactActEnvironment(false);
+        let insideEnv: boolean | undefined;
+        act(() => {
+            insideEnv = getIsReactActEnvironment();
+        });
+        expect(insideEnv).toBe(true);
+        expect(getIsReactActEnvironment()).toBe(false);
+        setIsReactActEnvironment(before);
+    });
+
+    it("keeps the flag set across an async callback and restores it on settle", async () => {
+        const before = getIsReactActEnvironment();
+        setIsReactActEnvironment(false);
+        let envBeforeAwait: boolean | undefined;
+        let envAfterAwait: boolean | undefined;
+        await act(async () => {
+            envBeforeAwait = getIsReactActEnvironment();
+            await Promise.resolve();
+            envAfterAwait = getIsReactActEnvironment();
+        });
+        expect(envBeforeAwait).toBe(true);
+        expect(envAfterAwait).toBe(true);
+        expect(getIsReactActEnvironment()).toBe(false);
+        setIsReactActEnvironment(before);
+    });
+
+    it("restores the flag after a sync throw", () => {
+        const before = getIsReactActEnvironment();
+        setIsReactActEnvironment(false);
+        expect(() =>
+            act(() => {
+                throw new Error("boom");
+            }),
+        ).toThrow("boom");
+        expect(getIsReactActEnvironment()).toBe(false);
+        setIsReactActEnvironment(before);
+    });
+
+    it("restores the flag after an async rejection", async () => {
+        const before = getIsReactActEnvironment();
+        setIsReactActEnvironment(false);
+        await expect(
+            act(async () => {
+                throw new Error("boom");
+            }),
+        ).rejects.toThrow("boom");
+        expect(getIsReactActEnvironment()).toBe(false);
+        setIsReactActEnvironment(before);
     });
 });

--- a/packages/testing/tests/user-event.test.tsx
+++ b/packages/testing/tests/user-event.test.tsx
@@ -14,6 +14,8 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent, waitFor } from "../src/index.js";
 import { isEditable } from "../src/widget.js";
 
+const widgetHasFocus = (w: Gtk.Widget): boolean => (w as unknown as { hasFocus: boolean }).hasFocus;
+
 describe("userEvent.click", () => {
     it("emits clicked signal on button", async () => {
         const handleClick = vi.fn();
@@ -156,6 +158,9 @@ describe("userEvent.tab", () => {
         const first = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "First" });
         first.grabFocus();
         await userEvent.tab(first);
+
+        const second = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Second" });
+        expect(widgetHasFocus(second)).toBe(true);
     });
 
     it("moves focus backward with shift option", async () => {
@@ -169,6 +174,9 @@ describe("userEvent.tab", () => {
         const second = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Second" });
         second.grabFocus();
         await userEvent.tab(second, { shift: true });
+
+        const first = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "First" });
+        expect(widgetHasFocus(first)).toBe(true);
     });
 });
 
@@ -186,6 +194,7 @@ describe("userEvent.selectOptions", () => {
 
         const dropdown = await screen.findByRole(Gtk.AccessibleRole.COMBO_BOX);
         await userEvent.selectOptions(dropdown, 1);
+        expect((dropdown as Gtk.DropDown).getSelected()).toBe(1);
     });
 
     it("selects row in list box by index", async () => {
@@ -198,6 +207,7 @@ describe("userEvent.selectOptions", () => {
 
         const listBox = await screen.findByRole(Gtk.AccessibleRole.LIST);
         await userEvent.selectOptions(listBox, 0);
+        expect((listBox as Gtk.ListBox).getSelectedRow()).not.toBeNull();
     });
 
     describe("error handling", () => {
@@ -240,6 +250,7 @@ describe("userEvent.deselectOptions", () => {
         const listBox = await screen.findByRole(Gtk.AccessibleRole.LIST);
         await userEvent.selectOptions(listBox, [0, 1]);
         await userEvent.deselectOptions(listBox, 0);
+        expect((listBox as Gtk.ListBox).getSelectedRows()).toHaveLength(1);
     });
 
     describe("error handling", () => {

--- a/packages/testing/tests/wait-for.test.ts
+++ b/packages/testing/tests/wait-for.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { waitFor, waitForElementToBeRemoved } from "../src/wait-for.js";
 
-describe("waitFor", () => {
+describe("waitFor success", () => {
     it("resolves immediately when callback succeeds", async () => {
         const result = await waitFor(() => "success");
         expect(result).toBe("success");
@@ -23,6 +23,19 @@ describe("waitFor", () => {
         expect(attempts).toBe(3);
     });
 
+    it("handles async callbacks", async () => {
+        let attempts = 0;
+        const result = await waitFor(async () => {
+            attempts++;
+            await new Promise((r) => setTimeout(r, 5));
+            if (attempts < 2) throw new Error("Not ready");
+            return "async success";
+        });
+        expect(result).toBe("async success");
+    });
+});
+
+describe("waitFor timeout", () => {
     it("throws timeout error when callback never succeeds", async () => {
         await expect(
             waitFor(
@@ -81,24 +94,13 @@ describe("waitFor", () => {
         expect(onTimeout).toHaveBeenCalledTimes(1);
         expect(onTimeout).toHaveBeenCalledWith(expect.any(Error));
     });
-
-    it("handles async callbacks", async () => {
-        let attempts = 0;
-        const result = await waitFor(async () => {
-            attempts++;
-            await new Promise((r) => setTimeout(r, 5));
-            if (attempts < 2) throw new Error("Not ready");
-            return "async success";
-        });
-        expect(result).toBe("async success");
-    });
 });
 
-describe("waitForElementToBeRemoved", () => {
-    const createMockWidget = (hasParent: boolean) => ({
-        getParent: () => (hasParent ? {} : null),
-    });
+const createMockWidget = (hasParent: boolean) => ({
+    getParent: () => (hasParent ? {} : null),
+});
 
+describe("waitForElementToBeRemoved preconditions", () => {
     it("throws if element is already removed", async () => {
         const element = createMockWidget(false);
 
@@ -112,7 +114,9 @@ describe("waitForElementToBeRemoved", () => {
             "Element already removed: waitForElementToBeRemoved requires the element to be present initially",
         );
     });
+});
 
+describe("waitForElementToBeRemoved success", () => {
     it("resolves when element is removed", async () => {
         let hasParent = true;
         const element = {
@@ -123,7 +127,9 @@ describe("waitForElementToBeRemoved", () => {
             hasParent = false;
         }, 50);
 
-        await waitForElementToBeRemoved(element as never, { timeout: 500, interval: 10 });
+        await expect(
+            waitForElementToBeRemoved(element as never, { timeout: 500, interval: 10 }),
+        ).resolves.toBeUndefined();
     });
 
     it("resolves when callback returns null", async () => {
@@ -133,9 +139,31 @@ describe("waitForElementToBeRemoved", () => {
             element = null;
         }, 50);
 
-        await waitForElementToBeRemoved(() => element as never, { timeout: 500, interval: 10 });
+        await expect(
+            waitForElementToBeRemoved(() => element as never, { timeout: 500, interval: 10 }),
+        ).resolves.toBeUndefined();
     });
 
+    it("handles getParent throwing error as removed", async () => {
+        let shouldThrow = false;
+        const element = {
+            getParent: () => {
+                if (shouldThrow) throw new Error("Widget destroyed");
+                return {};
+            },
+        };
+
+        setTimeout(() => {
+            shouldThrow = true;
+        }, 50);
+
+        await expect(
+            waitForElementToBeRemoved(element as never, { timeout: 500, interval: 10 }),
+        ).resolves.toBeUndefined();
+    });
+});
+
+describe("waitForElementToBeRemoved timeout", () => {
     it("times out if element is never removed", async () => {
         const element = createMockWidget(true);
 
@@ -154,21 +182,5 @@ describe("waitForElementToBeRemoved", () => {
         ).rejects.toThrow("Custom removal timeout");
 
         expect(onTimeout).toHaveBeenCalledTimes(1);
-    });
-
-    it("handles getParent throwing error as removed", async () => {
-        let shouldThrow = false;
-        const element = {
-            getParent: () => {
-                if (shouldThrow) throw new Error("Widget destroyed");
-                return {};
-            },
-        };
-
-        setTimeout(() => {
-            shouldThrow = true;
-        }, 50);
-
-        await waitForElementToBeRemoved(element as never, { timeout: 500, interval: 10 });
     });
 });

--- a/packages/testing/tests/wait-for.test.tsx
+++ b/packages/testing/tests/wait-for.test.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { describe, expect, it } from "vitest";
 import { render, screen, userEvent, waitFor, waitForElementToBeRemoved } from "../src/index.js";
 
-describe("waitFor", () => {
+describe("waitFor resolves", () => {
     it("resolves when callback succeeds", async () => {
         let value = 0;
         setTimeout(() => {
@@ -30,7 +30,9 @@ describe("waitFor", () => {
 
         expect(attempts).toBeGreaterThanOrEqual(3);
     });
+});
 
+describe("waitFor timing", () => {
     it("respects custom timeout", async () => {
         const start = Date.now();
 
@@ -80,22 +82,22 @@ describe("waitFor", () => {
             ),
         ).rejects.toThrow("Custom timeout message");
     });
+});
 
-    describe("error handling", () => {
-        it("includes last error message in timeout error", async () => {
-            await expect(
-                waitFor(
-                    () => {
-                        throw new Error("Specific failure reason");
-                    },
-                    { timeout: 100 },
-                ),
-            ).rejects.toThrow("Specific failure reason");
-        });
+describe("waitFor error handling", () => {
+    it("includes last error message in timeout error", async () => {
+        await expect(
+            waitFor(
+                () => {
+                    throw new Error("Specific failure reason");
+                },
+                { timeout: 100 },
+            ),
+        ).rejects.toThrow("Specific failure reason");
     });
 });
 
-describe("waitForElementToBeRemoved", () => {
+describe("waitForElementToBeRemoved widget", () => {
     it("resolves when element is removed from tree", async () => {
         const DynamicComponent = () => {
             const [showLabel, setShowLabel] = useState(true);
@@ -115,7 +117,7 @@ describe("waitForElementToBeRemoved", () => {
         const removalPromise = waitForElementToBeRemoved(tempButton);
         await userEvent.click(removeButton);
 
-        await removalPromise;
+        await expect(removalPromise).resolves.toBeUndefined();
     });
 
     it("accepts callback that returns element", async () => {
@@ -145,9 +147,11 @@ describe("waitForElementToBeRemoved", () => {
         });
 
         await userEvent.click(removeButton);
-        await removalPromise;
+        await expect(removalPromise).resolves.toBeUndefined();
     });
+});
 
+describe("waitForElementToBeRemoved timeout", () => {
     it("respects custom timeout", async () => {
         await render(<GtkButton label="Permanent" />);
 
@@ -155,18 +159,18 @@ describe("waitForElementToBeRemoved", () => {
 
         await expect(waitForElementToBeRemoved(widget, { timeout: 100 })).rejects.toThrow("Timed out");
     });
+});
 
-    describe("error handling", () => {
-        it("throws immediately if element is already removed", async () => {
-            await render("Test");
+describe("waitForElementToBeRemoved error handling", () => {
+    it("throws immediately if element is already removed", async () => {
+        await render("Test");
 
-            await expect(waitForElementToBeRemoved(null as never)).rejects.toThrow("already removed");
-        });
+        await expect(waitForElementToBeRemoved(null as never)).rejects.toThrow("already removed");
+    });
 
-        it("throws if callback returns null initially", async () => {
-            await render("Test");
+    it("throws if callback returns null initially", async () => {
+        await render("Test");
 
-            await expect(waitForElementToBeRemoved(() => null)).rejects.toThrow("already removed");
-        });
+        await expect(waitForElementToBeRemoved(() => null)).rejects.toThrow("already removed");
     });
 });

--- a/packages/testing/tests/within.test.tsx
+++ b/packages/testing/tests/within.test.tsx
@@ -1,10 +1,10 @@
 import * as Gtk from "@gtkx/ffi/gtk";
-import { GtkBox, GtkButton, GtkEntry, GtkFrame, GtkLabel } from "@gtkx/react";
+import { GtkBox, GtkButton, GtkFrame } from "@gtkx/react";
 import { describe, expect, it } from "vitest";
 import { render, screen, within } from "../src/index.js";
 
-describe("within", () => {
-    it("scopes queries to container element", async () => {
+describe("within scoping", () => {
+    it("scopes queries to the given container", async () => {
         await render(
             <GtkBox orientation={Gtk.Orientation.VERTICAL}>
                 <GtkFrame name="section-a" label="Section A">
@@ -17,13 +17,13 @@ describe("within", () => {
         );
 
         const sectionA = await screen.findByName("section-a");
-        const { findByRole } = within(sectionA);
+        const submit = await within(sectionA).findByRole(Gtk.AccessibleRole.BUTTON);
 
-        const submitButton = await findByRole(Gtk.AccessibleRole.BUTTON);
-        expect(submitButton).toBeDefined();
+        expect(submit).toBeDefined();
+        expect((submit as Gtk.Button).getLabel()).toBe("Submit");
     });
 
-    it("does not find elements outside container", async () => {
+    it("does not find elements outside the container", async () => {
         await render(
             <GtkBox orientation={Gtk.Orientation.VERTICAL}>
                 <GtkFrame name="inner-frame" label="Inner">
@@ -34,87 +34,11 @@ describe("within", () => {
         );
 
         const frame = await screen.findByName("inner-frame");
-        const { findByText } = within(frame);
 
-        await expect(findByText("Outside", { timeout: 100 })).rejects.toThrow("Unable to find");
+        await expect(within(frame).findByText("Outside", { timeout: 100 })).rejects.toThrow("Unable to find");
     });
 
-    it("provides findByRole query", async () => {
-        await render(
-            <GtkFrame name="container">
-                <GtkButton label="Test" />
-            </GtkFrame>,
-        );
-
-        const frame = await screen.findByName("container");
-        const { findByRole } = within(frame);
-        const button = await findByRole(Gtk.AccessibleRole.BUTTON);
-        expect(button).toBeDefined();
-    });
-
-    it("provides findByText query", async () => {
-        await render(<GtkFrame name="container">Hello World</GtkFrame>);
-
-        const frame = await screen.findByName("container");
-        const { findByText } = within(frame);
-        const label = await findByText("Hello World");
-        expect(label).toBeDefined();
-    });
-
-    it("provides findByLabelText query", async () => {
-        const entryRef = { current: null as Gtk.Entry | null };
-        const LabelledEntry = () => (
-            <GtkFrame name="container">
-                <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                    <GtkLabel label="Action" mnemonicWidget={entryRef.current} />
-                    <GtkEntry
-                        ref={(el) => {
-                            entryRef.current = el;
-                        }}
-                    />
-                </GtkBox>
-            </GtkFrame>
-        );
-
-        const { rerender } = await render(<LabelledEntry />);
-        await rerender(<LabelledEntry />);
-
-        const frame = await screen.findByName("container");
-        const { findByLabelText } = within(frame);
-        const entry = await findByLabelText("Action");
-        expect(entry).toBeDefined();
-    });
-
-    it("provides findByName query", async () => {
-        await render(
-            <GtkFrame name="container">
-                <GtkEntry name="my-input" />
-            </GtkFrame>,
-        );
-
-        const frame = await screen.findByName("container");
-        const { findByName } = within(frame);
-        const entry = await findByName("my-input");
-        expect(entry).toBeDefined();
-    });
-
-    it("provides findAllByRole query", async () => {
-        await render(
-            <GtkFrame name="container">
-                <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                    <GtkButton label="First" />
-                    <GtkButton label="Second" />
-                </GtkBox>
-            </GtkFrame>,
-        );
-
-        const frame = await screen.findByName("container");
-        const { findAllByRole } = within(frame);
-        const buttons = await findAllByRole(Gtk.AccessibleRole.BUTTON);
-        expect(buttons.length).toBe(2);
-    });
-
-    it("provides findAllByText query", async () => {
+    it("returns the full bound-queries surface", async () => {
         await render(
             <GtkFrame name="container">
                 <GtkBox orientation={Gtk.Orientation.VERTICAL}>
@@ -125,58 +49,16 @@ describe("within", () => {
         );
 
         const frame = await screen.findByName("container");
-        const { findAllByText } = within(frame);
-        const buttons = await findAllByText("Item");
-        expect(buttons.length).toBe(2);
+        const bound = within(frame);
+        const items = await bound.findAllByText("Item");
+
+        expect(items.length).toBe(2);
+        expect(typeof bound.queryByRole).toBe("function");
+        expect(typeof bound.queryAllByName).toBe("function");
     });
+});
 
-    it("provides findAllByLabelText query", async () => {
-        const ref1 = { current: null as Gtk.Entry | null };
-        const ref2 = { current: null as Gtk.Entry | null };
-        const LabelledEntries = () => (
-            <GtkFrame name="container">
-                <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                    <GtkLabel label="Action" mnemonicWidget={ref1.current} />
-                    <GtkEntry
-                        ref={(el) => {
-                            ref1.current = el;
-                        }}
-                    />
-                    <GtkLabel label="Action" mnemonicWidget={ref2.current} />
-                    <GtkEntry
-                        ref={(el) => {
-                            ref2.current = el;
-                        }}
-                    />
-                </GtkBox>
-            </GtkFrame>
-        );
-
-        const { rerender } = await render(<LabelledEntries />);
-        await rerender(<LabelledEntries />);
-
-        const frame = await screen.findByName("container");
-        const { findAllByLabelText } = within(frame);
-        const entries = await findAllByLabelText("Action");
-        expect(entries.length).toBe(2);
-    });
-
-    it("provides findAllByName query", async () => {
-        await render(
-            <GtkFrame name="container">
-                <GtkBox orientation={Gtk.Orientation.VERTICAL}>
-                    <GtkEntry name="field" />
-                    <GtkEntry name="field" />
-                </GtkBox>
-            </GtkFrame>,
-        );
-
-        const frame = await screen.findByName("container");
-        const { findAllByName } = within(frame);
-        const entries = await findAllByName("field");
-        expect(entries.length).toBe(2);
-    });
-
+describe("within nested", () => {
     it("supports nested within calls", async () => {
         await render(
             <GtkFrame name="outer-frame">
@@ -187,10 +69,9 @@ describe("within", () => {
         );
 
         const outer = await screen.findByName("outer-frame");
-        const { findByName: findInOuter } = within(outer);
-        const inner = await findInOuter("inner-frame");
-        const { findByRole } = within(inner);
-        const button = await findByRole(Gtk.AccessibleRole.BUTTON);
+        const inner = await within(outer).findByName("inner-frame");
+        const button = await within(inner).findByRole(Gtk.AccessibleRole.BUTTON);
+
         expect(button).toBeDefined();
     });
 });

--- a/packages/testing/tsconfig.lib.json
+++ b/packages/testing/tsconfig.lib.json
@@ -1,9 +1,3 @@
 {
-    "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": "src",
-        "emitDeclarationOnly": false
-    },
-    "extends": "../../tsconfig.base.json",
-    "include": ["src/**/*"]
+    "extends": "../../tsconfig.lib.json"
 }

--- a/packages/testing/tsconfig.test.json
+++ b/packages/testing/tsconfig.test.json
@@ -1,10 +1,5 @@
 {
-    "compilerOptions": {
-        "outDir": "out-tsc/test",
-        "rootDir": "."
-    },
-    "extends": "../../tsconfig.base.json",
-    "include": ["tests/**/*.ts", "tests/**/*.tsx"],
+    "extends": "../../tsconfig.test.json",
     "references": [
         {
             "path": "./tsconfig.lib.json"

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -1,13 +1,11 @@
 import gtkx from "@gtkx/vitest";
-import { defineConfig, mergeConfig } from "vitest/config";
-import baseConfig from "../../vitest.config.js";
+import { defineConfig } from "vitest/config";
 
-export default mergeConfig(
-    baseConfig,
-    defineConfig({
-        plugins: [gtkx()],
-        test: {
-            setupFiles: ["./tests/setup.ts"],
-        },
-    }),
-);
+export default defineConfig({
+    plugins: [gtkx()],
+    test: {
+        name: "testing",
+        include: ["tests/**/*.test.{ts,tsx}"],
+        setupFiles: ["./tests/setup.ts"],
+    },
+});

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -38,11 +38,11 @@
         "src"
     ],
     "scripts": {
-        "build": "tsc -b && cp ../../README.md .",
+        "build": "tsc -b",
         "typecheck": "tsc -b --emitDeclarationOnly"
     },
     "devDependencies": {
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.7"
     },
     "peerDependencies": {
         "vitest": ">=4"

--- a/packages/vitest/src/plugin.ts
+++ b/packages/vitest/src/plugin.ts
@@ -5,7 +5,7 @@ import type { Plugin } from "vitest/config";
 /**
  * Creates the GTKX Vitest plugin for running GTK tests.
  *
- * Each worker spawns its own Xvfb instance on a PID-based display number.
+ * Each worker spawns its own Xvfb instance on a display Xvfb selects.
  *
  * @returns Vitest plugin configuration
  *

--- a/packages/vitest/src/setup.ts
+++ b/packages/vitest/src/setup.ts
@@ -1,52 +1,154 @@
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { beforeAll } from "vitest";
+import { type ChildProcess, type StdioOptions, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Readable } from "node:stream";
 
-const display = 100 + (process.pid % 5000);
-const socketPath = `/tmp/.X11-unix/X${display}`;
+const busDir = mkdtempSync(join(tmpdir(), "gtkx-dbus-"));
+const busConfigPath = join(busDir, "session.conf");
+const busSocketPath = join(busDir, "bus");
 
-const xvfb = spawn("Xvfb", [`:${display}`, "-screen", "0", "1024x768x24"], {
-    stdio: "ignore",
-});
+writeFileSync(
+    busConfigPath,
+    `<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <listen>unix:path=${busSocketPath}</listen>
+  <auth>EXTERNAL</auth>
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>`,
+);
 
-xvfb.unref();
+/**
+ * Spawns a long-lived helper process whose lifetime is bound to this worker.
+ *
+ * `setpriv --pdeathsig SIGKILL` makes the kernel kill the helper the instant
+ * the worker process dies — by any signal, including a `SIGSEGV` from a native
+ * crash or a `SIGKILL` from the OOM killer — paths that `process.on` exit and
+ * signal handlers cannot cover. Without it a crashed worker orphans its `Xvfb`
+ * and `dbus-daemon`, leaking one of each per crash.
+ */
+const spawnWorkerChild = (command: string, args: string[], stdio: StdioOptions): ChildProcess => {
+    const child = spawn("setpriv", ["--pdeathsig", "SIGKILL", command, ...args], { stdio });
+    child.unref();
+    return child;
+};
 
+const xvfb = spawnWorkerChild("Xvfb", ["-displayfd", "1", "-screen", "0", "1024x768x24"], ["ignore", "pipe", "pipe"]);
+const dbus = spawnWorkerChild("dbus-daemon", [`--config-file=${busConfigPath}`], "ignore");
+
+process.env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${busSocketPath}`;
 process.env.GDK_BACKEND = "x11";
+process.env.GDK_DISABLE = "vulkan";
 process.env.GSK_RENDERER = "cairo";
+process.env.GTK_A11Y = "test";
 process.env.LIBGL_ALWAYS_SOFTWARE = "1";
-process.env.DISPLAY = `:${display}`;
+process.env.GSETTINGS_BACKEND = "memory";
 
-const killXvfb = (): void => {
+const killChildren = (): void => {
     if (xvfb.pid !== undefined) {
         try {
             process.kill(xvfb.pid, "SIGTERM");
         } catch {}
     }
+    if (dbus.pid !== undefined) {
+        try {
+            process.kill(dbus.pid, "SIGTERM");
+        } catch {}
+    }
+    try {
+        rmSync(busDir, { recursive: true, force: true });
+    } catch {}
 };
 
-process.on("exit", killXvfb);
+process.on("exit", killChildren);
 
 process.on("SIGTERM", () => {
-    killXvfb();
+    killChildren();
     process.exit(143);
 });
 
 process.on("SIGINT", () => {
-    killXvfb();
+    killChildren();
     process.exit(130);
 });
 
-const waitForDisplay = async (timeout = 5000): Promise<void> => {
+const waitForFile = async (path: string, label: string, timeout = 15000): Promise<void> => {
     const start = Date.now();
     while (Date.now() - start < timeout) {
-        if (existsSync(socketPath)) {
+        if (existsSync(path)) {
             return;
         }
         await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    throw new Error(`Xvfb display :${display} did not become available within ${timeout}ms`);
+    throw new Error(`${label} did not become available within ${timeout}ms`);
 };
 
-beforeAll(async () => {
-    await waitForDisplay();
-});
+/**
+ * Resolves with the display number Xvfb chose, reported on its `-displayfd`.
+ *
+ * Letting Xvfb scan for and claim a free display — rather than computing one
+ * from the worker PID — removes collisions between the many worker `Xvfb`
+ * instances a `turbo` run starts concurrently. The number is written only once
+ * the server owns the display and accepts connections, so it is usable as soon
+ * as it arrives. An early server exit is surfaced with its captured log instead
+ * of stalling until the timeout elapses.
+ */
+const waitForDisplay = (timeout = 15000): Promise<string> =>
+    new Promise((resolve, reject) => {
+        const { stdout, stderr } = xvfb;
+        if (stdout === null || stderr === null) {
+            reject(new Error("Xvfb output pipes are unavailable"));
+            return;
+        }
+        stdout.setEncoding("utf8");
+        stderr.setEncoding("utf8");
+        let displayBuffer = "";
+        let log = "";
+        let timer: ReturnType<typeof setTimeout>;
+        const stopListening = (): void => {
+            clearTimeout(timer);
+            stdout.removeAllListeners("data");
+            stderr.removeAllListeners("data");
+            xvfb.removeAllListeners("exit");
+        };
+        const drain = (stream: Readable): void => {
+            stream.resume();
+            (stream as Partial<{ unref(): void }>).unref?.();
+        };
+        const onDisplay = (chunk: string): void => {
+            displayBuffer += chunk;
+            const newline = displayBuffer.indexOf("\n");
+            if (newline === -1) {
+                return;
+            }
+            stopListening();
+            drain(stdout);
+            drain(stderr);
+            resolve(displayBuffer.slice(0, newline).trim());
+        };
+        const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+            stopListening();
+            reject(
+                new Error(
+                    `Xvfb exited (code ${code ?? "null"}, signal ${signal ?? "null"}) before reporting a display\n${log}`,
+                ),
+            );
+        };
+        timer = setTimeout(() => {
+            stopListening();
+            reject(new Error(`Xvfb did not report a display within ${timeout}ms\n${log}`));
+        }, timeout);
+        stdout.on("data", onDisplay);
+        stderr.on("data", (chunk: string) => {
+            log += chunk;
+        });
+        xvfb.on("exit", onExit);
+    });
+
+const [display] = await Promise.all([waitForDisplay(), waitForFile(busSocketPath, "D-Bus session bus")]);
+process.env.DISPLAY = `:${display}`;

--- a/packages/vitest/tsconfig.lib.json
+++ b/packages/vitest/tsconfig.lib.json
@@ -1,9 +1,3 @@
 {
-    "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": "src",
-        "emitDeclarationOnly": false
-    },
-    "extends": "../../tsconfig.base.json",
-    "include": ["src/**/*"]
+    "extends": "../../tsconfig.lib.json"
 }


### PR DESCRIPTION
- Mirrors **React Testing Library** `act` semantics: queue-aware flushing, proper Promise wrapping of async returns
- New `query-helpers.ts` and `react-internals-instrumentation.ts` for RTL-style queries against the GTK widget tree
- `flushRunloops` now drains only GLib idle to bound React re-renders and prevent runaway loops
- All tests migrated to use `@gtkx/testing` exclusively; ad-hoc `tests/helpers/*` patterns removed
- `@gtkx/vitest` aligned with the shared vitest config to dedupe lcov paths
- Sync GTK dialogs replaced with async variants in tests (sync dialogs spin nested main loops that hang tests)