### PR TITLE
Enable React Compiler for gtkx apps and the CLI build pipeline

### DIFF
--- a/examples/browser/src/app.tsx
+++ b/examples/browser/src/app.tsx
@@ -14,7 +14,7 @@ import {
     quit,
     WebKitWebView,
 } from "@gtkx/react";
-import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 
 const DEFAULT_URL = "https://gtkx.dev";
 
@@ -51,16 +51,13 @@ const useBrowserController = (webViewRef: RefObject<WebKit.WebView | null>) => {
         progress: 0,
     });
 
-    const setUrl = useCallback((url: string) => setState((s) => ({ ...s, url })), []);
+    const setUrl = (url: string) => setState((s) => ({ ...s, url }));
 
-    const navigate = useCallback(
-        (targetUrl: string) => {
-            webViewRef.current?.loadUri(normalizeUrl(targetUrl));
-        },
-        [webViewRef],
-    );
+    const navigate = (targetUrl: string) => {
+        webViewRef.current?.loadUri(normalizeUrl(targetUrl));
+    };
 
-    const handleLoadChanged = useCallback((loadEvent: WebKit.LoadEvent, webView: WebKit.WebView) => {
+    const handleLoadChanged = (loadEvent: WebKit.LoadEvent, webView: WebKit.WebView) => {
         setState((s) => ({
             ...s,
             canGoBack: webView.canGoBack(),
@@ -69,16 +66,13 @@ const useBrowserController = (webViewRef: RefObject<WebKit.WebView | null>) => {
             ...(loadEvent === WebKit.LoadEvent.COMMITTED && { url: webView.getUri() ?? s.url }),
             ...(loadEvent === WebKit.LoadEvent.FINISHED && { isLoading: false, progress: 1 }),
         }));
-    }, []);
+    };
 
-    const handleNotify = useCallback(
-        (pspec: GObject.ParamSpec) => {
-            const webView = webViewRef.current;
-            if (!webView || pspec.getName() !== "estimated-load-progress") return;
-            setState((s) => ({ ...s, progress: webView.getEstimatedLoadProgress() }));
-        },
-        [webViewRef],
-    );
+    const handleNotify = (pspec: GObject.ParamSpec) => {
+        const webView = webViewRef.current;
+        if (!webView || pspec.getName() !== "estimated-load-progress") return;
+        setState((s) => ({ ...s, progress: webView.getEstimatedLoadProgress() }));
+    };
 
     return { state, setUrl, navigate, handleLoadChanged, handleNotify };
 };

--- a/examples/gtk-demo/src/app.tsx
+++ b/examples/gtk-demo/src/app.tsx
@@ -26,7 +26,7 @@ import {
     useApplication,
     useProperty,
 } from "@gtkx/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Sidebar } from "./components/sidebar.js";
 import { SourceViewer } from "./components/source-viewer.js";
 import { DemoProvider, parseTitle, useDemo } from "./context/demo-context.js";
@@ -290,14 +290,14 @@ const useDemoWindows = () => {
     const [demoWindows, setDemoWindows] = useState<number[]>([]);
     const [nextWindowId, setNextWindowId] = useState(1);
 
-    const openWindow = useCallback(() => {
+    const openWindow = () => {
         setDemoWindows((prev) => [...prev, nextWindowId]);
         setNextWindowId((prev) => prev + 1);
-    }, [nextWindowId]);
+    };
 
-    const closeWindow = useCallback((id: number) => {
+    const closeWindow = (id: number) => {
         setDemoWindows((prev) => prev.filter((w) => w !== id));
-    }, []);
+    };
 
     return { demoWindows, openWindow, closeWindow };
 };
@@ -342,15 +342,15 @@ const MainWindow = () => {
 
     const windowTitle = currentDemo ? parseTitle(currentDemo.title).displayTitle : "GTK Demo";
 
-    const handleRun = useCallback(() => {
+    const handleRun = () => {
         if (!currentDemo) return;
         openWindow();
-    }, [currentDemo, openWindow]);
+    };
 
-    const handleKeyboardShortcuts = useCallback(() => {
+    const handleKeyboardShortcuts = () => {
         if (!activeWindow) return;
         showShortcutsDialog(activeWindow);
-    }, [activeWindow]);
+    };
 
     const titlebar = (
         <AppHeaderBar

--- a/examples/gtk-demo/src/components/sidebar.tsx
+++ b/examples/gtk-demo/src/components/sidebar.tsx
@@ -1,6 +1,5 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkInscription, GtkListView, GtkScrolledWindow, GtkSearchBar, GtkSearchEntry } from "@gtkx/react";
-import { useCallback, useMemo } from "react";
 import { useDemo } from "../context/demo-context.js";
 import type { TreeItem } from "../demos/types.js";
 
@@ -37,20 +36,17 @@ const renderItem = (item: TreeItem) => {
 export const Sidebar = ({ searchMode, onSearchChanged }: SidebarProps) => {
     const { filteredTreeItems, currentDemo, setCurrentDemo, searchQuery, demos } = useDemo();
 
-    const items = useMemo(() => filteredTreeItems.map(treeItemToData), [filteredTreeItems]);
+    const items = filteredTreeItems.map(treeItemToData);
 
-    const selected = useMemo(() => (currentDemo ? [`demo-${currentDemo.id}`] : EMPTY_SELECTION), [currentDemo]);
+    const selected = currentDemo ? [`demo-${currentDemo.id}`] : EMPTY_SELECTION;
 
-    const handleSelectionChanged = useCallback(
-        (ids: string[]) => {
-            const selectedId = ids[0];
-            if (!selectedId?.startsWith("demo-")) return;
-            const demoId = selectedId.slice(5);
-            const demo = demos.find((d) => d.id === demoId);
-            if (demo) setCurrentDemo(demo);
-        },
-        [demos, setCurrentDemo],
-    );
+    const handleSelectionChanged = (ids: string[]) => {
+        const selectedId = ids[0];
+        if (!selectedId?.startsWith("demo-")) return;
+        const demoId = selectedId.slice(5);
+        const demo = demos.find((d) => d.id === demoId);
+        if (demo) setCurrentDemo(demo);
+    };
 
     return (
         <GtkBox orientation={Gtk.Orientation.VERTICAL}>

--- a/examples/gtk-demo/src/components/source-viewer.tsx
+++ b/examples/gtk-demo/src/components/source-viewer.tsx
@@ -1,21 +1,17 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import type * as GtkSource from "@gtkx/gi/gtksource";
 import { GtkBox, GtkLabel, GtkScrolledWindow, GtkSourceView } from "@gtkx/react";
-import { useCallback } from "react";
 import { useDemo } from "../context/demo-context.js";
 
 export const SourceViewer = () => {
     const { currentDemo } = useDemo();
 
-    const handleRef = useCallback(
-        (view: GtkSource.View | null) => {
-            if (view && currentDemo?.sourceCode) {
-                const buffer = view.getBuffer();
-                buffer.setText(currentDemo.sourceCode, -1);
-            }
-        },
-        [currentDemo?.sourceCode],
-    );
+    const handleRef = (view: GtkSource.View | null) => {
+        if (view && currentDemo?.sourceCode) {
+            const buffer = view.getBuffer();
+            buffer.setText(currentDemo.sourceCode, -1);
+        }
+    };
 
     return (
         <GtkScrolledWindow vexpand hexpand>

--- a/examples/gtk-demo/src/context/demo-context.tsx
+++ b/examples/gtk-demo/src/context/demo-context.tsx
@@ -1,5 +1,5 @@
 import type * as Gtk from "@gtkx/gi/gtk";
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, type ReactNode, useContext, useState } from "react";
 import type { Demo, TreeItem } from "../demos/types.js";
 
 interface DemoContextValue {
@@ -130,42 +130,36 @@ const findFirstDemo = (treeItems: TreeItem[]): Demo | null => {
 };
 
 export const DemoProvider = ({ demos, children }: DemoTreeProviderProps) => {
-    const treeItems = useMemo(() => buildTree(demos), [demos]);
+    const treeItems = buildTree(demos);
 
-    const firstDemo = useMemo(() => findFirstDemo(treeItems), [treeItems]);
+    const firstDemo = findFirstDemo(treeItems);
 
     const [currentDemo, setCurrentDemoState] = useState<Demo | null>(firstDemo);
     const [searchQuery, setSearchQuery] = useState("");
     const [windowTitle, setWindowTitle] = useState<string | null>(null);
     const [defaultWidget, setDefaultWidget] = useState<Gtk.Widget | null>(null);
 
-    const setCurrentDemo = useCallback((demo: Demo | null) => {
+    const setCurrentDemo = (demo: Demo | null) => {
         setCurrentDemoState(demo);
         setWindowTitle(null);
         setDefaultWidget(null);
-    }, []);
+    };
 
-    const filteredTreeItems = useMemo(
-        () => (searchQuery.trim() ? filterTree(treeItems, searchQuery) : treeItems),
-        [treeItems, searchQuery],
-    );
+    const filteredTreeItems = searchQuery.trim() ? filterTree(treeItems, searchQuery) : treeItems;
 
-    const contextValue = useMemo(
-        () => ({
-            demos,
-            treeItems,
-            currentDemo,
-            setCurrentDemo,
-            searchQuery,
-            setSearchQuery,
-            filteredTreeItems,
-            windowTitle,
-            setWindowTitle,
-            defaultWidget,
-            setDefaultWidget,
-        }),
-        [demos, treeItems, currentDemo, searchQuery, filteredTreeItems, windowTitle, defaultWidget, setCurrentDemo],
-    );
+    const contextValue = {
+        demos,
+        treeItems,
+        currentDemo,
+        setCurrentDemo,
+        searchQuery,
+        setSearchQuery,
+        filteredTreeItems,
+        windowTitle,
+        setWindowTitle,
+        defaultWidget,
+        setDefaultWidget,
+    };
 
     return <DemoContext.Provider value={contextValue}>{children}</DemoContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/advanced/font-features.tsx
+++ b/examples/gtk-demo/src/demos/advanced/font-features.tsx
@@ -26,7 +26,7 @@ import {
     GtkViewport,
     useAdjustment,
 } from "@gtkx/react";
-import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./font-features.tsx?raw";
 
@@ -439,36 +439,25 @@ const buildWaterfallStyle = ({ fontDesc, wfSize, fontFeaturesString, fgColor, le
 function useFontFeaturesStyles(state: ReturnType<typeof useFontFeaturesState>) {
     const { fontDesc, fgColor, bgColor, size, letterSpacing, lineHeight, checkStates, radioStates } = state;
 
-    const fontFeaturesString = useMemo(
-        () => buildFontFeaturesString(checkStates, radioStates),
-        [checkStates, radioStates],
-    );
+    const fontFeaturesString = buildFontFeaturesString(checkStates, radioStates);
 
-    const bgStyle = useMemo(() => buildBgStyle(bgColor), [bgColor]);
+    const bgStyle = buildBgStyle(bgColor);
 
-    const previewStyle = useMemo(
-        () => buildPreviewStyle({ fontDesc, size, fgColor, letterSpacing, lineHeight }),
-        [fontDesc, size, fgColor, letterSpacing, lineHeight],
-    );
+    const previewStyle = buildPreviewStyle({ fontDesc, size, fgColor, letterSpacing, lineHeight });
 
-    const editStyle = useMemo(
-        () => buildEditStyle({ fontDesc, size, fontFeaturesString, fgColor, letterSpacing }),
-        [fontDesc, size, fontFeaturesString, fgColor, letterSpacing],
-    );
+    const editStyle = buildEditStyle({ fontDesc, size, fontFeaturesString, fgColor, letterSpacing });
 
-    const createWaterfallStyle = useCallback(
-        (wfSize: number) => buildWaterfallStyle({ fontDesc, wfSize, fontFeaturesString, fgColor, letterSpacing }),
-        [fontDesc, fontFeaturesString, fgColor, letterSpacing],
-    );
+    const createWaterfallStyle = (wfSize: number) =>
+        buildWaterfallStyle({ fontDesc, wfSize, fontFeaturesString, fgColor, letterSpacing });
 
-    const pangoFontFeaturesString = useMemo(() => {
+    const pangoFontFeaturesString = (() => {
         if (fontFeaturesString === "normal") return null;
         return fontFeaturesString.replaceAll('"', "").replaceAll(" 1", "=1").replaceAll(" 0", "=0");
-    }, [fontFeaturesString]);
+    })();
 
-    const settingsText = useMemo(() => pangoFontFeaturesString ?? "", [pangoFontFeaturesString]);
+    const settingsText = pangoFontFeaturesString ?? "";
 
-    const descriptionText = useMemo(() => fontDesc?.toString() ?? "Sans 14", [fontDesc]);
+    const descriptionText = fontDesc?.toString() ?? "Sans 14";
 
     return {
         fontFeaturesString,
@@ -485,46 +474,37 @@ function useFontFeaturesStyles(state: ReturnType<typeof useFontFeaturesState>) {
 function useFeatureHandlers(state: ReturnType<typeof useFontFeaturesState>) {
     const { setCheckStates, setRadioStates } = state;
 
-    const toggleCheck = useCallback(
-        (tag: string) => {
-            setCheckStates((prev) => {
-                const next = new Map(prev);
-                const current = next.get(tag) ?? "inconsistent";
-                if (current === "inconsistent") next.set(tag, "active");
-                else if (current === "active") next.set(tag, "inactive");
-                else next.set(tag, "active");
-                return next;
-            });
-        },
-        [setCheckStates],
-    );
+    const toggleCheck = (tag: string) => {
+        setCheckStates((prev) => {
+            const next = new Map(prev);
+            const current = next.get(tag) ?? "inconsistent";
+            if (current === "inconsistent") next.set(tag, "active");
+            else if (current === "active") next.set(tag, "inactive");
+            else next.set(tag, "active");
+            return next;
+        });
+    };
 
-    const resetToInconsistent = useCallback(
-        (tag: string) => {
-            setCheckStates((prev) => {
-                const next = new Map(prev);
-                next.set(tag, "inconsistent");
-                return next;
-            });
-        },
-        [setCheckStates],
-    );
+    const resetToInconsistent = (tag: string) => {
+        setCheckStates((prev) => {
+            const next = new Map(prev);
+            next.set(tag, "inconsistent");
+            return next;
+        });
+    };
 
-    const selectRadio = useCallback(
-        (groupTitle: string, tag: string) => {
-            setRadioStates((prev) => {
-                const next = new Map(prev);
-                next.set(groupTitle, tag);
-                return next;
-            });
-        },
-        [setRadioStates],
-    );
+    const selectRadio = (groupTitle: string, tag: string) => {
+        setRadioStates((prev) => {
+            const next = new Map(prev);
+            next.set(groupTitle, tag);
+            return next;
+        });
+    };
 
-    const resetFeatures = useCallback(() => {
+    const resetFeatures = () => {
         setCheckStates(createInitialCheckStates());
         setRadioStates(createInitialRadioStates());
-    }, [setCheckStates, setRadioStates]);
+    };
 
     return { toggleCheck, resetToInconsistent, selectRadio, resetFeatures };
 }
@@ -532,18 +512,18 @@ function useFeatureHandlers(state: ReturnType<typeof useFontFeaturesState>) {
 function useColorHandlers(state: ReturnType<typeof useFontFeaturesState>) {
     const { fgColor, bgColor, setFgColor, setBgColor, setSize, setLetterSpacing, setLineHeight } = state;
 
-    const swapColors = useCallback(() => {
+    const swapColors = () => {
         setFgColor(buildRgba(bgColor.red, bgColor.green, bgColor.blue, 1));
         setBgColor(buildRgba(fgColor.red, fgColor.green, fgColor.blue, 1));
-    }, [fgColor, bgColor, setFgColor, setBgColor]);
+    };
 
-    const resetBasic = useCallback(() => {
+    const resetBasic = () => {
         setSize(20);
         setLetterSpacing(0);
         setLineHeight(1);
         setFgColor(createDefaultFgColor());
         setBgColor(createDefaultBgColor());
-    }, [setSize, setLetterSpacing, setLineHeight, setFgColor, setBgColor]);
+    };
 
     return { swapColors, resetBasic };
 }
@@ -551,26 +531,23 @@ function useColorHandlers(state: ReturnType<typeof useFontFeaturesState>) {
 function useSampleHandlers(state: ReturnType<typeof useFontFeaturesState>) {
     const { sampleCounterRef, setPreviewText, editTextViewRef } = state;
 
-    const updatePreviewText = useCallback(
-        (text: string) => {
-            setPreviewText(text);
-            const tv = editTextViewRef.current;
-            if (tv) tv.getBuffer().setText(text, -1);
-        },
-        [setPreviewText, editTextViewRef],
-    );
+    const updatePreviewText = (text: string) => {
+        setPreviewText(text);
+        const tv = editTextViewRef.current;
+        if (tv) tv.getBuffer().setText(text, -1);
+    };
 
-    const handleAlphabet = useCallback(() => {
+    const handleAlphabet = () => {
         sampleCounterRef.current += 1;
         const idx = sampleCounterRef.current % ALPHABET_SAMPLES.length;
         updatePreviewText(ALPHABET_SAMPLES[idx] ?? "");
-    }, [sampleCounterRef, updatePreviewText]);
+    };
 
-    const handleParagraph = useCallback(() => {
+    const handleParagraph = () => {
         sampleCounterRef.current += 1;
         const idx = sampleCounterRef.current % PARAGRAPH_SAMPLES.length;
         updatePreviewText(PARAGRAPH_SAMPLES[idx] ?? "");
-    }, [sampleCounterRef, updatePreviewText]);
+    };
 
     return { handleAlphabet, handleParagraph };
 }
@@ -578,35 +555,26 @@ function useSampleHandlers(state: ReturnType<typeof useFontFeaturesState>) {
 function useEntryHandlers(state: ReturnType<typeof useFontFeaturesState>) {
     const { setSize, setLetterSpacing, setLineHeight } = state;
 
-    const handleSizeEntry = useCallback(
-        (entry: Gtk.Entry) => {
-            const val = Number.parseFloat(entry.getText());
-            if (Number.isFinite(val) && val >= 7 && val <= 100) {
-                setSize(val);
-            }
-        },
-        [setSize],
-    );
+    const handleSizeEntry = (entry: Gtk.Entry) => {
+        const val = Number.parseFloat(entry.getText());
+        if (Number.isFinite(val) && val >= 7 && val <= 100) {
+            setSize(val);
+        }
+    };
 
-    const handleLetterspacingEntry = useCallback(
-        (entry: Gtk.Entry) => {
-            const val = Number.parseFloat(entry.getText());
-            if (Number.isFinite(val) && val >= -1024 && val <= 8192) {
-                setLetterSpacing(val);
-            }
-        },
-        [setLetterSpacing],
-    );
+    const handleLetterspacingEntry = (entry: Gtk.Entry) => {
+        const val = Number.parseFloat(entry.getText());
+        if (Number.isFinite(val) && val >= -1024 && val <= 8192) {
+            setLetterSpacing(val);
+        }
+    };
 
-    const handleLineHeightEntry = useCallback(
-        (entry: Gtk.Entry) => {
-            const val = Number.parseFloat(entry.getText());
-            if (Number.isFinite(val) && val >= 0.75 && val <= 2.5) {
-                setLineHeight(val);
-            }
-        },
-        [setLineHeight],
-    );
+    const handleLineHeightEntry = (entry: Gtk.Entry) => {
+        const val = Number.parseFloat(entry.getText());
+        if (Number.isFinite(val) && val >= 0.75 && val <= 2.5) {
+            setLineHeight(val);
+        }
+    };
 
     return { handleSizeEntry, handleLetterspacingEntry, handleLineHeightEntry };
 }
@@ -616,10 +584,10 @@ function useFontFeaturesHandlers(state: ReturnType<typeof useFontFeaturesState>)
     const colorHandlers = useColorHandlers(state);
     const sampleHandlers = useSampleHandlers(state);
     const entryHandlers = useEntryHandlers(state);
-    const resetAll = useCallback(() => {
+    const resetAll = () => {
         colorHandlers.resetBasic();
         featureHandlers.resetFeatures();
-    }, [colorHandlers, featureHandlers]);
+    };
 
     return {
         ...featureHandlers,
@@ -658,7 +626,7 @@ function usePreviewAttributes(
     pangoFontFeaturesString: string | null,
     previewSelection: { start: number; end: number } | null,
 ): Pango.AttrList | null {
-    return useMemo(() => {
+    return (() => {
         if (!pangoFontFeaturesString) return null;
         const attrList = Pango.AttrList.new();
         const attr = Pango.attrFontFeaturesNew(pangoFontFeaturesString);
@@ -666,7 +634,7 @@ function usePreviewAttributes(
         attr.endIndex = previewSelection?.end ?? 0xffffffff;
         attrList.insert(attr);
         return attrList;
-    }, [pangoFontFeaturesString, previewSelection]);
+    })();
 }
 
 const FontFeaturesFontButton = ({ state }: { state: FontFeaturesState }) => {
@@ -1008,29 +976,20 @@ const FontFeaturesPreviewSettingsRow = ({
 function useViewModeToggleHandlers(state: FontFeaturesState) {
     const { previewText, setViewMode, savedTextRef } = state;
 
-    const handlePlainToggled = useCallback(
-        (btn: Gtk.ToggleButton) => {
-            if (btn.getActive()) setViewMode("plain");
-        },
-        [setViewMode],
-    );
+    const handlePlainToggled = (btn: Gtk.ToggleButton) => {
+        if (btn.getActive()) setViewMode("plain");
+    };
 
-    const handleWaterfallToggled = useCallback(
-        (btn: Gtk.ToggleButton) => {
-            if (btn.getActive()) setViewMode("waterfall");
-        },
-        [setViewMode],
-    );
+    const handleWaterfallToggled = (btn: Gtk.ToggleButton) => {
+        if (btn.getActive()) setViewMode("waterfall");
+    };
 
-    const handleEditToggled = useCallback(
-        (btn: Gtk.ToggleButton) => {
-            if (btn.getActive()) {
-                savedTextRef.current = previewText;
-                setViewMode("edit");
-            }
-        },
-        [previewText, savedTextRef, setViewMode],
-    );
+    const handleEditToggled = (btn: Gtk.ToggleButton) => {
+        if (btn.getActive()) {
+            savedTextRef.current = previewText;
+            setViewMode("edit");
+        }
+    };
 
     return { handlePlainToggled, handleWaterfallToggled, handleEditToggled };
 }
@@ -1146,7 +1105,11 @@ const FontFeaturesProvider = ({ children }: DemoProviderProps) => {
     const state = useFontFeaturesState();
     const styles = useFontFeaturesStyles(state);
     const handlers = useFontFeaturesHandlers(state);
-    const value = useMemo<FontFeaturesContextValue>(() => ({ state, styles, handlers }), [state, styles, handlers]);
+    const value = {
+        state,
+        styles,
+        handlers,
+    };
     return <FontFeaturesContext.Provider value={value}>{children}</FontFeaturesContext.Provider>;
 };
 

--- a/examples/gtk-demo/src/demos/advanced/fontrendering.tsx
+++ b/examples/gtk-demo/src/demos/advanced/fontrendering.tsx
@@ -32,7 +32,7 @@ import {
     GtkShortcutController,
     GtkToggleButton,
 } from "@gtkx/react";
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./fontrendering.tsx?raw";
 
@@ -541,84 +541,78 @@ const computeTextLayout = ({ cr, width, height, fontOptions, fontDesc, text, hin
 function useDrawTextMode(state: FontRenderingState) {
     const { fontDesc, text, hintStyle, antialias, hintMetrics } = state;
 
-    return useCallback(
-        (cr: Context, width: number, height: number) => {
-            cr.setSourceRgb(1, 1, 1);
-            cr.paint();
+    return (cr: Context, width: number, height: number) => {
+        cr.setSourceRgb(1, 1, 1);
+        cr.paint();
 
-            const fontOptions = createGridFontOptions(hintStyle, antialias, hintMetrics);
-            const { inkPixel, logicalRect, baseline, target } = computeTextLayout({
-                cr,
-                width,
-                height,
-                fontOptions,
-                fontDesc,
-                text,
-                hintMetrics,
-            });
+        const fontOptions = createGridFontOptions(hintStyle, antialias, hintMetrics);
+        const { inkPixel, logicalRect, baseline, target } = computeTextLayout({
+            cr,
+            width,
+            height,
+            fontOptions,
+            fontDesc,
+            text,
+            hintMetrics,
+        });
 
-            const surfaceWidth = inkPixel.width + 20;
-            const surfaceHeight = inkPixel.height + 20;
+        const surfaceWidth = inkPixel.width + 20;
+        const surfaceHeight = inkPixel.height + 20;
 
-            const ctx: DrawTextModeContext = {
-                cr,
-                width,
-                height,
-                state,
-                fontOptions,
-                target,
-                inkPixel,
-                logicalRect,
-                baseline,
-                surfaceWidth,
-                surfaceHeight,
-            };
-            const { small, scaledWidth, scaledHeight, offsetX, offsetY } = drawSmallSurface(ctx);
-            drawOverlays(ctx, { offsetX, offsetY, scaledWidth, scaledHeight });
-            small.finish();
-        },
-        [fontDesc, text, hintStyle, antialias, hintMetrics, state],
-    );
+        const ctx: DrawTextModeContext = {
+            cr,
+            width,
+            height,
+            state,
+            fontOptions,
+            target,
+            inkPixel,
+            logicalRect,
+            baseline,
+            surfaceWidth,
+            surfaceHeight,
+        };
+        const { small, scaledWidth, scaledHeight, offsetX, offsetY } = drawSmallSurface(ctx);
+        drawOverlays(ctx, { offsetX, offsetY, scaledWidth, scaledHeight });
+        small.finish();
+    };
 }
 
 function useDrawGridMode(state: FontRenderingState) {
     const { fontDesc, text, hintStyle, antialias, hintMetrics, scale } = state;
 
-    return useCallback(
-        (cr: Context, width: number, height: number) => {
-            const fontOptions = createGridFontOptions(hintStyle, antialias, hintMetrics);
-            const target = cr.getTarget();
-            const tmpSurface = Surface.createSimilar(target, Content.COLOR_ALPHA, 1, 1);
-            const tmpCr = Context.create(tmpSurface);
-            tmpCr.setFontOptions(fontOptions);
+    return (cr: Context, width: number, height: number) => {
+        const fontOptions = createGridFontOptions(hintStyle, antialias, hintMetrics);
+        const target = cr.getTarget();
+        const tmpSurface = Surface.createSimilar(target, Content.COLOR_ALPHA, 1, 1);
+        const tmpCr = Context.create(tmpSurface);
+        tmpCr.setFontOptions(fontOptions);
 
-            const context = PangoCairo.createContext(tmpCr);
-            PangoCairo.contextSetFontOptions(context, fontOptions);
-            context.setRoundGlyphPositions(hintMetrics);
+        const context = PangoCairo.createContext(tmpCr);
+        PangoCairo.contextSetFontOptions(context, fontOptions);
+        context.setRoundGlyphPositions(hintMetrics);
 
-            const layoutSetup = setupGridLayout(context, fontDesc, text);
-            if (!layoutSetup) return;
-            const { logicalRect, ch } = layoutSetup;
+        const layoutSetup = setupGridLayout(context, fontDesc, text);
+        if (!layoutSetup) return;
+        const { logicalRect, ch } = layoutSetup;
 
-            const surfaceWidth = Math.round((logicalRect.width * 3) / 2);
-            const surfaceHeight = logicalRect.height * 4;
-            const small = Surface.createSimilar(target, Content.COLOR_ALPHA, surfaceWidth, surfaceHeight);
-            const smallSetup = renderSmallSurface({ small, fontOptions, fontDesc, ch, hintMetrics });
-            if (!smallSetup) {
-                small.finish();
-                tmpSurface.finish();
-                return;
-            }
-
-            cr.setSourceRgb(1, 1, 1);
-            cr.paint();
-            paintSmallSurface({ cr, small, surfaceWidth, surfaceHeight, scale, width, height });
-
+        const surfaceWidth = Math.round((logicalRect.width * 3) / 2);
+        const surfaceHeight = logicalRect.height * 4;
+        const small = Surface.createSimilar(target, Content.COLOR_ALPHA, surfaceWidth, surfaceHeight);
+        const smallSetup = renderSmallSurface({ small, fontOptions, fontDesc, ch, hintMetrics });
+        if (!smallSetup) {
             small.finish();
             tmpSurface.finish();
-        },
-        [fontDesc, text, hintStyle, antialias, hintMetrics, scale],
-    );
+            return;
+        }
+
+        cr.setSourceRgb(1, 1, 1);
+        cr.paint();
+        paintSmallSurface({ cr, small, surfaceWidth, surfaceHeight, scale, width, height });
+
+        small.finish();
+        tmpSurface.finish();
+    };
 }
 
 const FontRenderingTitlebar = () => {
@@ -844,13 +838,13 @@ const FontRenderingProvider = ({ children }: DemoProviderProps) => {
     const drawGridMode = useDrawGridMode(state);
     const drawFunc = mode === "text" ? drawTextMode : drawGridMode;
 
-    const naturalSize = useMemo(() => {
+    const naturalSize = (() => {
         const inputs: MeasurementInputs = { text, fontDesc, hintStyle, antialias, hintMetrics, scale };
         return mode === "text" ? measureTextSurface(inputs) : measureGridSurface(inputs);
-    }, [mode, text, fontDesc, hintStyle, antialias, hintMetrics, scale]);
+    })();
 
-    const zoomIn = useCallback(() => setScale((s) => Math.min(32, s + 1)), [setScale]);
-    const zoomOut = useCallback(() => setScale((s) => Math.max(1, s - 1)), [setScale]);
+    const zoomIn = () => setScale((s) => Math.min(32, s + 1));
+    const zoomOut = () => setScale((s) => Math.max(1, s - 1));
 
     return (
         <FontRenderingContext.Provider value={{ state, drawFunc, zoomIn, zoomOut, naturalSize }}>

--- a/examples/gtk-demo/src/demos/advanced/markup.tsx
+++ b/examples/gtk-demo/src/demos/advanced/markup.tsx
@@ -1,6 +1,6 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkCheckButton, GtkHeaderBar, GtkScrolledWindow, GtkStack, GtkStackPage, GtkTextView } from "@gtkx/react";
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./markup.tsx?raw";
 import markupContent from "./markup.txt?raw";
@@ -107,25 +107,26 @@ const MarkupProvider = ({ children }: DemoProviderProps) => {
     const [showSource, setShowSource] = useState(false);
     const markupRef = useRef(SAMPLE_MARKUP);
 
-    const applyMarkup = useCallback(() => {
+    const applyMarkup = () => {
         applyMarkupToView(formattedViewRef.current, markupRef.current);
-    }, []);
+    };
 
-    const handleSourceToggle = useCallback(
-        (active: boolean) => {
-            if (!active && showSource) {
-                syncMarkupFromSource(sourceViewRef.current, markupRef);
-                applyMarkup();
-            }
-            setShowSource(active);
-        },
-        [showSource, applyMarkup],
-    );
+    const handleSourceToggle = (active: boolean) => {
+        if (!active && showSource) {
+            syncMarkupFromSource(sourceViewRef.current, markupRef);
+            applyMarkup();
+        }
+        setShowSource(active);
+    };
 
-    const value = useMemo<MarkupContextValue>(
-        () => ({ showSource, handleSourceToggle, applyMarkup, formattedViewRef, sourceViewRef, markupRef }),
-        [showSource, handleSourceToggle, applyMarkup],
-    );
+    const value = {
+        showSource,
+        handleSourceToggle,
+        applyMarkup,
+        formattedViewRef,
+        sourceViewRef,
+        markupRef,
+    };
 
     return <MarkupContext.Provider value={value}>{children}</MarkupContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/advanced/textmask.tsx
+++ b/examples/gtk-demo/src/demos/advanced/textmask.tsx
@@ -4,14 +4,14 @@ import type * as Gtk from "@gtkx/gi/gtk";
 import * as Pango from "@gtkx/gi/pango";
 import * as PangoCairo from "@gtkx/gi/pangocairo";
 import { GtkDrawingArea } from "@gtkx/react";
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./textmask.tsx?raw";
 
 const TextmaskDemo = () => {
     const drawingAreaRef = useRef<Gtk.DrawingArea>(null);
 
-    const drawFunc = useCallback((cr: Context, width: number, height: number) => {
+    const drawFunc = (cr: Context, width: number, height: number) => {
         cr.save();
 
         const widget = drawingAreaRef.current;
@@ -43,7 +43,7 @@ const TextmaskDemo = () => {
         cr.stroke();
 
         cr.restore();
-    }, []);
+    };
 
     return <GtkDrawingArea name="textmask-area" ref={drawingAreaRef} render={drawFunc} />;
 };

--- a/examples/gtk-demo/src/demos/benchmark/frames.tsx
+++ b/examples/gtk-demo/src/demos/benchmark/frames.tsx
@@ -4,7 +4,7 @@ import * as Graphene from "@gtkx/gi/graphene";
 import * as Gtk from "@gtkx/gi/gtk";
 import * as Pango from "@gtkx/gi/pango";
 import { GtkBox, GtkHeaderBar, GtkLabel } from "@gtkx/react";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./frames.tsx?raw";
 
@@ -94,11 +94,11 @@ function useFramesState() {
         return () => clearInterval(interval);
     }, [colorWidget]);
 
-    const fpsAttrs = useMemo(() => {
+    const fpsAttrs = (() => {
         const attrs = Pango.AttrList.new();
         attrs.insert(Pango.attrFontFeaturesNew("tnum=1"));
         return attrs;
-    }, []);
+    })();
 
     return { setColorWidget, fps, fpsAttrs };
 }

--- a/examples/gtk-demo/src/demos/benchmark/themes.tsx
+++ b/examples/gtk-demo/src/demos/benchmark/themes.tsx
@@ -3,7 +3,7 @@ import type * as Gdk from "@gtkx/gi/gdk";
 import * as Gtk from "@gtkx/gi/gtk";
 import * as Pango from "@gtkx/gi/pango";
 import { AdwAlertDialog, createPortal, GtkBox, GtkButton, GtkHeaderBar, GtkLabel, GtkToggleButton } from "@gtkx/react";
-import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Demo, DemoProps, DemoProviderProps } from "../types.js";
 import sourceCode from "./themes.tsx?raw";
 
@@ -125,11 +125,11 @@ const ThemesWarningDialog = ({ window, onResponse }: { window: Gtk.Window; onRes
     );
 
 function useFpsAttrs() {
-    return useMemo(() => {
+    return (() => {
         const attrs = Pango.AttrList.new();
         attrs.insert(Pango.attrFontFeaturesNew("tnum=1"));
         return attrs;
-    }, []);
+    })();
 }
 
 function useThemesCycling(window: React.RefObject<Gtk.Window | null>) {
@@ -145,11 +145,8 @@ function useThemesCycling(window: React.RefObject<Gtk.Window | null>) {
 
     useThemesLifecycle(window, originalSettingsRef, tickIdRef);
 
-    const tickCallback = useCallback(
-        (_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean =>
-            applyNextTheme(window, themeIndexRef, frameClock, fpsRef),
-        [window],
-    );
+    const tickCallback = (_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean =>
+        applyNextTheme(window, themeIndexRef, frameClock, fpsRef);
 
     useEffect(() => {
         if (!isRunning) return;
@@ -157,14 +154,14 @@ function useThemesCycling(window: React.RefObject<Gtk.Window | null>) {
         return () => clearInterval(interval);
     }, [isRunning]);
 
-    const startCycling = useCallback(() => {
+    const startCycling = () => {
         const win = window.current;
         if (!win) return;
         tickIdRef.current = win.addTickCallback(tickCallback);
         setIsRunning(true);
-    }, [window, tickCallback]);
+    };
 
-    const stopCycling = useCallback(() => {
+    const stopCycling = () => {
         const win = window.current;
         if (win && tickIdRef.current !== null) {
             win.removeTickCallback(tickIdRef.current);
@@ -174,24 +171,18 @@ function useThemesCycling(window: React.RefObject<Gtk.Window | null>) {
         setIsRunning(false);
         fpsRef.current = "";
         setFps("");
-    }, [window]);
+    };
 
-    const handleToggle = useCallback(
-        (active: boolean) => {
-            if (active) setShowWarning(true);
-            else stopCycling();
-        },
-        [stopCycling],
-    );
+    const handleToggle = (active: boolean) => {
+        if (active) setShowWarning(true);
+        else stopCycling();
+    };
 
-    const handleWarningResponse = useCallback(
-        (response: string) => {
-            setShowWarning(false);
-            if (response === "ok") startCycling();
-            else setIsRunning(false);
-        },
-        [startCycling],
-    );
+    const handleWarningResponse = (response: string) => {
+        setShowWarning(false);
+        if (response === "ok") startCycling();
+        else setIsRunning(false);
+    };
 
     return { isRunning, fps, showWarning, fpsAttrs, boxRef, handleToggle, handleWarningResponse };
 }

--- a/examples/gtk-demo/src/demos/buttons/expander.tsx
+++ b/examples/gtk-demo/src/demos/buttons/expander.tsx
@@ -10,7 +10,6 @@ import {
     GtkTextTag,
     GtkTextView,
 } from "@gtkx/react";
-import { useCallback, useMemo } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./expander.tsx?raw";
 import { path as gtkLogoCursorPath } from "./gtk_logo_cursor.png";
@@ -21,15 +20,15 @@ Do it already!
 `;
 
 const ExpanderDemo = () => {
-    const texture = useMemo(() => Gdk.Texture.newFromResource(gtkLogoCursorPath), []);
+    const texture = Gdk.Texture.newFromResource(gtkLogoCursorPath);
 
-    const handleExpandedNotify = useCallback((pspec: GObject.ParamSpec, self: Gtk.Expander) => {
+    const handleExpandedNotify = (pspec: GObject.ParamSpec, self: Gtk.Expander) => {
         if (pspec.getName() !== "expanded") return;
         const root = self.getRoot();
         if (!root) return;
         const win = root instanceof Gtk.Window ? root : null;
         if (win) win.setResizable(self.getExpanded());
-    }, []);
+    };
 
     return (
         <GtkBox

--- a/examples/gtk-demo/src/demos/buttons/spinbutton.tsx
+++ b/examples/gtk-demo/src/demos/buttons/spinbutton.tsx
@@ -1,6 +1,6 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { type AdjustmentConfig, GtkGrid, GtkGridChild, GtkLabel, GtkSpinButton, useAdjustment } from "@gtkx/react";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./spinbutton.tsx?raw";
 
@@ -58,7 +58,7 @@ const handleTimeOutput = (spin: Gtk.SpinButton) => {
 };
 
 function useMonthSpinHandlers() {
-    const handleMonthInput = useCallback((spin: Gtk.SpinButton): [number, number] => {
+    const handleMonthInput = (spin: Gtk.SpinButton): [number, number] => {
         const text = spin.getText().toLowerCase();
         for (let i = 0; i < MONTHS.length; i++) {
             if (MONTHS[i]?.toLowerCase().startsWith(text)) {
@@ -66,14 +66,14 @@ function useMonthSpinHandlers() {
             }
         }
         return [GTK_INPUT_ERROR, 0];
-    }, []);
+    };
 
-    const handleMonthOutput = useCallback((spin: Gtk.SpinButton) => {
+    const handleMonthOutput = (spin: Gtk.SpinButton) => {
         const value = spin.getValue();
         const index = Math.round(value) - 1;
         spin.setText(MONTHS[index] ?? "January");
         return true;
-    }, []);
+    };
 
     return { handleMonthInput, handleMonthOutput };
 }

--- a/examples/gtk-demo/src/demos/css/css-blendmodes.tsx
+++ b/examples/gtk-demo/src/demos/css/css-blendmodes.tsx
@@ -12,7 +12,7 @@ import {
     GtkStackPage,
     GtkStackSwitcher,
 } from "@gtkx/react";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import type { Demo } from "../types.js";
 import blendsPath from "./blends.png";
 import cmyPath from "./cmy.jpg";
@@ -203,15 +203,15 @@ const CssBlendmodesDemo = () => {
     const [stack, setStack] = useState<Gtk.Stack | null>(null);
     const [blendMode, setBlendMode] = useState("normal");
 
-    const blendCss = useMemo(() => createBlendCss(blendMode), [blendMode]);
+    const blendCss = createBlendCss(blendMode);
 
-    const handleRowActivated = useCallback((row: Gtk.ListBoxRow) => {
+    const handleRowActivated = (row: Gtk.ListBoxRow) => {
         const index = row.getIndex();
         const mode = BLEND_MODES[index];
         if (mode) setBlendMode(mode.id);
-    }, []);
+    };
 
-    const selectAndFocusNormalRow = useCallback((widget: Gtk.Widget) => {
+    const selectAndFocusNormalRow = (widget: Gtk.Widget) => {
         const listbox = widget as Gtk.ListBox;
         const normalIndex = BLEND_MODES.findIndex((m) => m.id === "normal");
         const row = listbox.getRowAtIndex(normalIndex);
@@ -219,7 +219,7 @@ const CssBlendmodesDemo = () => {
             listbox.selectRow(row);
             row.grabFocus();
         }
-    }, []);
+    };
 
     return (
         <GtkGrid

--- a/examples/gtk-demo/src/demos/css/errorstates.tsx
+++ b/examples/gtk-demo/src/demos/css/errorstates.tsx
@@ -13,7 +13,7 @@ import {
     GtkSwitch,
     useAdjustment,
 } from "@gtkx/react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type { Demo, DemoProps } from "../types.js";
 import sourceCode from "./errorstates.tsx?raw";
 
@@ -49,43 +49,37 @@ type ErrorStatesState = ReturnType<typeof useErrorStatesState>;
 function useErrorStatesHandlers(state: ErrorStatesState) {
     const { detailsEntry, moreDetailsEntry, modeSwitch, levelScale, setMoreDetailsError, setShowError } = state;
 
-    const validateMoreDetails = useCallback(() => {
+    const validateMoreDetails = () => {
         const detailsText = detailsEntry?.getText() ?? "";
         const moreDetailsText = moreDetailsEntry?.getText() ?? "";
         setMoreDetailsError(moreDetailsText.length > 0 && detailsText.length === 0);
-    }, [detailsEntry, moreDetailsEntry, setMoreDetailsError]);
+    };
 
-    const handleDetailsChange = useCallback(() => validateMoreDetails(), [validateMoreDetails]);
-    const handleMoreDetailsChange = useCallback(() => validateMoreDetails(), [validateMoreDetails]);
+    const handleDetailsChange = () => validateMoreDetails();
+    const handleMoreDetailsChange = () => validateMoreDetails();
 
-    const handleLevelChange = useCallback(
-        (_value: number) => {
-            if (!modeSwitch || !levelScale) return;
-            const active = modeSwitch.getActive();
-            const switchState = modeSwitch.getState();
-            const value = levelScale.getValue();
-            if (active && !switchState && value > 50) {
-                setShowError(false);
-                modeSwitch.setState(true);
-            } else if (switchState && value <= 50) {
-                modeSwitch.setState(false);
-            }
-        },
-        [modeSwitch, levelScale, setShowError],
-    );
+    const handleLevelChange = (_value: number) => {
+        if (!modeSwitch || !levelScale) return;
+        const active = modeSwitch.getActive();
+        const switchState = modeSwitch.getState();
+        const value = levelScale.getValue();
+        if (active && !switchState && value > 50) {
+            setShowError(false);
+            modeSwitch.setState(true);
+        } else if (switchState && value <= 50) {
+            modeSwitch.setState(false);
+        }
+    };
 
-    const handleModeStateSet = useCallback(
-        (switchState: boolean, sw: Gtk.Switch) => {
-            if (!switchState || (levelScale && levelScale.getValue() > 50)) {
-                setShowError(false);
-                sw.setState(switchState);
-            } else {
-                setShowError(true);
-            }
-            return true;
-        },
-        [levelScale, setShowError],
-    );
+    const handleModeStateSet = (switchState: boolean, sw: Gtk.Switch) => {
+        if (!switchState || (levelScale && levelScale.getValue() > 50)) {
+            setShowError(false);
+            sw.setState(switchState);
+        } else {
+            setShowError(true);
+        }
+        return true;
+    };
 
     return { handleDetailsChange, handleMoreDetailsChange, handleLevelChange, handleModeStateSet };
 }

--- a/examples/gtk-demo/src/demos/css/use-css-editor.ts
+++ b/examples/gtk-demo/src/demos/css/use-css-editor.ts
@@ -4,7 +4,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { cssParserWarningQuark } from "@gtkx/gi/gtk";
 import * as Pango from "@gtkx/gi/pango";
 import type { RefObject } from "react";
-import { useCallback, useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 
 const clearTags = (buffer: Gtk.TextBuffer) => {
     const startIter = buffer.getStartIter();
@@ -89,31 +89,28 @@ export function useCssEditor(defaultCss: string) {
     const errorTagRef = useRef<Gtk.TextTag | null>(null);
     const warningTagRef = useRef<Gtk.TextTag | null>(null);
 
-    const handleParsingError = useCallback(
-        (section: Gtk.CssSection, error: GLib.Error) =>
-            markParsingError({
-                textView: textViewRef.current,
-                section,
-                error,
-                warningTag: warningTagRef.current,
-                errorTag: errorTagRef.current,
-            }),
-        [],
-    );
-
-    const onBufferChanged = useCallback((buffer: Gtk.TextBuffer) => {
+    const onBufferChanged = (buffer: Gtk.TextBuffer) => {
         clearTags(buffer);
         const startIter = buffer.getStartIter();
         const endIter = buffer.getEndIter();
         const text = buffer.getText(startIter, endIter, false) ?? "";
         providerRef.current?.loadFromString(text);
-    }, []);
+    };
 
     useLayoutEffect(() => {
         const textView = textViewRef.current;
         if (!textView) return;
         const buffer = textView.getBuffer();
         if (!buffer) return;
+
+        const handleParsingError = (section: Gtk.CssSection, error: GLib.Error) =>
+            markParsingError({
+                textView: textViewRef.current,
+                section,
+                error,
+                warningTag: warningTagRef.current,
+                errorTag: errorTagRef.current,
+            });
 
         setupTags({ buffer, errorTagRef, warningTagRef });
         const cleanup = setupProvider({
@@ -123,7 +120,7 @@ export function useCssEditor(defaultCss: string) {
         });
         providerRef.current?.loadFromString(defaultCss);
         return cleanup;
-    }, [defaultCss, handleParsingError]);
+    }, [defaultCss]);
 
     return { textViewRef, onBufferChanged };
 }

--- a/examples/gtk-demo/src/demos/dialogs/pickers.tsx
+++ b/examples/gtk-demo/src/demos/dialogs/pickers.tsx
@@ -12,7 +12,7 @@ import {
     GtkGridChild,
     GtkLabel,
 } from "@gtkx/react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type { Demo, DemoProps } from "../types.js";
 import sourceCode from "./pickers.tsx?raw";
 
@@ -25,12 +25,12 @@ function useFilePickerState() {
     const [fileName, setFileName] = useState("None");
     const [isPdf, setIsPdf] = useState(false);
 
-    const setFile = useCallback((file: Gio.File) => {
+    const setFile = (file: Gio.File) => {
         setSelectedFile(file);
         setFileName(file.getBasename() ?? file.getUri() ?? "");
         const info = file.queryInfo("standard::content-type", 0, null);
         setIsPdf(info.getContentType() === "application/pdf");
-    }, []);
+    };
 
     return { selectedFile, setSelectedFile, fileName, setFileName, isPdf, setIsPdf, setFile };
 }
@@ -60,18 +60,15 @@ const launchFile = async (selectedFile: Gio.File | null, action: (launcher: Gtk.
 function useDropAndOpenHandlers(window: React.RefObject<Gtk.Window | null>, state: FilePickerState) {
     const { setFile, setSelectedFile, setFileName, setIsPdf } = state;
 
-    const handleFileDrop = useCallback(
-        (value: GObject.Value) => {
-            if (!GObject.typeCheckValueHolds(value, gfileType)) return false;
-            const file = value.getObject();
-            if (file && file instanceof Gio.File) {
-                setFile(file);
-                return true;
-            }
-            return false;
-        },
-        [setFile],
-    );
+    const handleFileDrop = (value: GObject.Value) => {
+        if (!GObject.typeCheckValueHolds(value, gfileType)) return false;
+        const file = value.getObject();
+        if (file && file instanceof Gio.File) {
+            setFile(file);
+            return true;
+        }
+        return false;
+    };
 
     const handleOpenFile = async () => {
         await runWithTimeout(async (cancellable) => {
@@ -94,23 +91,17 @@ function useDropAndOpenHandlers(window: React.RefObject<Gtk.Window | null>, stat
 function useFileLaunchHandlers(window: React.RefObject<Gtk.Window | null>, state: FilePickerState) {
     const { selectedFile, isPdf } = state;
 
-    const handleLaunchApp = useCallback(
-        () =>
-            launchFile(selectedFile, async (l) => {
-                await l.launch(window.current, null);
-            }),
-        [window, selectedFile],
-    );
+    const handleLaunchApp = () =>
+        launchFile(selectedFile, async (l) => {
+            await l.launch(window.current, null);
+        });
 
-    const handleOpenFolder = useCallback(
-        () =>
-            launchFile(selectedFile, async (l) => {
-                await l.openContainingFolder(window.current, null);
-            }),
-        [window, selectedFile],
-    );
+    const handleOpenFolder = () =>
+        launchFile(selectedFile, async (l) => {
+            await l.openContainingFolder(window.current, null);
+        });
 
-    const handlePrintFile = useCallback(async () => {
+    const handlePrintFile = async () => {
         if (!selectedFile || !isPdf) return;
         await runWithTimeout(async (cancellable) => {
             try {
@@ -120,16 +111,16 @@ function useFileLaunchHandlers(window: React.RefObject<Gtk.Window | null>, state
                 if (e instanceof Error) console.error(e.message);
             }
         });
-    }, [window, selectedFile, isPdf]);
+    };
 
-    const handleLaunchUri = useCallback(async () => {
+    const handleLaunchUri = async () => {
         try {
             const launcher = Gtk.UriLauncher.new("http://www.gtk.org");
             await launcher.launch(window.current, null);
         } catch (e) {
             if (e instanceof Error) console.error(e.message);
         }
-    }, [window]);
+    };
 
     return { handleLaunchApp, handleOpenFolder, handlePrintFile, handleLaunchUri };
 }

--- a/examples/gtk-demo/src/demos/drawing/drawingarea.tsx
+++ b/examples/gtk-demo/src/demos/drawing/drawingarea.tsx
@@ -1,7 +1,7 @@
 import { Content, Context, Format, ImageSurface, Operator, Surface } from "@gtkx/gi/cairo";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkDrawingArea, GtkFrame, GtkGestureDrag, GtkLabel } from "@gtkx/react";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./drawingarea.tsx?raw";
 
@@ -127,29 +127,23 @@ function useScribbleHandlers(
     surfaceRef: React.RefObject<ImageSurface | null>,
     startPointRef: React.RefObject<{ x: number; y: number }>,
 ) {
-    const handleDragBegin = useCallback(
-        (startX: number, startY: number) => {
-            startPointRef.current = { x: startX, y: startY };
-            if (surfaceRef.current && ref.current) {
-                drawBrush(surfaceRef.current, ref.current, startX, startY);
-            }
-        },
-        [ref, surfaceRef, startPointRef],
-    );
+    const handleDragBegin = (startX: number, startY: number) => {
+        startPointRef.current = { x: startX, y: startY };
+        if (surfaceRef.current && ref.current) {
+            drawBrush(surfaceRef.current, ref.current, startX, startY);
+        }
+    };
 
-    const handleDragOffset = useCallback(
-        (offsetX: number, offsetY: number) => {
-            if (surfaceRef.current && ref.current) {
-                drawBrush(
-                    surfaceRef.current,
-                    ref.current,
-                    startPointRef.current.x + offsetX,
-                    startPointRef.current.y + offsetY,
-                );
-            }
-        },
-        [ref, surfaceRef, startPointRef],
-    );
+    const handleDragOffset = (offsetX: number, offsetY: number) => {
+        if (surfaceRef.current && ref.current) {
+            drawBrush(
+                surfaceRef.current,
+                ref.current,
+                startPointRef.current.x + offsetX,
+                startPointRef.current.y + offsetY,
+            );
+        }
+    };
 
     return { handleDragBegin, handleDragUpdate: handleDragOffset, handleDragEnd: handleDragOffset };
 }
@@ -159,16 +153,16 @@ const ScribbleArea = ({ accessibleLabelledBy }: { accessibleLabelledBy?: Gtk.Wid
     const surfaceRef = useRef<ImageSurface | null>(null);
     const startPointRef = useRef({ x: 0, y: 0 });
 
-    const handleResize = useCallback((width: number, height: number) => {
+    const handleResize = (width: number, height: number) => {
         surfaceRef.current = createSurface(width, height);
-    }, []);
+    };
 
-    const drawScribble = useCallback((cr: Context) => {
+    const drawScribble = (cr: Context) => {
         if (surfaceRef.current) {
             cr.setSourceSurface(surfaceRef.current, 0, 0);
             cr.paint();
         }
-    }, []);
+    };
 
     const { handleDragBegin, handleDragUpdate, handleDragEnd } = useScribbleHandlers(ref, surfaceRef, startPointRef);
 

--- a/examples/gtk-demo/src/demos/drawing/images.tsx
+++ b/examples/gtk-demo/src/demos/drawing/images.tsx
@@ -1,7 +1,7 @@
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkFrame, GtkImage, GtkLabel, GtkPicture, GtkSwitch, GtkToggleButton, GtkVideo } from "@gtkx/react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { path as floppybuddyGifPath } from "../gestures/floppybuddy.gif";
 import gtkLogoWebmUri from "../media/gtk-logo.webm";
 import type { Demo, DemoProps } from "../types.js";
@@ -53,7 +53,7 @@ const ImagesPanel = ({ title, children }: { title: string; children: React.React
 );
 
 const StatefulIconPanel = () => {
-    const svg = useMemo(() => loadSvgPaintable(statefulSvgPath), []);
+    const [svg] = useState(() => loadSvgPaintable(statefulSvgPath));
     const [state, setState] = useState(false);
 
     return (
@@ -75,7 +75,7 @@ const StatefulIconPanel = () => {
 };
 
 const PathAnimationPanel = () => {
-    const svg = useMemo(() => loadSvgPaintable(animatedSvgPath), []);
+    const [svg] = useState(() => loadSvgPaintable(animatedSvgPath));
 
     return (
         <ImagesPanel title="Path animation">
@@ -88,7 +88,7 @@ const ImagesDemo = ({ window }: DemoProps) => {
     const [widgetPaintable, setWidgetPaintable] = useState<Gtk.WidgetPaintable | null>(null);
     const gifPaintable = useGifPaintable();
     const [insensitive, setInsensitive] = useState(false);
-    const videoFile = useMemo(() => Gio.fileNewForUri(gtkLogoWebmUri), []);
+    const videoFile = Gio.fileNewForUri(gtkLogoWebmUri);
 
     useEffect(() => {
         const win = window.current;

--- a/examples/gtk-demo/src/demos/drawing/paintable-svg.tsx
+++ b/examples/gtk-demo/src/demos/drawing/paintable-svg.tsx
@@ -1,7 +1,7 @@
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkButton, GtkGestureClick, GtkHeaderBar, GtkPicture } from "@gtkx/react";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import nodeEditorSvgUri from "./org.gtk.gtk4.NodeEditor.Devel.svg";
 import sourceCode from "./paintable-svg.tsx?raw";
@@ -53,17 +53,17 @@ const usePaintableSvgContext = (): PaintableSvgContextValue => {
 const PaintableSvgProvider = ({ window, children }: DemoProviderProps) => {
     const [svg, setSvg] = useState<Gtk.Svg | null>(() => loadSvgFromFile(Gio.fileNewForUri(nodeEditorSvgUri)));
 
-    const handleOpen = useCallback(async () => {
+    const handleOpen = async () => {
         const file = await pickSvgFile(window.current);
         if (!file) return;
         const next = loadSvgFromFile(file);
         if (next) setSvg(next);
-    }, [window]);
+    };
 
-    const value = useMemo<PaintableSvgContextValue>(
-        () => ({ svg, handleOpen: () => void handleOpen() }),
-        [svg, handleOpen],
-    );
+    const value = {
+        svg,
+        handleOpen: () => void handleOpen(),
+    };
     return <PaintableSvgContext.Provider value={value}>{children}</PaintableSvgContext.Provider>;
 };
 
@@ -80,11 +80,11 @@ const PaintableSvgTitlebar = () => {
 const PaintableSvgDemo = () => {
     const { svg } = usePaintableSvgContext();
 
-    const handlePressed = useCallback(() => {
+    const handlePressed = () => {
         if (!svg) return;
         const state = svg.getState();
         svg.setState(state < 63 ? state + 1 : 0);
-    }, [svg]);
+    };
 
     return (
         <GtkPicture name="picture" paintable={svg} widthRequest={16} heightRequest={16}>

--- a/examples/gtk-demo/src/demos/games/listview-minesweeper.tsx
+++ b/examples/gtk-demo/src/demos/games/listview-minesweeper.tsx
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkButton, GtkGridView, GtkHeaderBar, GtkImage, GtkLabel } from "@gtkx/react";
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./listview-minesweeper.tsx?raw";
 
@@ -127,38 +127,37 @@ const MinesweeperProvider = ({ children }: DemoProviderProps) => {
     const [gameState, setGameState] = useState<GameState>("playing");
     const soundStreamRef = useRef<Gtk.MediaFile | null>(null);
 
-    const playSound = useCallback((win: boolean) => playGameSound(win, soundStreamRef), []);
+    const playSound = (win: boolean) => playGameSound(win, soundStreamRef);
 
-    const handleCellClick = useCallback(
-        (index: number) => {
-            if (gameState !== "playing") return;
-            const cell = board[index];
-            if (!cell || cell.isRevealed) return;
+    const handleCellClick = (index: number) => {
+        if (gameState !== "playing") return;
+        const cell = board[index];
+        if (!cell || cell.isRevealed) return;
 
-            const newBoard = revealCell(index, board);
-            setBoard(newBoard);
+        const newBoard = revealCell(index, board);
+        setBoard(newBoard);
 
-            const result = evaluateBoard(newBoard, index);
-            if (result === "lost") {
-                setGameState("lost");
-                playSound(false);
-            } else if (result === "won") {
-                setGameState("won");
-                playSound(true);
-            }
-        },
-        [board, gameState, playSound],
-    );
+        const result = evaluateBoard(newBoard, index);
+        if (result === "lost") {
+            setGameState("lost");
+            playSound(false);
+        } else if (result === "won") {
+            setGameState("won");
+            playSound(true);
+        }
+    };
 
-    const resetGame = useCallback(() => {
+    const resetGame = () => {
         setBoard(createBoard());
         setGameState("playing");
-    }, []);
+    };
 
-    const value = useMemo<MinesweeperContextValue>(
-        () => ({ board, gameState, handleCellClick, resetGame }),
-        [board, gameState, handleCellClick, resetGame],
-    );
+    const value = {
+        board,
+        gameState,
+        handleCellClick,
+        resetGame,
+    };
 
     return <MinesweeperContext.Provider value={value}>{children}</MinesweeperContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/gestures/clipboard.tsx
+++ b/examples/gtk-demo/src/demos/gestures/clipboard.tsx
@@ -20,7 +20,7 @@ import {
     GtkStackPage,
     GtkToggleButton,
 } from "@gtkx/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import type { Demo, DemoProps } from "../types.js";
 import sourceCode from "./clipboard.tsx?raw";
 import { path as floppyBuddyPath } from "./floppybuddy.gif";
@@ -103,9 +103,9 @@ function useClipboardState() {
 type ClipboardState = ReturnType<typeof useClipboardState>;
 
 function useClipboardTextures() {
-    const portlandRoseTexture = useMemo(() => Gdk.Texture.newFromResource(portlandRosePath), []);
-    const floppyBuddyTexture = useMemo(() => Gdk.Texture.newFromResource(floppyBuddyPath), []);
-    const demo4LogoTexture = useMemo(() => Gdk.Texture.newFromResource(demo4LogoPath), []);
+    const portlandRoseTexture = Gdk.Texture.newFromResource(portlandRosePath);
+    const floppyBuddyTexture = Gdk.Texture.newFromResource(floppyBuddyPath);
+    const demo4LogoTexture = Gdk.Texture.newFromResource(demo4LogoPath);
     return { portlandRoseTexture, floppyBuddyTexture, demo4LogoTexture };
 }
 
@@ -134,17 +134,13 @@ function useClipboardChangedListener(setCanPaste: (canPaste: boolean) => void) {
 function useDragProviders(state: ClipboardState) {
     const { sourceText, sourceColor, selectedImage, sourceFile } = state;
 
-    const createTextDragProvider = useCallback(
-        () => Gdk.ContentProvider.newForValue(GObject.buildValue(GObject.Type.STRING, (v) => v.setString(sourceText))),
-        [sourceText],
-    );
+    const createTextDragProvider = () =>
+        Gdk.ContentProvider.newForValue(GObject.buildValue(GObject.Type.STRING, (v) => v.setString(sourceText)));
 
-    const createColorDragProvider = useCallback(
-        () => Gdk.ContentProvider.newForValue(GObject.buildValue(gdkRgbaType, (v) => v.setBoxed(sourceColor))),
-        [sourceColor],
-    );
+    const createColorDragProvider = () =>
+        Gdk.ContentProvider.newForValue(GObject.buildValue(gdkRgbaType, (v) => v.setBoxed(sourceColor)));
 
-    const createImageDragProvider = useCallback(() => {
+    const createImageDragProvider = () => {
         const path = imagePathForIndex(selectedImage);
         try {
             const texture = Gdk.Texture.newFromResource(path);
@@ -153,12 +149,12 @@ function useDragProviders(state: ClipboardState) {
             if (e instanceof Error) console.error(e.message);
             return null;
         }
-    }, [selectedImage]);
+    };
 
-    const createFileDragProvider = useCallback(() => {
+    const createFileDragProvider = () => {
         if (!sourceFile) return null;
         return Gdk.ContentProvider.newForValue(GObject.buildValue(gfileType, (v) => v.setObject(sourceFile)));
-    }, [sourceFile]);
+    };
 
     return { createTextDragProvider, createColorDragProvider, createImageDragProvider, createFileDragProvider };
 }
@@ -202,7 +198,7 @@ const copyFileToClipboard = (clipboard: Gdk.Clipboard, sourceFile: Gio.File) =>
 function useClipboardHandlers(state: ClipboardState, window: React.RefObject<Gtk.Window | null>) {
     const { sourceType, sourceText, sourceColor, selectedImage, sourceFile, setSourceFile, setPastedContent } = state;
 
-    const handleCopy = useCallback(() => {
+    const handleCopy = () => {
         const clipboard = getClipboard();
         if (!clipboard) return;
         if (sourceType === "Text") copyTextToClipboard(clipboard, sourceText);
@@ -210,9 +206,9 @@ function useClipboardHandlers(state: ClipboardState, window: React.RefObject<Gtk
         else if (sourceType === "Image") copyImageToClipboard(clipboard, selectedImage);
         else if ((sourceType === "File" || sourceType === "Folder") && sourceFile)
             copyFileToClipboard(clipboard, sourceFile);
-    }, [sourceType, sourceText, sourceColor, selectedImage, sourceFile]);
+    };
 
-    const handlePaste = useCallback(async () => {
+    const handlePaste = async () => {
         const clipboard = getClipboard();
         if (!clipboard) return;
         const formats = clipboard.getFormats();
@@ -225,22 +221,13 @@ function useClipboardHandlers(state: ClipboardState, window: React.RefObject<Gtk
         } catch (e) {
             if (e instanceof Error) console.error(e.message);
         }
-    }, [setPastedContent]);
+    };
 
-    const handleFileSelect = useCallback(
-        () => openFileDialog(window.current, "file", setSourceFile),
-        [window, setSourceFile],
-    );
+    const handleFileSelect = () => openFileDialog(window.current, "file", setSourceFile);
 
-    const handleFolderSelect = useCallback(
-        () => openFileDialog(window.current, "folder", setSourceFile),
-        [window, setSourceFile],
-    );
+    const handleFolderSelect = () => openFileDialog(window.current, "folder", setSourceFile);
 
-    const handleDrop = useCallback(
-        (value: GObject.Value) => handleClipboardDrop(value, setPastedContent),
-        [setPastedContent],
-    );
+    const handleDrop = (value: GObject.Value) => handleClipboardDrop(value, setPastedContent);
 
     return { handleCopy, handlePaste, handleFileSelect, handleFolderSelect, handleDrop };
 }

--- a/examples/gtk-demo/src/demos/gestures/cursors.tsx
+++ b/examples/gtk-demo/src/demos/gestures/cursors.tsx
@@ -1,7 +1,6 @@
 import * as Gdk from "@gtkx/gi/gdk";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkFrame, GtkImage, GtkLabel, GtkListBox, GtkListBoxRow, GtkScrolledWindow } from "@gtkx/react";
-import { useMemo } from "react";
 import { useCssResource } from "../../use-css-resource.js";
 import type { Demo } from "../types.js";
 import { path as aliasPath } from "./cursors/alias_cursor.png";
@@ -157,7 +156,7 @@ const buildCursorTooltips = (info: CursorInfo): readonly [string, string, string
           ];
 
 const CursorPreview = ({ info }: { info: CursorInfo }) => {
-    const texture = useMemo(() => getCursorTexture(info), [info]);
+    const texture = getCursorTexture(info);
     return <GtkImage paintable={texture} />;
 };
 
@@ -166,8 +165,8 @@ const CursorFrame = ({ cursor, tooltip }: { cursor: Gdk.Cursor; tooltip: string 
 );
 
 const CursorRow = ({ info }: { info: CursorInfo }) => {
-    const cursors = useMemo(() => buildCursorVariants(info), [info]);
-    const tooltips = useMemo(() => buildCursorTooltips(info), [info]);
+    const cursors = buildCursorVariants(info);
+    const tooltips = buildCursorTooltips(info);
     return (
         <GtkListBoxRow activatable={false}>
             <GtkBox spacing={10} marginStart={10} marginEnd={10} marginTop={10} marginBottom={10}>

--- a/examples/gtk-demo/src/demos/gestures/dnd.tsx
+++ b/examples/gtk-demo/src/demos/gestures/dnd.tsx
@@ -23,7 +23,7 @@ import {
     GtkSeparator,
     useAdjustment,
 } from "@gtkx/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useContextMenuGesture } from "../../use-context-menu-gesture.js";
 import { useImperativeDragVisibility } from "../../use-imperative-drag-visibility.js";
 import type { Demo } from "../types.js";
@@ -153,11 +153,11 @@ function ColorSwatch({ color }: Readonly<{ color: string }>) {
         background-color: ${color};
     `;
 
-    const createColorProvider = useCallback(() => {
+    const createColorProvider = () => {
         const rgba = new Gdk.RGBA();
         rgba.parse(color);
         return Gdk.ContentProvider.newForValue(GObject.buildValue(gdkRgbaType, (v) => v.setBoxed(rgba)));
-    }, [color]);
+    };
 
     return (
         <GtkBox name={`swatch-${color}`} cssClasses={[swatchStyle, dynamicStyle]}>
@@ -167,9 +167,9 @@ function ColorSwatch({ color }: Readonly<{ color: string }>) {
 }
 
 function CssPatternSwatch({ id, cssClass }: Readonly<{ id: string; cssClass: string }>) {
-    const createClassProvider = useCallback(() => {
+    const createClassProvider = () => {
         return Gdk.ContentProvider.newForValue(GObject.buildValue(GObject.Type.STRING, (v) => v.setString(cssClass)));
-    }, [cssClass]);
+    };
 
     return (
         <GtkBox name={`pattern-${id}`} cssClasses={[swatchStyle, cssClass]}>
@@ -235,10 +235,7 @@ function useDndState() {
         refs,
     });
 
-    const editingItem = useMemo(
-        () => (editState ? items.find((i) => i.id === editState.itemId) : null),
-        [editState, items],
-    );
+    const editingItem = editState ? items.find((i) => i.id === editState.itemId) : null;
 
     return {
         items,
@@ -338,28 +335,17 @@ function useItemHandlers(args: DndHandlerArgs) {
 function useItemEditHandlers(args: DndHandlerArgs) {
     const { setItems } = args;
 
-    const createContentProvider = useCallback(
-        (itemId: string) =>
-            Gdk.ContentProvider.newForValue(GObject.buildValue(GObject.Type.STRING, (v) => v.setString(itemId))),
-        [],
-    );
+    const createContentProvider = (itemId: string) =>
+        Gdk.ContentProvider.newForValue(GObject.buildValue(GObject.Type.STRING, (v) => v.setString(itemId)));
 
-    const toggleEditing = useCallback(
-        (itemId: string) => args.setEditState(args.contextMenu?.itemId === itemId ? null : { itemId }),
-        [args],
-    );
+    const toggleEditing = (itemId: string) =>
+        args.setEditState(args.contextMenu?.itemId === itemId ? null : { itemId });
 
-    const updateItemLabel = useCallback(
-        (itemId: string, label: string) =>
-            setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, label } : item))),
-        [setItems],
-    );
+    const updateItemLabel = (itemId: string, label: string) =>
+        setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, label } : item)));
 
-    const updateItemAngle = useCallback(
-        (itemId: string, angle: number) =>
-            setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, angle } : item))),
-        [setItems],
-    );
+    const updateItemAngle = (itemId: string, angle: number) =>
+        setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, angle } : item)));
 
     return { createContentProvider, toggleEditing, updateItemLabel, updateItemAngle };
 }
@@ -367,29 +353,18 @@ function useItemEditHandlers(args: DndHandlerArgs) {
 function useItemRotateHandlers(args: DndHandlerArgs) {
     const { setItems } = args;
 
-    const updateItemAngleDelta = useCallback(
-        (itemId: string, angleDeltaDeg: number) =>
-            setItems((prev) =>
-                prev.map((item) => (item.id === itemId ? { ...item, angleDelta: angleDeltaDeg } : item)),
-            ),
-        [setItems],
-    );
+    const updateItemAngleDelta = (itemId: string, angleDeltaDeg: number) =>
+        setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, angleDelta: angleDeltaDeg } : item)));
 
-    const handleRotateAngleChanged = useCallback(
-        (itemId: string) => (_angle: number, angleDelta: number) =>
-            updateItemAngleDelta(itemId, (angleDelta * 180) / Math.PI),
-        [updateItemAngleDelta],
-    );
+    const handleRotateAngleChanged = (itemId: string) => (_angle: number, angleDelta: number) =>
+        updateItemAngleDelta(itemId, (angleDelta * 180) / Math.PI);
 
-    const handleRotateEnd = useCallback(
-        (itemId: string) =>
-            setItems((prev) =>
-                prev.map((item) =>
-                    item.id === itemId ? { ...item, angle: item.angle + item.angleDelta, angleDelta: 0 } : item,
-                ),
+    const handleRotateEnd = (itemId: string) =>
+        setItems((prev) =>
+            prev.map((item) =>
+                item.id === itemId ? { ...item, angle: item.angle + item.angleDelta, angleDelta: 0 } : item,
             ),
-        [setItems],
-    );
+        );
 
     return { handleRotateAngleChanged, handleRotateEnd };
 }
@@ -397,28 +372,22 @@ function useItemRotateHandlers(args: DndHandlerArgs) {
 function useItemDragHandlers(args: DndHandlerArgs) {
     const { setItems, refs } = args;
 
-    const bringToFront = useCallback(
-        (itemId: string) =>
-            setItems((prev) => {
-                const idx = prev.findIndex((i) => i.id === itemId);
-                if (idx === -1 || idx === prev.length - 1) return prev;
-                const item = prev[idx];
-                if (!item) return prev;
-                return [...prev.slice(0, idx), ...prev.slice(idx + 1), item];
-            }),
-        [setItems],
-    );
+    const bringToFront = (itemId: string) =>
+        setItems((prev) => {
+            const idx = prev.findIndex((i) => i.id === itemId);
+            if (idx === -1 || idx === prev.length - 1) return prev;
+            const item = prev[idx];
+            if (!item) return prev;
+            return [...prev.slice(0, idx), ...prev.slice(idx + 1), item];
+        });
 
-    const setDragIcon = useCallback(
-        (itemId: string, source: Gtk.DragSource) => {
-            const button = refs.buttonRefs.current.get(itemId);
-            if (!button) return;
-            const paintable = Gtk.WidgetPaintable.new(button);
-            const { x, y } = refs.dragHotspotRef.current;
-            source.setIcon(paintable, x, y);
-        },
-        [refs],
-    );
+    const setDragIcon = (itemId: string, source: Gtk.DragSource) => {
+        const button = refs.buttonRefs.current.get(itemId);
+        if (!button) return;
+        const paintable = Gtk.WidgetPaintable.new(button);
+        const { x, y } = refs.dragHotspotRef.current;
+        source.setIcon(paintable, x, y);
+    };
 
     return { bringToFront, setDragIcon };
 }
@@ -426,20 +395,17 @@ function useItemDragHandlers(args: DndHandlerArgs) {
 function useContextMenuHandlers(args: DndHandlerArgs) {
     const { items, setItems, contextMenu, setContextMenu, setEditState, refs } = args;
 
-    const handleContextMenu = useCallback(
-        (clickX: number, clickY: number) => {
-            const hitItem = items.find((item) => {
-                const r = refs.itemRadii.current.get(item.id) ?? ITEM_SIZE;
-                const size = 2 * r;
-                return clickX >= item.x && clickX <= item.x + size && clickY >= item.y && clickY <= item.y + size;
-            });
-            setContextMenu({ x: clickX, y: clickY, itemId: hitItem?.id ?? null });
-            setTimeout(() => refs.contextMenuRef.current?.popup(), 0);
-        },
-        [items, setContextMenu, refs],
-    );
+    const handleContextMenu = (clickX: number, clickY: number) => {
+        const hitItem = items.find((item) => {
+            const r = refs.itemRadii.current.get(item.id) ?? ITEM_SIZE;
+            const size = 2 * r;
+            return clickX >= item.x && clickX <= item.x + size && clickY >= item.y && clickY <= item.y + size;
+        });
+        setContextMenu({ x: clickX, y: clickY, itemId: hitItem?.id ?? null });
+        setTimeout(() => refs.contextMenuRef.current?.popup(), 0);
+    };
 
-    const handleAddItem = useCallback(() => {
+    const handleAddItem = () => {
         if (!contextMenu) return;
         const id = String(nextItemNumber);
         const label = `Item ${nextItemNumber}`;
@@ -450,20 +416,20 @@ function useContextMenuHandlers(args: DndHandlerArgs) {
         ]);
         refs.contextMenuRef.current?.popdown();
         setContextMenu(null);
-    }, [contextMenu, setItems, setContextMenu, refs]);
+    };
 
-    const handleEditItem = useCallback(() => {
+    const handleEditItem = () => {
         if (!contextMenu?.itemId) return;
         setEditState({ itemId: contextMenu.itemId });
         refs.contextMenuRef.current?.popdown();
-    }, [contextMenu, setEditState, refs]);
+    };
 
-    const handleDeleteItem = useCallback(() => {
+    const handleDeleteItem = () => {
         if (!contextMenu?.itemId) return;
         setItems((prev) => prev.filter((item) => item.id !== contextMenu.itemId));
         refs.contextMenuRef.current?.popdown();
         setContextMenu(null);
-    }, [contextMenu, setItems, setContextMenu, refs]);
+    };
 
     return { handleContextMenu, handleAddItem, handleEditItem, handleDeleteItem };
 }
@@ -471,50 +437,39 @@ function useContextMenuHandlers(args: DndHandlerArgs) {
 function useDropHandlers(args: DndHandlerArgs) {
     const { setItems, setTrashHovering, refs } = args;
 
-    const handleCanvasDrop = useCallback(
-        (value: GObject.Value, x: number, y: number) => {
-            const itemId = value.getString();
-            if (itemId) {
-                const r = refs.itemRadii.current.get(itemId) ?? 0;
-                setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, x: x - r, y: y - r } : item)));
-            }
-            return true;
-        },
-        [setItems, refs],
-    );
+    const handleCanvasDrop = (value: GObject.Value, x: number, y: number) => {
+        const itemId = value.getString();
+        if (itemId) {
+            const r = refs.itemRadii.current.get(itemId) ?? 0;
+            setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, x: x - r, y: y - r } : item)));
+        }
+        return true;
+    };
 
-    const handleTrashDrop = useCallback(
-        (value: GObject.Value) => {
-            const itemId = value.getString();
-            if (itemId) setItems((prev) => prev.filter((item) => item.id !== itemId));
-            setTrashHovering(false);
-            return true;
-        },
-        [setItems, setTrashHovering],
-    );
+    const handleTrashDrop = (value: GObject.Value) => {
+        const itemId = value.getString();
+        if (itemId) setItems((prev) => prev.filter((item) => item.id !== itemId));
+        setTrashHovering(false);
+        return true;
+    };
 
-    const handleItemColorDrop = useCallback(
-        (itemId: string, value: GObject.Value) => {
-            const rgba = value.getBoxed<Gdk.RGBA>();
-            if (rgba instanceof Gdk.RGBA) {
-                const cssColor = rgba.toString() ?? "transparent";
-                setItems((prev) =>
-                    prev.map((item) => (item.id === itemId ? { ...item, style: { type: "rgba", cssColor } } : item)),
-                );
-                return true;
-            }
-            const className = value.getString();
-            if (className) {
-                setItems((prev) =>
-                    prev.map((item) =>
-                        item.id === itemId ? { ...item, style: { type: "cssClass", className } } : item,
-                    ),
-                );
-            }
+    const handleItemColorDrop = (itemId: string, value: GObject.Value) => {
+        const rgba = value.getBoxed<Gdk.RGBA>();
+        if (rgba instanceof Gdk.RGBA) {
+            const cssColor = rgba.toString() ?? "transparent";
+            setItems((prev) =>
+                prev.map((item) => (item.id === itemId ? { ...item, style: { type: "rgba", cssColor } } : item)),
+            );
             return true;
-        },
-        [setItems],
-    );
+        }
+        const className = value.getString();
+        if (className) {
+            setItems((prev) =>
+                prev.map((item) => (item.id === itemId ? { ...item, style: { type: "cssClass", className } } : item)),
+            );
+        }
+        return true;
+    };
 
     return { handleCanvasDrop, handleTrashDrop, handleItemColorDrop };
 }
@@ -648,7 +603,7 @@ const loadTrashPaintable = (): Gtk.Svg => {
 };
 
 const DndTrashZone = ({ boxRef, trashHovering, setTrashHovering, handleTrashDrop }: DndTrashZoneProps) => {
-    const svg = useMemo(loadTrashPaintable, []);
+    const [svg] = useState(loadTrashPaintable);
 
     const attachFrameClockAndPlay = (image: Gtk.Widget) => {
         const frameClock = image.getFrameClock();

--- a/examples/gtk-demo/src/demos/gestures/gestures.tsx
+++ b/examples/gtk-demo/src/demos/gestures/gestures.tsx
@@ -2,7 +2,7 @@ import type { Context } from "@gtkx/gi/cairo";
 import { Pattern } from "@gtkx/gi/cairo";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkDrawingArea, GtkGestureLongPress, GtkGestureRotate, GtkGestureSwipe, GtkGestureZoom } from "@gtkx/react";
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./gestures.tsx?raw";
 
@@ -13,24 +13,21 @@ interface GestureState {
 }
 
 function useGesturesHandlers(gestureStateRef: React.RefObject<GestureState>, queueDraw: () => void) {
-    const handleSwipe = useCallback(
-        (velocityX: number, velocityY: number) => {
-            gestureStateRef.current.swipeX = velocityX / 10;
-            gestureStateRef.current.swipeY = velocityY / 10;
-            queueDraw();
-        },
-        [queueDraw, gestureStateRef],
-    );
+    const handleSwipe = (velocityX: number, velocityY: number) => {
+        gestureStateRef.current.swipeX = velocityX / 10;
+        gestureStateRef.current.swipeY = velocityY / 10;
+        queueDraw();
+    };
 
-    const handleLongPressPressed = useCallback(() => {
+    const handleLongPressPressed = () => {
         gestureStateRef.current.longPressed = true;
         queueDraw();
-    }, [queueDraw, gestureStateRef]);
+    };
 
-    const handleLongPressEnd = useCallback(() => {
+    const handleLongPressEnd = () => {
         gestureStateRef.current.longPressed = false;
         queueDraw();
-    }, [queueDraw, gestureStateRef]);
+    };
 
     return { handleSwipe, handleLongPressPressed, handleLongPressEnd };
 }
@@ -114,11 +111,11 @@ const GesturesDemo = () => {
     const zoomRef = useRef<Gtk.GestureZoom | null>(null);
     const drawingAreaRef = useRef<Gtk.DrawingArea | null>(null);
 
-    const queueDraw = useCallback(() => drawingAreaRef.current?.queueDraw(), []);
+    const queueDraw = () => drawingAreaRef.current?.queueDraw();
 
     const handlers = useGesturesHandlers(gestureStateRef, queueDraw);
 
-    const drawFunc = useCallback((cr: Context, width: number, height: number) => {
+    const drawFunc = (cr: Context, width: number, height: number) => {
         drawGestures(cr, {
             width,
             height,
@@ -126,7 +123,7 @@ const GesturesDemo = () => {
             rotate: rotateRef.current,
             zoom: zoomRef.current,
         });
-    }, []);
+    };
 
     return (
         <GtkDrawingArea

--- a/examples/gtk-demo/src/demos/input/hypertext.tsx
+++ b/examples/gtk-demo/src/demos/input/hypertext.tsx
@@ -16,7 +16,7 @@ import {
     GtkTextView,
 } from "@gtkx/react";
 import type { ReactNode } from "react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./hypertext.tsx?raw";
 
@@ -192,27 +192,24 @@ function useClickHandler(
     findLinkAtOffset: (offset: number) => number | null,
     setCurrentPage: (page: number) => void,
 ) {
-    return useCallback(
-        (_nPress: number, clickX: number, clickY: number) => {
-            const textView = textViewRef.current;
-            if (!textView) return;
-            const buffer = textView.getBuffer();
-            const [, startIter, endIter] = buffer.getSelectionBounds();
-            if (startIter.getOffset() !== endIter.getOffset()) return;
+    return (_nPress: number, clickX: number, clickY: number) => {
+        const textView = textViewRef.current;
+        if (!textView) return;
+        const buffer = textView.getBuffer();
+        const [, startIter, endIter] = buffer.getSelectionBounds();
+        if (startIter.getOffset() !== endIter.getOffset()) return;
 
-            const [bufferX, bufferY] = textView.windowToBufferCoords(
-                Gtk.TextWindowType.WIDGET,
-                Math.trunc(clickX),
-                Math.trunc(clickY),
-            );
-            const [result, iter] = textView.getIterAtPosition(bufferX, bufferY);
-            if (!result) return;
+        const [bufferX, bufferY] = textView.windowToBufferCoords(
+            Gtk.TextWindowType.WIDGET,
+            Math.trunc(clickX),
+            Math.trunc(clickY),
+        );
+        const [result, iter] = textView.getIterAtPosition(bufferX, bufferY);
+        if (!result) return;
 
-            const targetPage = findLinkAtOffset(iter.getOffset());
-            if (targetPage !== null) setCurrentPage(targetPage);
-        },
-        [textViewRef, findLinkAtOffset, setCurrentPage],
-    );
+        const targetPage = findLinkAtOffset(iter.getOffset());
+        if (targetPage !== null) setCurrentPage(targetPage);
+    };
 }
 
 function useMotionHandler(
@@ -220,31 +217,28 @@ function useMotionHandler(
     findLinkAtOffset: (offset: number) => number | null,
     hoveringRef: React.RefObject<boolean>,
 ) {
-    return useCallback(
-        (motionX: number, motionY: number) => {
-            const textView = textViewRef.current;
-            if (!textView) return;
-            const [bufferX, bufferY] = textView.windowToBufferCoords(
-                Gtk.TextWindowType.WIDGET,
-                Math.trunc(motionX),
-                Math.trunc(motionY),
-            );
-            const [result, iter] = textView.getIterAtPosition(bufferX, bufferY);
-            if (!result) {
-                if (hoveringRef.current) {
-                    textView.setCursor(Gdk.Cursor.newFromName("text", null));
-                    hoveringRef.current = false;
-                }
-                return;
+    return (motionX: number, motionY: number) => {
+        const textView = textViewRef.current;
+        if (!textView) return;
+        const [bufferX, bufferY] = textView.windowToBufferCoords(
+            Gtk.TextWindowType.WIDGET,
+            Math.trunc(motionX),
+            Math.trunc(motionY),
+        );
+        const [result, iter] = textView.getIterAtPosition(bufferX, bufferY);
+        if (!result) {
+            if (hoveringRef.current) {
+                textView.setCursor(Gdk.Cursor.newFromName("text", null));
+                hoveringRef.current = false;
             }
-            const overLink = findLinkAtOffset(iter.getOffset()) !== null;
-            if (overLink !== hoveringRef.current) {
-                hoveringRef.current = overLink;
-                textView.setCursor(Gdk.Cursor.newFromName(overLink ? "pointer" : "text", null));
-            }
-        },
-        [textViewRef, findLinkAtOffset, hoveringRef],
-    );
+            return;
+        }
+        const overLink = findLinkAtOffset(iter.getOffset()) !== null;
+        if (overLink !== hoveringRef.current) {
+            hoveringRef.current = overLink;
+            textView.setCursor(Gdk.Cursor.newFromName(overLink ? "pointer" : "text", null));
+        }
+    };
 }
 
 function useKeyPressHandler(
@@ -252,52 +246,43 @@ function useKeyPressHandler(
     findLinkAtOffset: (offset: number) => number | null,
     setCurrentPage: (page: number) => void,
 ) {
-    return useCallback(
-        (keyval: number) => {
-            if (keyval !== Gdk.KEY_Return && keyval !== Gdk.KEY_KP_Enter) return false;
-            const textView = textViewRef.current;
-            if (!textView) return false;
-            const buffer = textView.getBuffer();
-            const iter = buffer.getIterAtMark(buffer.getInsert());
-            const targetPage = findLinkAtOffset(iter.getOffset());
-            if (targetPage === null) return false;
-            setCurrentPage(targetPage);
-            return true;
-        },
-        [textViewRef, findLinkAtOffset, setCurrentPage],
-    );
+    return (keyval: number) => {
+        if (keyval !== Gdk.KEY_Return && keyval !== Gdk.KEY_KP_Enter) return false;
+        const textView = textViewRef.current;
+        if (!textView) return false;
+        const buffer = textView.getBuffer();
+        const iter = buffer.getIterAtMark(buffer.getInsert());
+        const targetPage = findLinkAtOffset(iter.getOffset());
+        if (targetPage === null) return false;
+        setCurrentPage(targetPage);
+        return true;
+    };
 }
 
 const HypertextDemo = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const textViewRef = useRef<Gtk.TextView | null>(null);
 
-    const getIconPaintable = useCallback((iconName: string, size: number): Gtk.IconPaintable | null => {
+    const getIconPaintable = (iconName: string, size: number): Gtk.IconPaintable | null => {
         const textView = textViewRef.current;
         if (!textView) return null;
         const display = textView.getDisplay();
         const theme = Gtk.IconTheme.getForDisplay(display);
         return theme.lookupIcon(iconName, null, size, 1, Gtk.TextDirection.LTR, Gtk.IconLookupFlags.PRELOAD);
-    }, []);
+    };
 
-    const sayWord = useCallback((word: string): void => {
+    const sayWord = (word: string): void => {
         spawn("espeak-ng", [word], { stdio: "ignore" });
-    }, []);
+    };
 
-    const { content, linkInfos } = useMemo(
-        () => buildPageContent(currentPage, getIconPaintable, sayWord),
-        [currentPage, getIconPaintable, sayWord],
-    );
+    const { content, linkInfos } = buildPageContent(currentPage, getIconPaintable, sayWord);
 
-    const findLinkAtOffset = useCallback(
-        (offset: number): number | null => {
-            for (const link of linkInfos) {
-                if (offset >= link.start && offset < link.end) return link.targetPage;
-            }
-            return null;
-        },
-        [linkInfos],
-    );
+    const findLinkAtOffset = (offset: number): number | null => {
+        for (const link of linkInfos) {
+            if (offset >= link.start && offset < link.end) return link.targetPage;
+        }
+        return null;
+    };
 
     const handlers = useHypertextHandlers(textViewRef, findLinkAtOffset, setCurrentPage);
 

--- a/examples/gtk-demo/src/demos/input/password-entry.tsx
+++ b/examples/gtk-demo/src/demos/input/password-entry.tsx
@@ -1,7 +1,7 @@
 import type * as GObject from "@gtkx/gi/gobject";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkButton, GtkHeaderBar, GtkPasswordEntry } from "@gtkx/react";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import { useDemo } from "../../context/demo-context.js";
 import type { Demo, DemoProps, DemoProviderProps } from "../types.js";
 import sourceCode from "./password-entry.tsx?raw";
@@ -26,18 +26,19 @@ const PasswordEntryProvider = ({ children }: DemoProviderProps) => {
 
     const passwordsMatch = password.length > 0 && password === confirm;
 
-    const handlePasswordNotify = useCallback((pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => {
+    const handlePasswordNotify = (pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => {
         if (pspec.getName() === "text") setPassword(self.getText() ?? "");
-    }, []);
+    };
 
-    const handleConfirmNotify = useCallback((pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => {
+    const handleConfirmNotify = (pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => {
         if (pspec.getName() === "text") setConfirm(self.getText() ?? "");
-    }, []);
+    };
 
-    const value = useMemo<PasswordEntryContextValue>(
-        () => ({ passwordsMatch, handlePasswordNotify, handleConfirmNotify }),
-        [passwordsMatch, handlePasswordNotify, handleConfirmNotify],
-    );
+    const value = {
+        passwordsMatch,
+        handlePasswordNotify,
+        handleConfirmNotify,
+    };
 
     return <PasswordEntryContext.Provider value={value}>{children}</PasswordEntryContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/input/search-entry.tsx
+++ b/examples/gtk-demo/src/demos/input/search-entry.tsx
@@ -1,6 +1,6 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkHeaderBar, GtkLabel, GtkSearchBar, GtkSearchEntry, GtkToggleButton } from "@gtkx/react";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import type { Demo, DemoProps, DemoProviderProps } from "../types.js";
 import sourceCode from "./search-entry.tsx?raw";
 
@@ -24,14 +24,17 @@ const SearchEntryProvider = ({ children }: DemoProviderProps) => {
     const [searchText, setSearchText] = useState("");
     const [searchMode, setSearchMode] = useState(false);
 
-    const handleToggleButtonClicked = useCallback((btn: Gtk.ToggleButton) => {
+    const handleToggleButtonClicked = (btn: Gtk.ToggleButton) => {
         setSearchMode(btn.getActive());
-    }, []);
+    };
 
-    const value = useMemo<SearchEntryContextValue>(
-        () => ({ searchText, setSearchText, searchMode, setSearchMode, handleToggleButtonClicked }),
-        [searchText, searchMode, handleToggleButtonClicked],
-    );
+    const value = {
+        searchText,
+        setSearchText,
+        searchMode,
+        setSearchMode,
+        handleToggleButtonClicked,
+    };
 
     return <SearchEntryContext.Provider value={value}>{children}</SearchEntryContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/input/tabs.tsx
+++ b/examples/gtk-demo/src/demos/input/tabs.tsx
@@ -1,19 +1,18 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import * as Pango from "@gtkx/gi/pango";
 import { GtkScrolledWindow, GtkTextView } from "@gtkx/react";
-import { useMemo } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./tabs.tsx?raw";
 
 const TabsDemo = () => {
-    const tabs = useMemo(() => {
+    const tabs = (() => {
         const t = Pango.TabArray.new(3, true);
         t.setTab(0, Pango.TabAlign.LEFT, 0);
         t.setTab(1, Pango.TabAlign.DECIMAL, 150);
         t.setDecimalPoint(1, ".");
         t.setTab(2, Pango.TabAlign.RIGHT, 290);
         return t;
-    }, []);
+    })();
 
     return (
         <GtkScrolledWindow

--- a/examples/gtk-demo/src/demos/input/textview.tsx
+++ b/examples/gtk-demo/src/demos/input/textview.tsx
@@ -16,7 +16,7 @@ import {
     GtkTextView,
     useAdjustment,
 } from "@gtkx/react";
-import { type RefObject, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { type RefObject, useLayoutEffect, useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./textview.tsx?raw";
 
@@ -417,19 +417,19 @@ const TextViewDemo = () => {
     const easterEggWindowRef = useRef<Gtk.Window | null>(null);
     const [sharedBuffer] = useState(() => new Gtk.TextBuffer());
 
-    const handleClickMe = useCallback(() => {
+    const handleClickMe = () => {
         const tv = textView1Ref.current;
         if (tv) handleEasterEgg(tv, easterEggWindowRef);
-    }, []);
+    };
 
-    const iconPaintable = useMemo(() => {
+    const iconPaintable = (() => {
         const display = Gdk.Display.getDefault();
         if (!display) return null;
         const iconTheme = Gtk.IconTheme.getForDisplay(display);
         return iconTheme.lookupIcon("drive-harddisk", null, 32, 1, Gtk.TextDirection.NONE, 0);
-    }, []);
+    })();
 
-    const nuclearPaintable = useMemo(() => createNuclearTexture(), []);
+    const nuclearPaintable = createNuclearTexture();
 
     useLayoutEffect(() => {
         const tv2 = textView2Ref.current;

--- a/examples/gtk-demo/src/demos/layout/fixed.tsx
+++ b/examples/gtk-demo/src/demos/layout/fixed.tsx
@@ -2,7 +2,6 @@ import * as Graphene from "@gtkx/gi/graphene";
 import * as Gsk from "@gtkx/gi/gsk";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkFixed, GtkFixedChild, GtkFrame, GtkScrolledWindow } from "@gtkx/react";
-import { useMemo } from "react";
 import { useCssResource } from "../../use-css-resource.js";
 import type { Demo } from "../types.js";
 import fixedCss from "./fixed.css?raw";
@@ -84,12 +83,10 @@ function createFaceTransform(face: CubeFace): Gsk.Transform {
 const FixedDemo = () => {
     useCssResource(fixedCss);
 
-    const faceTransforms = useMemo(() => {
-        return CUBE_FACES.map((face) => ({
-            face,
-            transform: createFaceTransform(face),
-        }));
-    }, []);
+    const faceTransforms = CUBE_FACES.map((face) => ({
+        face,
+        transform: createFaceTransform(face),
+    }));
 
     return (
         <GtkScrolledWindow name="scrolled">

--- a/examples/gtk-demo/src/demos/layout/fixed2.tsx
+++ b/examples/gtk-demo/src/demos/layout/fixed2.tsx
@@ -3,7 +3,7 @@ import * as Graphene from "@gtkx/gi/graphene";
 import * as Gsk from "@gtkx/gi/gsk";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkFixed, GtkFixedChild, GtkLabel, GtkScrolledWindow } from "@gtkx/react";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./fixed2.tsx?raw";
 
@@ -40,22 +40,21 @@ const Fixed2Demo = () => {
     const fixedRef = useRef<Gtk.Fixed | null>(null);
     const tickIdRef = useRef<number | null>(null);
 
-    const tickCallback = useCallback((_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean => {
-        const fixed = fixedRef.current;
-        const label = labelRef.current;
-        if (!fixed || !label) return true;
-        const now = frameClock.getFrameTime();
-        startTimeRef.current ??= now;
-        const duration = (now - startTimeRef.current) / 1_000_000;
-        const transform = computeFixedTransform(duration, label, fixed) ?? null;
-        fixed.setChildTransform(label, transform);
-        return true;
-    }, []);
-
     useEffect(() => {
         const fixed = fixedRef.current;
         if (!fixed) return;
         startTimeRef.current = null;
+        const tickCallback = (_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean => {
+            const currentFixed = fixedRef.current;
+            const label = labelRef.current;
+            if (!currentFixed || !label) return true;
+            const now = frameClock.getFrameTime();
+            startTimeRef.current ??= now;
+            const duration = (now - startTimeRef.current) / 1_000_000;
+            const transform = computeFixedTransform(duration, label, currentFixed) ?? null;
+            currentFixed.setChildTransform(label, transform);
+            return true;
+        };
         tickIdRef.current = fixed.addTickCallback(tickCallback);
         return () => {
             if (tickIdRef.current !== null) {
@@ -63,15 +62,15 @@ const Fixed2Demo = () => {
                 tickIdRef.current = null;
             }
         };
-    }, [tickCallback]);
+    }, []);
 
-    const handleLabelRef = useCallback((label: Gtk.Label | null) => {
+    const handleLabelRef = (label: Gtk.Label | null) => {
         labelRef.current = label;
-    }, []);
+    };
 
-    const handleFixedRef = useCallback((fixed: Gtk.Fixed | null) => {
+    const handleFixedRef = (fixed: Gtk.Fixed | null) => {
         fixedRef.current = fixed;
-    }, []);
+    };
 
     return (
         <GtkScrolledWindow name="scrolled" hexpand vexpand>

--- a/examples/gtk-demo/src/demos/layout/flowbox.tsx
+++ b/examples/gtk-demo/src/demos/layout/flowbox.tsx
@@ -2,7 +2,6 @@ import type { Context } from "@gtkx/gi/cairo";
 import * as Gdk from "@gtkx/gi/gdk";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkButton, GtkDrawingArea, GtkFlowBox, GtkScrolledWindow } from "@gtkx/react";
-import { useMemo } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./flowbox.tsx?raw";
 
@@ -694,14 +693,10 @@ function drawColor(cr: Context, _width: number, _height: number, rgba: Gdk.RGBA)
 }
 
 const FlowBoxDemo = () => {
-    const colorItems = useMemo(
-        () =>
-            COLORS.map((color) => {
-                const rgba = getParsedColors().get(color);
-                return { color, rgba };
-            }),
-        [],
-    );
+    const colorItems = COLORS.map((color) => {
+        const rgba = getParsedColors().get(color);
+        return { color, rgba };
+    });
 
     return (
         <GtkScrolledWindow name="scrolled" hscrollbarPolicy={Gtk.PolicyType.NEVER}>

--- a/examples/gtk-demo/src/demos/layout/overlay-decorative.tsx
+++ b/examples/gtk-demo/src/demos/layout/overlay-decorative.tsx
@@ -10,7 +10,7 @@ import {
     GtkTextView,
     useAdjustment,
 } from "@gtkx/react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import type { Demo } from "../types.js";
 import { path as decor1Path } from "./decor1.png";
 import { path as decor2Path } from "./decor2.png";
@@ -20,8 +20,8 @@ const OverlayDecorativeDemo = () => {
     const [margin, setMargin] = useState(100);
     const marginAdjustment = useAdjustment({ value: margin, lower: 0, upper: 100, stepIncrement: 1, pageIncrement: 1 });
 
-    const decor1 = useMemo(() => Gdk.Texture.newFromResource(decor1Path), []);
-    const decor2 = useMemo(() => Gdk.Texture.newFromResource(decor2Path), []);
+    const decor1 = Gdk.Texture.newFromResource(decor1Path);
+    const decor2 = Gdk.Texture.newFromResource(decor2Path);
 
     return (
         <GtkOverlay name="overlay">

--- a/examples/gtk-demo/src/demos/layout/overlay.tsx
+++ b/examples/gtk-demo/src/demos/layout/overlay.tsx
@@ -1,6 +1,6 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkButton, GtkEntry, GtkGrid, GtkGridChild, GtkLabel, GtkOverlay, GtkOverlayChild } from "@gtkx/react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./overlay.tsx?raw";
 
@@ -13,13 +13,13 @@ import sourceCode from "./overlay.tsx?raw";
 const OverlayDemo = () => {
     const [value, setValue] = useState("");
 
-    const handleNumber = useCallback((num: number) => {
+    const handleNumber = (num: number) => {
         setValue(String(num));
-    }, []);
+    };
 
-    const handleEntryChanged = useCallback((entry: Gtk.Entry) => {
+    const handleEntryChanged = (entry: Gtk.Entry) => {
         setValue(entry.getText());
-    }, []);
+    };
 
     const buttons = [];
     for (let j = 0; j < 5; j++) {

--- a/examples/gtk-demo/src/demos/layout/sizegroup.tsx
+++ b/examples/gtk-demo/src/demos/layout/sizegroup.tsx
@@ -1,6 +1,6 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkCheckButton, GtkDropDown, GtkFrame, GtkLabel, GtkSizeGroup } from "@gtkx/react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./sizegroup.tsx?raw";
 
@@ -41,7 +41,7 @@ const SizeGroupDemo = () => {
     const [dashing, setDashing] = useState("Solid");
     const [lineEnd, setLineEnd] = useState("Square");
 
-    const handleToggle = useCallback((button: Gtk.CheckButton) => setGroupingEnabled(button.getActive()), []);
+    const handleToggle = (button: Gtk.CheckButton) => setGroupingEnabled(button.getActive());
 
     return (
         <GtkBox

--- a/examples/gtk-demo/src/demos/lists/listbox-controls.tsx
+++ b/examples/gtk-demo/src/demos/lists/listbox-controls.tsx
@@ -16,7 +16,7 @@ import {
     GtkViewport,
     useAdjustment,
 } from "@gtkx/react";
-import { type ReactNode, useCallback, useRef, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./listbox-controls.tsx?raw";
 
@@ -169,14 +169,14 @@ const ListBoxControlsDemo = () => {
     const checkRef = useRef<Gtk.CheckButton | null>(null);
     const imageRef = useRef<Gtk.Image | null>(null);
 
-    const handleRowActivated = useCallback((row: Gtk.ListBoxRow) => {
+    const handleRowActivated = (row: Gtk.ListBoxRow) => {
         const sw = switchRef.current;
         const chk = checkRef.current;
         const img = imageRef.current;
         if (sw?.isAncestor(row)) setSwitchActive((prev) => !prev);
         else if (chk?.isAncestor(row)) setCheckActive((prev) => !prev);
         else if (img?.isAncestor(row)) setImageOpacity((prev) => (prev === 0 ? 1 : 0));
-    }, []);
+    };
 
     return (
         <GtkScrolledWindow hscrollbarPolicy={Gtk.PolicyType.NEVER} minContentHeight={200} vexpand>

--- a/examples/gtk-demo/src/demos/lists/listbox.tsx
+++ b/examples/gtk-demo/src/demos/lists/listbox.tsx
@@ -17,7 +17,7 @@ import {
     MenuItem,
     MenuSection,
 } from "@gtkx/react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { path as appleRedPath } from "../css/apple-red.png";
 import type { Demo } from "../types.js";
 import sourceCode from "./listbox.tsx?raw";
@@ -215,11 +215,11 @@ const MessageDetails = ({ message, expanded }: { message: Message; expanded: boo
 const MessageRow = ({ message, expanded, onToggleExpand, onFavorite, onReshare }: MessageRowProps) => {
     const extraButtonsRef = useRef<Gtk.Box>(null);
 
-    const handleStateFlagsChanged = useCallback((_previousFlags: Gtk.StateFlags, row: Gtk.Widget) => {
+    const handleStateFlagsChanged = (_previousFlags: Gtk.StateFlags, row: Gtk.Widget) => {
         const flags = row.getStateFlags();
         const visible = (flags & Gtk.StateFlags.PRELIGHT) !== 0 || (flags & Gtk.StateFlags.SELECTED) !== 0;
         extraButtonsRef.current?.setVisible(visible);
-    }, []);
+    };
 
     return (
         <GtkListBoxRow onStateFlagsChanged={handleStateFlagsChanged}>
@@ -246,32 +246,29 @@ const ListBoxDemo = () => {
     const [messages, setMessages] = useState(ALL_MESSAGES);
     const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
 
-    const sortedMessages = useMemo(() => [...messages].sort((a, b) => b.time - a.time), [messages]);
+    const sortedMessages = [...messages].sort((a, b) => b.time - a.time);
 
-    const handleToggleExpand = useCallback((id: number) => {
+    const handleToggleExpand = (id: number) => {
         setExpandedIds((prev) => {
             const next = new Set(prev);
             if (next.has(id)) next.delete(id);
             else next.add(id);
             return next;
         });
-    }, []);
+    };
 
-    const handleFavorite = useCallback((id: number) => {
+    const handleFavorite = (id: number) => {
         setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, nFavorites: m.nFavorites + 1 } : m)));
-    }, []);
+    };
 
-    const handleReshare = useCallback((id: number) => {
+    const handleReshare = (id: number) => {
         setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, nReshares: m.nReshares + 1 } : m)));
-    }, []);
+    };
 
-    const handleRowActivated = useCallback(
-        (row: Gtk.ListBoxRow) => {
-            const msg = sortedMessages[row.getIndex()];
-            if (msg) handleToggleExpand(msg.id);
-        },
-        [sortedMessages, handleToggleExpand],
-    );
+    const handleRowActivated = (row: Gtk.ListBoxRow) => {
+        const msg = sortedMessages[row.getIndex()];
+        if (msg) handleToggleExpand(msg.id);
+    };
 
     return (
         <GtkBox orientation={Gtk.Orientation.VERTICAL} spacing={12}>

--- a/examples/gtk-demo/src/demos/lists/listview-applauncher.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-applauncher.tsx
@@ -3,7 +3,6 @@ import * as Gdk from "@gtkx/gi/gdk";
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkImage, GtkLabel, GtkListView, GtkScrolledWindow } from "@gtkx/react";
-import { useCallback, useMemo } from "react";
 import type { Demo, DemoProps } from "../types.js";
 import sourceCode from "./listview-applauncher.tsx?raw";
 
@@ -15,40 +14,33 @@ interface AppItem {
 }
 
 const ListViewApplauncherDemo = ({ window }: DemoProps) => {
-    const apps = useMemo<AppItem[]>(
-        () =>
-            Gio.appInfoGetAll().map((app) => ({
-                appInfo: app,
-                id: app.getId() ?? crypto.randomUUID(),
-                name: app.getDisplayName(),
-                icon: app.getIcon(),
-            })),
-        [],
-    );
+    const apps = Gio.appInfoGetAll().map((app) => ({
+        appInfo: app,
+        id: app.getId() ?? crypto.randomUUID(),
+        name: app.getDisplayName(),
+        icon: app.getIcon(),
+    }));
 
-    const handleActivate = useCallback(
-        (position: number) => {
-            const app = apps[position];
-            if (!app) return;
+    const handleActivate = (position: number) => {
+        const app = apps[position];
+        if (!app) return;
 
-            const display = Gdk.Display.getDefault();
-            if (!display) return;
+        const display = Gdk.Display.getDefault();
+        if (!display) return;
 
-            const context = display.getAppLaunchContext();
-            try {
-                app.appInfo.launch(null, context);
-            } catch (error) {
-                const dialog = new Adw.AlertDialog();
-                dialog.setHeading(`Could not launch ${app.name}`);
-                dialog.setBody(error instanceof Error ? error.message : String(error));
-                dialog.addResponse("ok", "_OK");
-                dialog.setDefaultResponse("ok");
-                dialog.setCloseResponse("ok");
-                dialog.present(window.current);
-            }
-        },
-        [apps, window],
-    );
+        const context = display.getAppLaunchContext();
+        try {
+            app.appInfo.launch(null, context);
+        } catch (error) {
+            const dialog = new Adw.AlertDialog();
+            dialog.setHeading(`Could not launch ${app.name}`);
+            dialog.setBody(error instanceof Error ? error.message : String(error));
+            dialog.addResponse("ok", "_OK");
+            dialog.setDefaultResponse("ok");
+            dialog.setCloseResponse("ok");
+            dialog.present(window.current);
+        }
+    };
 
     return (
         <GtkScrolledWindow name="scrolled" vexpand hexpand>

--- a/examples/gtk-demo/src/demos/lists/listview-colors.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-colors.tsx
@@ -23,7 +23,7 @@ import {
     GtkToggleButton,
 } from "@gtkx/react";
 
-import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, memo, useContext, useEffect, useRef, useState } from "react";
 import { useLatest } from "../../use-latest.js";
 import type { Demo, DemoProviderProps } from "../types.js";
 import colorNamesRaw from "./color.names.txt?raw";
@@ -552,7 +552,7 @@ function useColorsState() {
         showSelectionInfo,
         setShowSelectionInfo,
         refillToken,
-        bumpRefillToken: useCallback(() => setRefillToken((t) => t + 1), []),
+        bumpRefillToken: () => setRefillToken((t) => t + 1),
     };
 }
 
@@ -561,29 +561,25 @@ type ColorsState = ReturnType<typeof useColorsState>;
 function useColorsComputed(state: ColorsState, models: ColorsModels) {
     const { displayFactory, bumpRefillToken } = state;
     const selectedColors = useSelectedColors(models.selection);
-    const averageColor = useMemo(() => calculateAverageColor(selectedColors), [selectedColors]);
+    const averageColor = calculateAverageColor(selectedColors);
     const showDetails = displayFactory === "everything";
     const gridCssClasses = displayFactory === "colors" ? COMPACT_CSS_CLASSES : EMPTY_CSS_CLASSES;
 
-    const handleRefill = useCallback(() => {
+    const handleRefill = () => {
         models.selection.unselectAll();
         bumpRefillToken();
-    }, [models, bumpRefillToken]);
+    };
 
-    const handleLimitChange = useCallback(
-        (id: string) => {
-            const limit = COLOR_LIMITS.find((l) => l.id === id);
-            if (limit) {
-                models.selection.unselectAll();
-                state.setColorLimit(limit.value);
-            }
-        },
-        [models, state],
-    );
+    const handleLimitChange = (id: string) => {
+        const limit = COLOR_LIMITS.find((l) => l.id === id);
+        if (limit) {
+            models.selection.unselectAll();
+            state.setColorLimit(limit.value);
+        }
+    };
 
-    const renderGridItem = useCallback(
-        (obj: GObject.Object) => <ColorGridItem item={(obj as ColorObject).colorItem} showDetails={showDetails} />,
-        [showDetails],
+    const renderGridItem = (obj: GObject.Object) => (
+        <ColorGridItem item={(obj as ColorObject).colorItem} showDetails={showDetails} />
     );
 
     return {
@@ -618,7 +614,11 @@ const ListViewColorsProvider = ({ children }: DemoProviderProps) => {
     const models = useColorsModels();
     useColorsSortMode(models, state.sortMode);
     const computed = useColorsComputed(state, models);
-    const value = useMemo<ColorsContextValue>(() => ({ state, models, computed }), [state, models, computed]);
+    const value = {
+        state,
+        models,
+        computed,
+    };
     return <ColorsContext.Provider value={value}>{children}</ColorsContext.Provider>;
 };
 

--- a/examples/gtk-demo/src/demos/lists/listview-filebrowser.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-filebrowser.tsx
@@ -13,7 +13,7 @@ import {
     GtkScrolledWindow,
 } from "@gtkx/react";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./listview-filebrowser.tsx?raw";
 
@@ -174,21 +174,21 @@ const FilebrowserProvider = ({ children }: DemoProviderProps) => {
     const [viewMode, setViewMode] = useState<ViewMode>("list");
     const files = useDirectoryFiles(currentPath);
 
-    const navigateUp = useCallback(() => {
+    const navigateUp = () => {
         const file = Gio.fileNewForPath(currentPath);
         const parent = file.getParent();
         if (parent) setCurrentPath(parent.getPath() ?? "/");
-    }, [currentPath]);
+    };
 
-    const handleActivate = useCallback(
-        (position: number) => navigateInto(files[position], currentPath, setCurrentPath),
-        [files, currentPath],
-    );
+    const handleActivate = (position: number) => navigateInto(files[position], currentPath, setCurrentPath);
 
-    const value = useMemo<FilebrowserContextValue>(
-        () => ({ viewMode, setViewMode, files, handleActivate, navigateUp }),
-        [viewMode, files, handleActivate, navigateUp],
-    );
+    const value = {
+        viewMode,
+        setViewMode,
+        files,
+        handleActivate,
+        navigateUp,
+    };
 
     return <FilebrowserContext.Provider value={value}>{children}</FilebrowserContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/lists/listview-selections.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-selections.tsx
@@ -19,7 +19,7 @@ import {
     GtkSpinButton,
     useAdjustment,
 } from "@gtkx/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./listview-selections.tsx?raw";
 
@@ -173,61 +173,52 @@ const appendSuggestionRow = (listBox: Gtk.ListBox, word: string, query: string):
     listBox.append(row);
 };
 
-const useRebuildSuggestionList = (refs: SuggestionRefs, words: string[]) =>
-    useCallback(
-        (text: string) => {
-            const popover = refs.popoverRef.current;
-            const listBox = refs.listBoxRef.current;
-            if (!popover || !listBox) return;
-            clearListBox(listBox);
-            if (text.length < 1) {
-                refs.suggestionsRef.current = [];
-                refs.selectedRef.current = -1;
-                popover.popdown();
-                return;
-            }
-            const lower = text.toLowerCase();
-            const matches = words.filter((w) => w.toLowerCase().includes(lower)).slice(0, 10);
-            refs.suggestionsRef.current = matches;
-            refs.selectedRef.current = -1;
-            if (matches.length === 0) {
-                popover.popdown();
-                return;
-            }
-            for (const word of matches) appendSuggestionRow(listBox, word, text);
-            popover.popup();
-        },
-        [refs, words],
-    );
-
-const useAcceptSuggestion = (refs: SuggestionRefs) =>
-    useCallback(() => {
-        const popover = refs.popoverRef.current;
-        const entry = refs.entryRef.current;
-        const matches = refs.suggestionsRef.current;
-        const idx = refs.selectedRef.current;
-        if (!popover || !entry || idx < 0 || idx >= matches.length) return false;
-        const word = matches[idx];
-        if (word === undefined) return false;
-        entry.setText(word);
-        entry.setPosition(-1);
+const useRebuildSuggestionList = (refs: SuggestionRefs, words: string[]) => (text: string) => {
+    const popover = refs.popoverRef.current;
+    const listBox = refs.listBoxRef.current;
+    if (!popover || !listBox) return;
+    clearListBox(listBox);
+    if (text.length < 1) {
+        refs.suggestionsRef.current = [];
+        refs.selectedRef.current = -1;
         popover.popdown();
-        return true;
-    }, [refs]);
+        return;
+    }
+    const lower = text.toLowerCase();
+    const matches = words.filter((w) => w.toLowerCase().includes(lower)).slice(0, 10);
+    refs.suggestionsRef.current = matches;
+    refs.selectedRef.current = -1;
+    if (matches.length === 0) {
+        popover.popdown();
+        return;
+    }
+    for (const word of matches) appendSuggestionRow(listBox, word, text);
+    popover.popup();
+};
 
-const useMoveSuggestion = (refs: SuggestionRefs) =>
-    useCallback(
-        (delta: number) => {
-            const listBox = refs.listBoxRef.current;
-            const matches = refs.suggestionsRef.current;
-            if (!listBox || matches.length === 0) return;
-            const next = (refs.selectedRef.current + delta + matches.length) % matches.length;
-            refs.selectedRef.current = next;
-            const row = listBox.getRowAtIndex(next);
-            if (row) listBox.selectRow(row);
-        },
-        [refs],
-    );
+const useAcceptSuggestion = (refs: SuggestionRefs) => () => {
+    const popover = refs.popoverRef.current;
+    const entry = refs.entryRef.current;
+    const matches = refs.suggestionsRef.current;
+    const idx = refs.selectedRef.current;
+    if (!popover || !entry || idx < 0 || idx >= matches.length) return false;
+    const word = matches[idx];
+    if (word === undefined) return false;
+    entry.setText(word);
+    entry.setPosition(-1);
+    popover.popdown();
+    return true;
+};
+
+const useMoveSuggestion = (refs: SuggestionRefs) => (delta: number) => {
+    const listBox = refs.listBoxRef.current;
+    const matches = refs.suggestionsRef.current;
+    if (!listBox || matches.length === 0) return;
+    const next = (refs.selectedRef.current + delta + matches.length) % matches.length;
+    refs.selectedRef.current = next;
+    const row = listBox.getRowAtIndex(next);
+    if (row) listBox.selectRow(row);
+};
 
 const buildSuggestionPopover = (entry: Gtk.Entry): { popover: Gtk.Popover; listBox: Gtk.ListBox } => {
     const popover = Gtk.Popover.new();
@@ -296,11 +287,8 @@ const SuggestionEntry = ({ words, placeholder, name }: { words: string[]; placeh
     const move = useMoveSuggestion(refs);
     const rebuild = useRebuildSuggestionList(refs, words);
     useSuggestionPopover(refs, accept);
-    const handleChanged = useCallback((entry: Gtk.Entry) => rebuild(entry.getText()), [rebuild]);
-    const handleKeyPressed = useCallback(
-        (keyval: number) => handleSuggestionKey(keyval, refs, move, accept),
-        [refs, move, accept],
-    );
+    const handleChanged = (entry: Gtk.Entry) => rebuild(entry.getText());
+    const handleKeyPressed = (keyval: number) => handleSuggestionKey(keyval, refs, move, accept);
     return (
         <GtkEntry ref={refs.entryRef} name={name} hexpand placeholderText={placeholder} onChanged={handleChanged}>
             <GtkEventControllerKey onKeyPressed={handleKeyPressed} />
@@ -492,12 +480,12 @@ const ListViewSelectionsDemo = () => {
         stepIncrement: 1,
     });
 
-    const handleFontSpinChanged = useCallback((val: number) => {
+    const handleFontSpinChanged = (val: number) => {
         const idx = Math.round(val);
         if (idx >= 0 && idx < getFontFamilies().length) {
             setFontIndex(idx);
         }
-    }, []);
+    };
 
     return (
         <GtkBox spacing={20} marginStart={20} marginEnd={20} marginTop={20} marginBottom={20}>

--- a/examples/gtk-demo/src/demos/lists/listview-settings.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-settings.tsx
@@ -16,7 +16,7 @@ import {
     GtkToggleButton,
 } from "@gtkx/react";
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./listview-settings.tsx?raw";
 
@@ -154,25 +154,25 @@ function useListViewSettingsState() {
     const [keySearchActive, setKeySearchActive] = useState(false);
     const [keySearchText, setKeySearchText] = useState("");
 
-    const handleSchemaSelected = useCallback((ids: string[]) => {
+    const handleSchemaSelected = (ids: string[]) => {
         const nodeId = ids[0];
         if (!nodeId) return;
         setSelectedNodeId(nodeId);
         setKeyInfos(loadKeysForNode(nodeId));
-    }, []);
+    };
 
-    const filteredKeyInfos = useMemo(() => {
+    const filteredKeyInfos = (() => {
         if (!keySearchText) return keyInfos;
         const lower = keySearchText.toLowerCase();
         return keyInfos.filter((k) => k.name.toLowerCase().includes(lower));
-    }, [keyInfos, keySearchText]);
+    })();
 
-    const handleKeySearchChanged = useCallback((entry: Gtk.SearchEntry) => setKeySearchText(entry.getText()), []);
+    const handleKeySearchChanged = (entry: Gtk.SearchEntry) => setKeySearchText(entry.getText());
 
-    const handleStopSearch = useCallback(() => {
+    const handleStopSearch = () => {
         setKeySearchActive(false);
         setKeySearchText("");
-    }, []);
+    };
 
     return {
         selectedNodeId,
@@ -254,40 +254,37 @@ function useColumnViewVisibilityMenuRef(
     const teardownRef = useRef<(() => void) | null>(null);
     const columnsListenerRef = useRef<{ list: Gio.ListModel; callback: () => void } | null>(null);
 
-    const detachColumnsListener = useCallback(() => {
+    const detachColumnsListener = () => {
         const listener = columnsListenerRef.current;
         if (listener) {
             listener.list.off("items-changed", listener.callback);
             columnsListenerRef.current = null;
         }
-    }, []);
+    };
 
-    return useCallback(
-        (cv: Gtk.ColumnView | null) => {
-            forwardRef.current = cv;
-            teardownRef.current?.();
-            teardownRef.current = null;
-            detachColumnsListener();
+    return (cv: Gtk.ColumnView | null) => {
+        forwardRef.current = cv;
+        teardownRef.current?.();
+        teardownRef.current = null;
+        detachColumnsListener();
 
-            if (!cv) return;
+        if (!cv) return;
 
-            const tryInstall = () => {
-                const teardown = installVisibilityMenu(cv);
-                if (teardown) {
-                    teardownRef.current = teardown;
-                    detachColumnsListener();
-                }
-            };
+        const tryInstall = () => {
+            const teardown = installVisibilityMenu(cv);
+            if (teardown) {
+                teardownRef.current = teardown;
+                detachColumnsListener();
+            }
+        };
 
-            tryInstall();
-            if (teardownRef.current) return;
+        tryInstall();
+        if (teardownRef.current) return;
 
-            const columnsList = cv.getColumns();
-            columnsList.on("items-changed", tryInstall);
-            columnsListenerRef.current = { list: columnsList, callback: tryInstall };
-        },
-        [forwardRef, detachColumnsListener],
-    );
+        const columnsList = cv.getColumns();
+        columnsList.on("items-changed", tryInstall);
+        columnsListenerRef.current = { list: columnsList, callback: tryInstall };
+    };
 }
 
 interface CommitKeyInfoEditArgs {
@@ -443,16 +440,14 @@ const ListViewSettingsProvider = ({ children }: DemoProviderProps) => {
     const columnViewRef = useRef<Gtk.ColumnView | null>(null);
     const columnViewCallbackRef = useColumnViewVisibilityMenuRef(columnViewRef);
 
-    const handleValueEdit = useCallback(
-        (keyInfo: KeyInfo, newText: string, widget: Gtk.Widget) =>
-            commitKeyInfoEdit({ keyInfo, newText, widget, state }),
-        [state],
-    );
+    const handleValueEdit = (keyInfo: KeyInfo, newText: string, widget: Gtk.Widget) =>
+        commitKeyInfoEdit({ keyInfo, newText, widget, state });
 
-    const value = useMemo<SettingsContextValue>(
-        () => ({ state, columnViewRef: columnViewCallbackRef, handleValueEdit }),
-        [state, handleValueEdit, columnViewCallbackRef],
-    );
+    const value = {
+        state,
+        columnViewRef: columnViewCallbackRef,
+        handleValueEdit,
+    };
 
     return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/lists/listview-settings2.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-settings2.tsx
@@ -13,7 +13,7 @@ import {
     GtkToggleButton,
 } from "@gtkx/react";
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./listview-settings2.tsx?raw";
 
@@ -213,33 +213,24 @@ const ListViewSettings2Provider = ({ children }: DemoProviderProps) => {
     const [searchMode, setSearchMode] = useState(false);
     const keysState = useRef(new Map<string, string>());
 
-    const handleSearchChanged = useCallback(
-        (entry: Gtk.SearchEntry) => setSearchText(entry.getText().toLowerCase()),
-        [],
-    );
+    const handleSearchChanged = (entry: Gtk.SearchEntry) => setSearchText(entry.getText().toLowerCase());
 
-    const handleStopSearch = useCallback(() => setSearchText(""), []);
+    const handleStopSearch = () => setSearchText("");
 
-    const filteredSchemaKeys = useMemo(() => filterSchemaKeys(searchText), [searchText]);
+    const filteredSchemaKeys = filterSchemaKeys(searchText);
 
-    const handleValueEdit = useCallback(
-        (key: KeyItem, entry: Gtk.Entry) => commitSettingValue(key, entry, keysState),
-        [],
-    );
+    const handleValueEdit = (key: KeyItem, entry: Gtk.Entry) => commitSettingValue(key, entry, keysState);
 
-    const value = useMemo<Settings2ContextValue>(
-        () => ({
-            searchMode,
-            setSearchMode,
-            setSearchText,
-            filteredSchemaKeys,
-            keysState,
-            handleSearchChanged,
-            handleStopSearch,
-            handleValueEdit,
-        }),
-        [searchMode, filteredSchemaKeys, handleSearchChanged, handleStopSearch, handleValueEdit],
-    );
+    const value = {
+        searchMode,
+        setSearchMode,
+        setSearchText,
+        filteredSchemaKeys,
+        keysState,
+        handleSearchChanged,
+        handleStopSearch,
+        handleValueEdit,
+    };
 
     return <Settings2Context.Provider value={value}>{children}</Settings2Context.Provider>;
 };

--- a/examples/gtk-demo/src/demos/lists/listview-weather.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-weather.tsx
@@ -1,6 +1,5 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkImage, GtkLabel, GtkListView, GtkScrolledWindow } from "@gtkx/react";
-import { useMemo } from "react";
 import type { Demo } from "../types.js";
 import rawWeatherData from "./listview_weather.txt?raw";
 import sourceCode from "./listview-weather.tsx?raw";
@@ -111,7 +110,7 @@ const parseWeatherData = (): WeatherInfo[] => {
 };
 
 const ListViewWeatherDemo = () => {
-    const weatherData = useMemo(() => parseWeatherData(), []);
+    const weatherData = parseWeatherData();
 
     return (
         <GtkScrolledWindow name="scrolled" vexpand hexpand>

--- a/examples/gtk-demo/src/demos/lists/listview-words.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-words.tsx
@@ -14,7 +14,7 @@ import {
     GtkSearchEntry,
 } from "@gtkx/react";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { useDemo } from "../../context/demo-context.js";
 import type { Demo, DemoProps, DemoProviderProps } from "../types.js";
 import sourceCode from "./listview-words.tsx?raw";
@@ -193,9 +193,9 @@ const ListViewWordsProvider = ({ window, children }: DemoProviderProps) => {
     const [searchText, setSearchText] = useState("");
     const { filteredWords, filterProgress } = useFilteredWords(words, searchText);
 
-    const loadFile = useCallback((filePath: string) => loadWordsFromFile(filePath, setWords, setSearchText), []);
+    const loadFile = (filePath: string) => loadWordsFromFile(filePath, setWords, setSearchText);
 
-    const handleOpen = useCallback(() => {
+    const handleOpen = () => {
         const run = async () => {
             const dialog = new Gtk.FileDialog();
             dialog.setTitle("Open file");
@@ -208,12 +208,15 @@ const ListViewWordsProvider = ({ window, children }: DemoProviderProps) => {
             }
         };
         void run();
-    }, [window, loadFile]);
+    };
 
-    const value = useMemo<WordsContextValue>(
-        () => ({ searchText, setSearchText, filteredWords, filterProgress, handleOpen }),
-        [searchText, filteredWords, filterProgress, handleOpen],
-    );
+    const value = {
+        searchText,
+        setSearchText,
+        filteredWords,
+        filterProgress,
+        handleOpen,
+    };
 
     return <WordsContext.Provider value={value}>{children}</WordsContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/media/video-player.tsx
+++ b/examples/gtk-demo/src/demos/media/video-player.tsx
@@ -2,7 +2,7 @@ import * as Gdk from "@gtkx/gi/gdk";
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkButton, GtkHeaderBar, GtkImage, GtkShortcut, GtkShortcutController, GtkVideo } from "@gtkx/react";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import { path as bbbPngPath } from "./bbb.png";
 import { path as gtkLogoCursorPath } from "./gtk_logo_cursor.png";
@@ -62,47 +62,33 @@ const useVideoPlayerContext = (): VideoPlayerContextValue => {
 
 const VideoPlayerProvider = ({ window, children }: DemoProviderProps) => {
     const [videoFile, setVideoFile] = useState<Gio.File | null>(null);
-    const logoPaintable = useMemo(() => Gdk.Texture.newFromResource(gtkLogoCursorPath), []);
-    const bbbPaintable = useMemo(() => Gdk.Texture.newFromResource(bbbPngPath), []);
+    const logoPaintable = Gdk.Texture.newFromResource(gtkLogoCursorPath);
+    const bbbPaintable = Gdk.Texture.newFromResource(bbbPngPath);
 
-    const handleOpen = useCallback(() => {
+    const handleOpen = () => {
         void openVideoDialog(window.current, setVideoFile);
-    }, [window]);
-    const handleLogo = useCallback(() => setVideoFile(Gio.fileNewForUri(gtkLogoUri)), []);
-    const handleBBB = useCallback(
-        () => setVideoFile(Gio.fileNewForUri("https://download.blender.org/peach/trailer/trailer_400p.ogg")),
-        [],
-    );
-    const handleFullscreen = useCallback(() => window.current?.fullscreen(), [window]);
-    const handleToggleFullscreen = useCallback(() => {
+    };
+    const handleLogo = () => setVideoFile(Gio.fileNewForUri(gtkLogoUri));
+    const handleBBB = () =>
+        setVideoFile(Gio.fileNewForUri("https://download.blender.org/peach/trailer/trailer_400p.ogg"));
+    const handleFullscreen = () => window.current?.fullscreen();
+    const handleToggleFullscreen = () => {
         const win = window.current;
         if (!win) return;
         if (win.isFullscreen()) win.unfullscreen();
         else win.fullscreen();
-    }, [window]);
+    };
 
-    const value = useMemo<VideoPlayerContextValue>(
-        () => ({
-            videoFile,
-            logoPaintable,
-            bbbPaintable,
-            handleOpen,
-            handleLogo,
-            handleBBB,
-            handleFullscreen,
-            handleToggleFullscreen,
-        }),
-        [
-            videoFile,
-            logoPaintable,
-            bbbPaintable,
-            handleOpen,
-            handleLogo,
-            handleBBB,
-            handleFullscreen,
-            handleToggleFullscreen,
-        ],
-    );
+    const value = {
+        videoFile,
+        logoPaintable,
+        bbbPaintable,
+        handleOpen,
+        handleLogo,
+        handleBBB,
+        handleFullscreen,
+        handleToggleFullscreen,
+    };
 
     return <VideoPlayerContext.Provider value={value}>{children}</VideoPlayerContext.Provider>;
 };

--- a/examples/gtk-demo/src/demos/navigation/revealer.tsx
+++ b/examples/gtk-demo/src/demos/navigation/revealer.tsx
@@ -1,6 +1,6 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkGrid, GtkGridChild, GtkImage, GtkRevealer } from "@gtkx/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./revealer.tsx?raw";
 
@@ -50,14 +50,14 @@ const RevealerDemo = () => {
         return () => clearInterval(timer);
     }, []);
 
-    const handleChildRevealed = useCallback((index: number) => {
+    const handleChildRevealed = (index: number) => {
         if (!activatedRef.current[index]) return;
         setRevealed((prev) => {
             const next = [...prev];
             next[index] = !next[index];
             return next;
         });
-    }, []);
+    };
 
     return (
         <GtkGrid name="revealer-grid" halign={Gtk.Align.CENTER} valign={Gtk.Align.CENTER}>

--- a/examples/gtk-demo/src/demos/navigation/sidebar.tsx
+++ b/examples/gtk-demo/src/demos/navigation/sidebar.tsx
@@ -1,7 +1,7 @@
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkHeaderBar, GtkImage, GtkLabel, GtkStack, GtkStackPage, GtkStackSidebar } from "@gtkx/react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import demoIconUri from "../../icons/org.gtk.Demo4.svg";
 import type { Demo } from "../types.js";
 import sourceCode from "./sidebar.tsx?raw";
@@ -19,7 +19,7 @@ const pages = [
 ];
 
 const SidebarDemo = () => {
-    const demoIcon = useMemo<Gio.Icon>(() => Gio.FileIcon.new(Gio.fileNewForUri(demoIconUri)), []);
+    const demoIcon = Gio.FileIcon.new(Gio.fileNewForUri(demoIconUri));
     const [stack, setStack] = useState<Gtk.Stack | null>(null);
 
     return (

--- a/examples/gtk-demo/src/demos/navigation/stack.tsx
+++ b/examples/gtk-demo/src/demos/navigation/stack.tsx
@@ -1,7 +1,7 @@
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkCheckButton, GtkImage, GtkSpinner, GtkStack, GtkStackPage, GtkStackSwitcher } from "@gtkx/react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import demoIconUri from "../../icons/org.gtk.Demo4.svg";
 import type { Demo } from "../types.js";
 import sourceCode from "./stack.tsx?raw";
@@ -11,7 +11,7 @@ import sourceCode from "./stack.tsx?raw";
  * Shows a stack with three pages and a GtkStackSwitcher.
  */
 const StackDemo = () => {
-    const demoIcon = useMemo<Gio.Icon>(() => Gio.FileIcon.new(Gio.fileNewForUri(demoIconUri)), []);
+    const demoIcon = Gio.FileIcon.new(Gio.fileNewForUri(demoIconUri));
     const [stack, setStack] = useState<Gtk.Stack | null>(null);
 
     return (

--- a/examples/gtk-demo/src/demos/opengl/gears.tsx
+++ b/examples/gtk-demo/src/demos/opengl/gears.tsx
@@ -11,7 +11,7 @@ import {
     GtkScale,
     useAdjustment,
 } from "@gtkx/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLatest } from "../../use-latest.js";
 import type { Demo } from "../types.js";
 import sourceCode from "./gears.tsx?raw";
@@ -531,49 +531,44 @@ const sampleFps = (frameClock: Gdk.FrameClock, frameTime: number, fpsRef: React.
 const FPS_POLL_MS = 500;
 
 function useGearsAnimation(refs: GearsRefs, fpsRef: React.RefObject<number>, setFps: (fps: number) => void) {
-    const tickCallback = useCallback(
-        (_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean => {
-            const frameTime = frameClock.getFrameTime();
-            if (refs.firstFrameTimeRef.current === 0) {
-                refs.firstFrameTimeRef.current = frameTime;
-                return true;
-            }
-            refs.angleRef.current = (((frameTime - refs.firstFrameTimeRef.current) / 1_000_000) * 70) % 360;
-            refs.glAreaRef.current?.queueRender();
-            sampleFps(frameClock, frameTime, fpsRef);
+    const tickCallback = (_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean => {
+        const frameTime = frameClock.getFrameTime();
+        if (refs.firstFrameTimeRef.current === 0) {
+            refs.firstFrameTimeRef.current = frameTime;
             return true;
-        },
-        [refs, fpsRef],
-    );
+        }
+        refs.angleRef.current = (((frameTime - refs.firstFrameTimeRef.current) / 1_000_000) * 70) % 360;
+        refs.glAreaRef.current?.queueRender();
+        sampleFps(frameClock, frameTime, fpsRef);
+        return true;
+    };
 
-    const startAnimation = useCallback(() => {
+    const startAnimation = () => {
         const glArea = refs.glAreaRef.current;
         if (!glArea || refs.tickIdRef.current !== null) return;
         refs.firstFrameTimeRef.current = 0;
         refs.tickIdRef.current = glArea.addTickCallback(tickCallback);
-    }, [refs, tickCallback]);
+    };
 
-    const stopAnimation = useCallback(() => {
-        const glArea = refs.glAreaRef.current;
-        if (!glArea || refs.tickIdRef.current === null) return;
-        glArea.removeTickCallback(refs.tickIdRef.current);
-        refs.tickIdRef.current = null;
-        refs.firstFrameTimeRef.current = 0;
-    }, [refs]);
+    const handleGLAreaRef = (glArea: Gtk.GLArea | null) => {
+        if (refs.glAreaRef.current && refs.tickIdRef.current !== null) {
+            refs.glAreaRef.current.removeTickCallback(refs.tickIdRef.current);
+            refs.tickIdRef.current = null;
+        }
+        refs.glAreaRef.current = glArea;
+        if (glArea) startAnimation();
+    };
 
-    const handleGLAreaRef = useCallback(
-        (glArea: Gtk.GLArea | null) => {
-            if (refs.glAreaRef.current && refs.tickIdRef.current !== null) {
-                refs.glAreaRef.current.removeTickCallback(refs.tickIdRef.current);
-                refs.tickIdRef.current = null;
-            }
-            refs.glAreaRef.current = glArea;
-            if (glArea) startAnimation();
+    useEffect(
+        () => () => {
+            const glArea = refs.glAreaRef.current;
+            if (!glArea || refs.tickIdRef.current === null) return;
+            glArea.removeTickCallback(refs.tickIdRef.current);
+            refs.tickIdRef.current = null;
+            refs.firstFrameTimeRef.current = 0;
         },
-        [refs, startAnimation],
+        [refs],
     );
-
-    useEffect(() => stopAnimation, [stopAnimation]);
 
     useEffect(() => {
         const interval = setInterval(() => setFps(fpsRef.current), FPS_POLL_MS);
@@ -584,14 +579,14 @@ function useGearsAnimation(refs: GearsRefs, fpsRef: React.RefObject<number>, set
 }
 
 function useGearsUnrealize(glStateRef: React.RefObject<GLState | null>) {
-    return useCallback(() => {
+    return () => {
         const state = glStateRef.current;
         if (!state) return;
         for (const vbo of state.gearVbos) gl.deleteBuffer(vbo);
         gl.deleteVertexArray(state.vao);
         gl.deleteProgram(state.program);
         glStateRef.current = null;
-    }, [glStateRef]);
+    };
 }
 
 const initGLOrError = (
@@ -650,34 +645,31 @@ const computeViewTransform = (refs: GearsRefs): number[] => {
 };
 
 function useGearsRender(refs: GearsRefs, setError: (e: string) => void) {
-    return useCallback(
-        (_context: Gdk.GLContext, self: Gtk.GLArea) => {
-            if (!initGLOrError(refs.glStateRef, self, setError)) return true;
-            const state = refs.glStateRef.current;
-            if (!state) return true;
+    return (_context: Gdk.GLContext, self: Gtk.GLArea) => {
+        if (!initGLOrError(refs.glStateRef, self, setError)) return true;
+        const state = refs.glStateRef.current;
+        if (!state) return true;
 
-            const scale = self.getScaleFactor();
-            const width = self.getAllocatedWidth() * scale;
-            const height = self.getAllocatedHeight() * scale;
+        const scale = self.getScaleFactor();
+        const width = self.getAllocatedWidth() * scale;
+        const height = self.getAllocatedHeight() * scale;
 
-            const projection = mat4Perspective(Math.PI / 3, width / height, 1, 1024);
-            gl.viewport(0, 0, width, height);
-            gl.clearColor(0, 0, 0, 0);
-            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-            gl.bindVertexArray(state.vao);
-            // biome-ignore lint/correctness/useHookAtTopLevel: not a hook
-            gl.useProgram(state.program);
+        const projection = mat4Perspective(Math.PI / 3, width / height, 1, 1024);
+        gl.viewport(0, 0, width, height);
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.bindVertexArray(state.vao);
+        // biome-ignore lint/correctness/useHookAtTopLevel: not a hook
+        gl.useProgram(state.program);
 
-            const transform = computeViewTransform(refs);
-            drawAllGears(state, transform, projection, refs.angleRef.current);
+        const transform = computeViewTransform(refs);
+        drawAllGears(state, transform, projection, refs.angleRef.current);
 
-            // biome-ignore lint/correctness/useHookAtTopLevel: not a hook
-            gl.useProgram(0);
-            gl.bindVertexArray(0);
-            return true;
-        },
-        [refs, setError],
-    );
+        // biome-ignore lint/correctness/useHookAtTopLevel: not a hook
+        gl.useProgram(0);
+        gl.bindVertexArray(0);
+        return true;
+    };
 }
 
 const GearsError = ({ error }: { error: string }) => (

--- a/examples/gtk-demo/src/demos/opengl/glarea.tsx
+++ b/examples/gtk-demo/src/demos/opengl/glarea.tsx
@@ -2,7 +2,7 @@ import * as Gdk from "@gtkx/gi/gdk";
 import * as gl from "@gtkx/gi/gl";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkButton, GtkGLArea, GtkLabel, GtkScale, useAdjustment } from "@gtkx/react";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { Demo, DemoProps } from "../types.js";
 import sourceCode from "./glarea.tsx?raw";
 
@@ -216,7 +216,7 @@ interface UseGLAreaHandlersArgs {
 const useGLAreaHandlers = (args: UseGLAreaHandlersArgs) => {
     const { glAreaRef, glStateRef, rotationX, rotationY, rotationZ } = args;
 
-    const handleRealize = useCallback(() => {
+    const handleRealize = () => {
         const area = glAreaRef.current;
         if (!area) return;
         area.makeCurrent();
@@ -227,28 +227,22 @@ const useGLAreaHandlers = (args: UseGLAreaHandlersArgs) => {
             if (e instanceof Error) console.error(e.message);
             glStateRef.current = null;
         }
-    }, [glAreaRef, glStateRef]);
+    };
 
-    const handleUnrealize = useCallback(() => {
+    const handleUnrealize = () => {
         const area = glAreaRef.current;
         if (area) area.makeCurrent();
         releaseGLState(glStateRef);
-    }, [glAreaRef, glStateRef]);
+    };
 
-    const handleRender = useCallback(
-        (_context: Gdk.GLContext) => renderGLArea({ glStateRef, rotationX, rotationY, rotationZ }),
-        [glStateRef, rotationX, rotationY, rotationZ],
-    );
+    const handleRender = (_context: Gdk.GLContext) => renderGLArea({ glStateRef, rotationX, rotationY, rotationZ });
 
-    const handleResize = useCallback((width: number, height: number) => gl.viewport(0, 0, width, height), []);
+    const handleResize = (width: number, height: number) => gl.viewport(0, 0, width, height);
 
-    const createAxisHandler = useCallback(
-        (axisSetter: (v: number) => void) => (value: number) => {
-            axisSetter((value * Math.PI) / 180);
-            glAreaRef.current?.queueRender();
-        },
-        [glAreaRef],
-    );
+    const createAxisHandler = (axisSetter: (v: number) => void) => (value: number) => {
+        axisSetter((value * Math.PI) / 180);
+        glAreaRef.current?.queueRender();
+    };
 
     return { handleRealize, handleUnrealize, handleRender, handleResize, createAxisHandler };
 };

--- a/examples/gtk-demo/src/demos/opengl/shadertoy.tsx
+++ b/examples/gtk-demo/src/demos/opengl/shadertoy.tsx
@@ -13,7 +13,7 @@ import {
     GtkScrolledWindow,
     GtkTextView,
 } from "@gtkx/react";
-import { type RefCallback, useCallback, useEffect, useRef, useState } from "react";
+import { type RefCallback, useEffect, useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import sourceCode from "./shadertoy.tsx?raw";
 
@@ -1135,29 +1135,26 @@ interface AnimState {
 }
 
 function useShaderTickCallback(animRef: React.RefObject<AnimState>, glAreaRef: React.RefObject<Gtk.GLArea | null>) {
-    return useCallback(
-        (_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean => {
-            const anim = animRef.current;
-            const frame = frameClock.getFrameCounter();
-            const frameTime = frameClock.getFrameTime();
+    return (_widget: Gtk.Widget, frameClock: Gdk.FrameClock): boolean => {
+        const anim = animRef.current;
+        const frame = frameClock.getFrameCounter();
+        const frameTime = frameClock.getFrameTime();
 
-            if (anim.firstFrameTime === 0) {
-                anim.firstFrameTime = frameTime;
-                anim.firstFrame = frame;
-                anim.time = 0;
-                anim.timedelta = 0;
-            } else {
-                const previousTime = anim.time;
-                anim.time = (frameTime - anim.firstFrameTime) / 1_000_000;
-                anim.frame = frame - anim.firstFrame;
-                anim.timedelta = anim.time - previousTime;
-            }
+        if (anim.firstFrameTime === 0) {
+            anim.firstFrameTime = frameTime;
+            anim.firstFrame = frame;
+            anim.time = 0;
+            anim.timedelta = 0;
+        } else {
+            const previousTime = anim.time;
+            anim.time = (frameTime - anim.firstFrameTime) / 1_000_000;
+            anim.frame = frame - anim.firstFrame;
+            anim.timedelta = anim.time - previousTime;
+        }
 
-            glAreaRef.current?.queueDraw();
-            return true;
-        },
-        [animRef, glAreaRef],
-    );
+        glAreaRef.current?.queueDraw();
+        return true;
+    };
 }
 
 function useShaderRefCallback(
@@ -1165,17 +1162,14 @@ function useShaderRefCallback(
     tickIdRef: React.RefObject<number | null>,
     tickCallback: (widget: Gtk.Widget, frameClock: Gdk.FrameClock) => boolean,
 ) {
-    return useCallback<RefCallback<Gtk.GLArea>>(
-        (area: Gtk.GLArea | null) => {
-            if (glAreaRef.current && tickIdRef.current !== null) {
-                glAreaRef.current.removeTickCallback(tickIdRef.current);
-                tickIdRef.current = null;
-            }
-            glAreaRef.current = area;
-            if (area) tickIdRef.current = area.addTickCallback(tickCallback);
-        },
-        [glAreaRef, tickIdRef, tickCallback],
-    );
+    return (area: Gtk.GLArea | null) => {
+        if (glAreaRef.current && tickIdRef.current !== null) {
+            glAreaRef.current.removeTickCallback(tickIdRef.current);
+            tickIdRef.current = null;
+        }
+        glAreaRef.current = area;
+        if (area) tickIdRef.current = area.addTickCallback(tickCallback);
+    };
 }
 
 function useShaderCleanup(glAreaRef: React.RefObject<Gtk.GLArea | null>, tickIdRef: React.RefObject<number | null>) {
@@ -1298,17 +1292,14 @@ const ShaderPreview = ({ shaderCode }: { shaderCode: string }) => {
     const tickCallback = useShaderTickCallback(animRef, glAreaRef);
     const handleRef = useShaderRefCallback(glAreaRef, tickIdRef, tickCallback);
     useShaderCleanup(glAreaRef, tickIdRef);
-    const handleUnrealize = useCallback(() => releaseShaderState(glStateRef), []);
-    const handleRender = useCallback(
-        (_context: Gdk.GLContext, self: Gtk.GLArea) =>
-            renderShaderPreview({ glStateRef, animRef, resolutionRef, self, shaderCode }),
-        [shaderCode],
-    );
+    const handleUnrealize = () => releaseShaderState(glStateRef);
+    const handleRender = (_context: Gdk.GLContext, self: Gtk.GLArea) =>
+        renderShaderPreview({ glStateRef, animRef, resolutionRef, self, shaderCode });
 
-    const handleResize = useCallback((width: number, height: number) => {
+    const handleResize = (width: number, height: number) => {
         resolutionRef.current = [width, height, 1];
         gl.viewport(0, 0, width, height);
-    }, []);
+    };
 
     return (
         <GtkGLArea
@@ -1489,45 +1480,39 @@ const drawShadertoyFrame = (state: GLState, anim: AnimState, resolution: [number
 function useShadertoyDrag(glAreaRef: React.RefObject<Gtk.GLArea | null>, animRef: React.RefObject<AnimState>) {
     const dragStartRef = useRef({ x: 0, y: 0 });
 
-    const handleDragBegin = useCallback(
-        (x: number, y: number) => {
-            const area = glAreaRef.current;
-            if (!area) return;
-            dragStartRef.current = { x, y };
-            const height = area.getHeight();
-            const scale = area.getScaleFactor();
+    const handleDragBegin = (x: number, y: number) => {
+        const area = glAreaRef.current;
+        if (!area) return;
+        dragStartRef.current = { x, y };
+        const height = area.getHeight();
+        const scale = area.getScaleFactor();
+        const anim = animRef.current;
+        anim.mouse[0] = x * scale;
+        anim.mouse[1] = (height - y) * scale;
+        anim.mouse[2] = anim.mouse[0];
+        anim.mouse[3] = anim.mouse[1];
+    };
+
+    const handleDragUpdate = (dx: number, dy: number) => {
+        const area = glAreaRef.current;
+        if (!area) return;
+        const sx = dragStartRef.current.x + dx;
+        const sy = dragStartRef.current.y + dy;
+        const width = area.getWidth();
+        const height = area.getHeight();
+        const scale = area.getScaleFactor();
+        if (sx >= 0 && sx < width && sy >= 0 && sy < height) {
             const anim = animRef.current;
-            anim.mouse[0] = x * scale;
-            anim.mouse[1] = (height - y) * scale;
-            anim.mouse[2] = anim.mouse[0];
-            anim.mouse[3] = anim.mouse[1];
-        },
-        [glAreaRef, animRef],
-    );
+            anim.mouse[0] = sx * scale;
+            anim.mouse[1] = (height - sy) * scale;
+        }
+    };
 
-    const handleDragUpdate = useCallback(
-        (dx: number, dy: number) => {
-            const area = glAreaRef.current;
-            if (!area) return;
-            const sx = dragStartRef.current.x + dx;
-            const sy = dragStartRef.current.y + dy;
-            const width = area.getWidth();
-            const height = area.getHeight();
-            const scale = area.getScaleFactor();
-            if (sx >= 0 && sx < width && sy >= 0 && sy < height) {
-                const anim = animRef.current;
-                anim.mouse[0] = sx * scale;
-                anim.mouse[1] = (height - sy) * scale;
-            }
-        },
-        [glAreaRef, animRef],
-    );
-
-    const handleDragEnd = useCallback(() => {
+    const handleDragEnd = () => {
         const anim = animRef.current;
         anim.mouse[2] = -anim.mouse[2];
         anim.mouse[3] = -anim.mouse[3];
-    }, [animRef]);
+    };
 
     return { handleDragBegin, handleDragUpdate, handleDragEnd };
 }
@@ -1536,26 +1521,23 @@ function useShadertoyEditor(
     sourceViewRef: React.RefObject<Gtk.TextView | null>,
     setCompiledCode: (code: string) => void,
 ) {
-    const handleRun = useCallback(() => {
+    const handleRun = () => {
         const view = sourceViewRef.current;
         if (!view) return;
         const buffer = view.getBuffer();
         const start = buffer.getStartIter();
         const end = buffer.getEndIter();
         setCompiledCode(buffer.getText(start, end, false) ?? "");
-    }, [sourceViewRef, setCompiledCode]);
+    };
 
-    const handleClear = useCallback(() => {
+    const handleClear = () => {
         sourceViewRef.current?.getBuffer().setText("", -1);
-    }, [sourceViewRef]);
+    };
 
-    const loadPreset = useCallback(
-        (code: string) => {
-            sourceViewRef.current?.getBuffer().setText(code, -1);
-            setCompiledCode(code);
-        },
-        [sourceViewRef, setCompiledCode],
-    );
+    const loadPreset = (code: string) => {
+        sourceViewRef.current?.getBuffer().setText(code, -1);
+        setCompiledCode(code);
+    };
 
     return { handleRun, handleClear, loadPreset };
 }
@@ -1604,14 +1586,11 @@ const ShadertoyEditor = ({
     sourceViewRef: React.RefObject<Gtk.TextView | null>;
     initialCode: string;
 }) => {
-    const handleSourceViewRef = useCallback(
-        (view: Gtk.TextView | null) => {
-            const previous = sourceViewRef.current;
-            sourceViewRef.current = view;
-            if (view && !previous) view.getBuffer().setText(initialCode, -1);
-        },
-        [sourceViewRef, initialCode],
-    );
+    const handleSourceViewRef = (view: Gtk.TextView | null) => {
+        const previous = sourceViewRef.current;
+        sourceViewRef.current = view;
+        if (view && !previous) view.getBuffer().setText(initialCode, -1);
+    };
     return (
         <GtkScrolledWindow minContentHeight={250} hasFrame hexpand>
             <GtkTextView
@@ -1671,44 +1650,32 @@ const ShadertoyControls = ({ onRun, onClear, onLoadPreset }: ShadertoyControlsPr
 
 function useShadertoyHandlers(refs: ReturnType<typeof useShadertoyRefs>, compiledCode: string) {
     const tickCallback = useShaderTickCallback(refs.animRef, refs.glAreaRef);
-    const handleUnrealize = useCallback(() => releaseShaderState(refs.glStateRef), [refs.glStateRef]);
+    const handleUnrealize = () => releaseShaderState(refs.glStateRef);
     const handleGLAreaRef = useShaderRefCallback(refs.glAreaRef, refs.tickIdRef, tickCallback);
     useShaderCleanup(refs.glAreaRef, refs.tickIdRef);
 
-    const compileShader = useCallback(
-        (imageShader: string): boolean =>
-            compileShadertoyShader({
-                glAreaRef: refs.glAreaRef,
-                glStateRef: refs.glStateRef,
-                animRef: refs.animRef,
-                imageShader,
-            }),
-        [refs.animRef, refs.glAreaRef, refs.glStateRef],
-    );
-
     useEffect(() => {
-        compileShader(compiledCode);
-    }, [compiledCode, compileShader]);
+        compileShadertoyShader({
+            glAreaRef: refs.glAreaRef,
+            glStateRef: refs.glStateRef,
+            animRef: refs.animRef,
+            imageShader: compiledCode,
+        });
+    }, [compiledCode, refs]);
 
-    const handleRender = useCallback(
-        (_context: Gdk.GLContext, self: Gtk.GLArea) =>
-            renderShadertoy({
-                glStateRef: refs.glStateRef,
-                animRef: refs.animRef,
-                resolution: refs.resolutionRef.current,
-                self,
-                compiledCode,
-            }),
-        [compiledCode, refs.animRef, refs.glStateRef, refs.resolutionRef],
-    );
+    const handleRender = (_context: Gdk.GLContext, self: Gtk.GLArea) =>
+        renderShadertoy({
+            glStateRef: refs.glStateRef,
+            animRef: refs.animRef,
+            resolution: refs.resolutionRef.current,
+            self,
+            compiledCode,
+        });
 
-    const handleResize = useCallback(
-        (width: number, height: number) => {
-            refs.resolutionRef.current = [width, height, 1];
-            gl.viewport(0, 0, width, height);
-        },
-        [refs.resolutionRef],
-    );
+    const handleResize = (width: number, height: number) => {
+        refs.resolutionRef.current = [width, height, 1];
+        gl.viewport(0, 0, width, height);
+    };
 
     return { handleUnrealize, handleGLAreaRef, handleRender, handleResize };
 }

--- a/examples/gtk-demo/src/use-context-menu-gesture.ts
+++ b/examples/gtk-demo/src/use-context-menu-gesture.ts
@@ -1,6 +1,6 @@
 import * as Gdk from "@gtkx/gi/gdk";
 import type * as Gtk from "@gtkx/gi/gtk";
-import { type RefObject, useCallback, useRef } from "react";
+import { type RefObject, useRef } from "react";
 
 /**
  * Wires a `GtkGestureClick` to fire `onContextMenu` on both the pointer and
@@ -46,21 +46,15 @@ export function useContextMenuGesture(options: ContextMenuGestureOptions): Conte
     const ref = useRef<Gtk.GestureClick | null>(null);
     const { onContextMenu } = options;
 
-    const onPressed = useCallback(
-        (_nPress: number, x: number, y: number) => {
-            const event = ref.current?.getCurrentEvent();
-            if (event?.triggersContextMenu()) onContextMenu(x, y);
-        },
-        [onContextMenu],
-    );
+    const onPressed = (_nPress: number, x: number, y: number) => {
+        const event = ref.current?.getCurrentEvent();
+        if (event?.triggersContextMenu()) onContextMenu(x, y);
+    };
 
-    const onReleased = useCallback(
-        (_nPress: number, x: number, y: number) => {
-            const event = ref.current?.getCurrentEvent();
-            if (event?.getEventType() === Gdk.EventType.TOUCH_END) onContextMenu(x, y);
-        },
-        [onContextMenu],
-    );
+    const onReleased = (_nPress: number, x: number, y: number) => {
+        const event = ref.current?.getCurrentEvent();
+        if (event?.getEventType() === Gdk.EventType.TOUCH_END) onContextMenu(x, y);
+    };
 
     return { ref, onPressed, onReleased };
 }

--- a/examples/gtk-demo/src/use-imperative-drag-visibility.ts
+++ b/examples/gtk-demo/src/use-imperative-drag-visibility.ts
@@ -1,5 +1,5 @@
 import type * as Gtk from "@gtkx/gi/gtk";
-import { type RefObject, useCallback, useRef } from "react";
+import { type RefObject, useRef } from "react";
 
 /**
  * Imperatively toggles the visibility of an ancillary widget across a drag
@@ -30,13 +30,13 @@ export interface ImperativeDragVisibility<T extends Gtk.Widget> {
 export function useImperativeDragVisibility<T extends Gtk.Widget>(): ImperativeDragVisibility<T> {
     const ref = useRef<T | null>(null);
 
-    const show = useCallback(() => {
+    const show = () => {
         ref.current?.setVisible(true);
-    }, []);
+    };
 
-    const hide = useCallback(() => {
+    const hide = () => {
         ref.current?.setVisible(false);
-    }, []);
+    };
 
     return { ref, show, hide };
 }

--- a/examples/tutorial/src/app.tsx
+++ b/examples/tutorial/src/app.tsx
@@ -26,7 +26,7 @@ import {
     useApplication,
     useSetting,
 } from "@gtkx/react";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import schemaId from "../com.gtkx.tutorial.gschema.xml";
 import { About } from "./components/about.js";
 import { DeleteConfirmation } from "./components/delete-confirmation.js";
@@ -137,20 +137,20 @@ const useNotesState = (toastOverlayRef: React.RefObject<Adw.ToastOverlay | null>
     const trashedNotes = notes.filter((n) => n.deleted);
     const favoriteNotes = activeNotes.filter((n) => n.favorite);
 
-    const addNote = useCallback(() => {
+    const addNote = () => {
         const note: Note = { id: crypto.randomUUID(), title: "Untitled", body: "", createdAt: new Date() };
         setNotes((prev) => [note, ...prev]);
-    }, []);
+    };
 
-    const updateNote = useCallback((id: string, fields: Partial<Pick<Note, "title" | "body">>) => {
+    const updateNote = (id: string, fields: Partial<Pick<Note, "title" | "body">>) => {
         setNotes((prev) => prev.map((n) => (n.id === id ? { ...n, ...fields } : n)));
-    }, []);
+    };
 
-    const restoreNote = useCallback((id: string) => {
+    const restoreNote = (id: string) => {
         setNotes((prev) => prev.map((n) => (n.id === id ? { ...n, deleted: false } : n)));
-    }, []);
+    };
 
-    const confirmDelete = useCallback(() => {
+    const confirmDelete = () => {
         if (!noteToDelete) return;
         const deletedNote = noteToDelete;
         if (selectedId === deletedNote.id) setSelectedId(null);
@@ -167,7 +167,7 @@ const useNotesState = (toastOverlayRef: React.RefObject<Adw.ToastOverlay | null>
         toast.buttonLabel = "Undo";
         toast.connect("button-clicked", () => restoreNote(deletedNote.id));
         toastOverlayRef.current?.addToast(toast);
-    }, [noteToDelete, selectedId, restoreNote, toastOverlayRef]);
+    };
 
     return {
         notes,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,8 @@
         "codegen": "node --conditions=source --import tsx src/cli.ts codegen --cwd ../.."
     },
     "dependencies": {
+        "@babel/core": "^7.29.7",
+        "@babel/preset-typescript": "^7.29.7",
         "@clack/prompts": "^1.5.1",
         "@gtkx/codegen": "workspace:*",
         "@gtkx/ffi": "workspace:*",
@@ -77,6 +79,7 @@
         "@gtkx/utils": "workspace:*",
         "@gtkx/vitest": "workspace:*",
         "@swc/core": "^1.15.40",
+        "babel-plugin-react-compiler": "^1.0.0",
         "c12": "^3.3.4",
         "citty": "^0.2.2",
         "ejs": "^6.0.1",
@@ -89,6 +92,7 @@
     },
     "devDependencies": {
         "@gtkx/testing": "workspace:*",
+        "@types/babel__core": "^7.20.5",
         "@types/ejs": "^3.1.5",
         "@types/react-refresh": "^0.14.7",
         "memfs": "^4.57.6"

--- a/packages/cli/src/babel-modules.d.ts
+++ b/packages/cli/src/babel-modules.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Ambient module declarations for the Babel packages used by the React
+ * Compiler transform. Both ship as CommonJS without bundled TypeScript types
+ * and expose their plugin/preset on the interop `default` member, so callers
+ * normalize with `mod.default ?? mod` before handing the value to Babel.
+ */
+
+declare module "babel-plugin-react-compiler" {
+    import type { PluginTarget } from "@babel/core";
+
+    /** The React Compiler Babel plugin. */
+    const plugin: PluginTarget & { default?: PluginTarget };
+    export default plugin;
+}
+
+declare module "@babel/preset-typescript" {
+    import type { PluginTarget } from "@babel/core";
+
+    /** The Babel preset that parses TypeScript/JSX syntax and strips type annotations. */
+    const preset: PluginTarget & { default?: PluginTarget };
+    export default preset;
+}

--- a/packages/cli/src/codegen/config-loader.ts
+++ b/packages/cli/src/codegen/config-loader.ts
@@ -1,7 +1,12 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { loadConfig } from "c12";
-import { defineConfig, type GtkxConfig } from "../config.js";
+import {
+    defineConfig,
+    type GtkxConfig,
+    type ResolvedReactCompilerOptions,
+    resolveReactCompilerOptions,
+} from "../config.js";
 
 /**
  * Outcome of loading a `gtkx.config.ts` file.
@@ -52,6 +57,29 @@ export const loadApplicationId = async (cwd: string): Promise<string | undefined
     } catch (error) {
         if (error instanceof GtkxConfigNotFoundError) {
             return undefined;
+        }
+        throw error;
+    }
+};
+
+/**
+ * Resolves the React Compiler options for a project from its `gtkx.config.ts`.
+ *
+ * Returns the option object passed to `babel-plugin-react-compiler`, or `null`
+ * when the compiler is disabled (`reactCompiler: false`). A missing config file
+ * yields the default-enabled options, so a project with no `gtkx.config.ts`
+ * still gets the compiler.
+ *
+ * @param cwd - Project root to search
+ * @returns The resolved compiler options, or `null` when disabled
+ */
+export const loadReactCompilerOptions = async (cwd: string): Promise<ResolvedReactCompilerOptions | null> => {
+    try {
+        const loaded = await loadGtkxConfig(cwd);
+        return resolveReactCompilerOptions(loaded.config.reactCompiler);
+    } catch (error) {
+        if (error instanceof GtkxConfigNotFoundError) {
+            return resolveReactCompilerOptions(undefined);
         }
         throw error;
     }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -134,6 +134,95 @@ export type GtkxConfig = {
      * ```
      */
     arrayProps?: Record<string, Record<string, string>>;
+
+    /**
+     * Controls the React Compiler (`babel-plugin-react-compiler`), which
+     * auto-memoizes components and hooks at build time so the reconciler
+     * commits fewer GObject property sets and signal reconnections per render.
+     *
+     * Enabled by default for every `gtkx dev`, `gtkx build`, and test run: the
+     * compiler transforms the project's own `.ts`/`.tsx` source (files under
+     * the project root, excluding `node_modules`) with `target: "19"`, matching
+     * GTKX's required React version.
+     *
+     * Set to `false` to disable it, or pass an object to tune the compiler.
+     *
+     * @example
+     * ```ts
+     * reactCompiler: false,
+     * ```
+     *
+     * @example
+     * ```ts
+     * reactCompiler: { compilationMode: "annotation" },
+     * ```
+     */
+    reactCompiler?: boolean | ReactCompilerOptions;
+};
+
+/**
+ * The React Compiler `compilationMode`: which functions it attempts to
+ * optimize. `"infer"` (the compiler default) memoizes functions recognized as
+ * components or hooks; `"annotation"` only those marked with a `"use memo"`
+ * directive; `"all"` every top-level function; `"syntax"` only those using
+ * optimization-eligible syntax.
+ */
+export type ReactCompilerCompilationMode = "infer" | "syntax" | "annotation" | "all";
+
+/**
+ * The React Compiler `panicThreshold`: how it reacts to code it cannot safely
+ * optimize. `"none"` (the compiler default) silently skips such functions;
+ * `"critical_errors"` fails the build on critical diagnostics; `"all_errors"`
+ * fails on any diagnostic.
+ */
+export type ReactCompilerPanicThreshold = "none" | "critical_errors" | "all_errors";
+
+/**
+ * User-tunable subset of `babel-plugin-react-compiler` options exposed through
+ * {@link GtkxConfig.reactCompiler}. The compiler `target` is always `"19"`,
+ * matching GTKX's required React version, and is not configurable.
+ */
+export type ReactCompilerOptions = {
+    /**
+     * See {@link ReactCompilerCompilationMode}. Omit to let the compiler
+     * default (`"infer"`) apply.
+     */
+    compilationMode?: ReactCompilerCompilationMode;
+    /**
+     * See {@link ReactCompilerPanicThreshold}. Omit to let the compiler
+     * default (`"none"`) apply.
+     */
+    panicThreshold?: ReactCompilerPanicThreshold;
+};
+
+/**
+ * The fully resolved option object handed to `babel-plugin-react-compiler`,
+ * produced by {@link resolveReactCompilerOptions}.
+ */
+export type ResolvedReactCompilerOptions = ReactCompilerOptions & {
+    /** Pinned to GTKX's required React major. */
+    target: "19";
+};
+
+const REACT_COMPILER_TARGET = "19";
+
+/**
+ * Maps a {@link GtkxConfig.reactCompiler} setting to the option object passed
+ * to `babel-plugin-react-compiler`, or `null` when the compiler is disabled.
+ *
+ * `false` disables it; `undefined` and `true` enable it with defaults; an
+ * object enables it with the given overrides. The `target` is always forced
+ * to `"19"`.
+ *
+ * @param setting - The `reactCompiler` value from `gtkx.config.ts`
+ * @returns The resolved compiler options, or `null` when disabled
+ */
+export const resolveReactCompilerOptions = (
+    setting: GtkxConfig["reactCompiler"],
+): ResolvedReactCompilerOptions | null => {
+    if (setting === false) return null;
+    const overrides = setting === undefined || setting === true ? {} : setting;
+    return { ...overrides, target: REACT_COMPILER_TARGET };
 };
 
 const validateLibraryEntry = (library: unknown): void => {
@@ -250,6 +339,40 @@ const validateArrayProps = (
     }
 };
 
+const REACT_COMPILER_COMPILATION_MODES: readonly ReactCompilerCompilationMode[] = [
+    "infer",
+    "syntax",
+    "annotation",
+    "all",
+];
+
+const REACT_COMPILER_PANIC_THRESHOLDS: readonly ReactCompilerPanicThreshold[] = [
+    "none",
+    "critical_errors",
+    "all_errors",
+];
+
+const validateReactCompilerEnum = <T extends string>(
+    value: T | undefined,
+    allowed: readonly T[],
+    field: string,
+): void => {
+    if (value !== undefined && !allowed.includes(value)) {
+        throw new Error(
+            `gtkx.config.ts: invalid \`reactCompiler.${field}\` "${String(value)}" — must be one of ${allowed.join(", ")}`,
+        );
+    }
+};
+
+const validateReactCompiler = (reactCompiler: GtkxConfig["reactCompiler"]): void => {
+    if (reactCompiler === undefined || typeof reactCompiler === "boolean") return;
+    if (typeof reactCompiler !== "object" || reactCompiler === null || Array.isArray(reactCompiler)) {
+        throw new Error("gtkx.config.ts: `reactCompiler` must be a boolean or an options object");
+    }
+    validateReactCompilerEnum(reactCompiler.compilationMode, REACT_COMPILER_COMPILATION_MODES, "compilationMode");
+    validateReactCompilerEnum(reactCompiler.panicThreshold, REACT_COMPILER_PANIC_THRESHOLDS, "panicThreshold");
+};
+
 /**
  * Identity helper that lets users author a {@link GtkxConfig} with full
  * type-checking and IDE autocompletion.
@@ -277,6 +400,7 @@ export const defineConfig = (config: GtkxConfig): GtkxConfig => {
     validateSlotMap(config.widgetSlots, "widgetSlots");
     validateSlotMap(config.containerSlots, "containerSlots");
     validateArrayProps(config.arrayProps, "arrayProps");
+    validateReactCompiler(config.reactCompiler);
     return config;
 };
 

--- a/packages/cli/src/vite-plugins/index.ts
+++ b/packages/cli/src/vite-plugins/index.ts
@@ -2,17 +2,21 @@ import type { Plugin } from "vite";
 import { gtkxAssets } from "./assets.js";
 import { gtkxResources } from "./gresources.js";
 import { gtkxGSettings } from "./gsettings.js";
+import { gtkxReactCompiler } from "./react-compiler.js";
 
 /**
  * The core GTKX Vite plugins shared by the `dev`, `build`, and test
  * pipelines, in the order they must run: GSettings schema compilation,
- * GResource bundling, then asset URL resolution.
+ * GResource bundling, asset URL resolution, then the React Compiler.
  *
  * Each pipeline appends its own extras (Fast Refresh for `dev`, the native
  * binary and built-url rewrites for `build`); the `@gtkx/vitest` plugin
- * spreads this set verbatim. `gtkxResources` self-loads `applicationId` from
- * `gtkx.config.ts`, so no caller threads build-time configuration through.
+ * spreads this set verbatim. The React Compiler runs first among the
+ * JS-transforming plugins (`enforce: "pre"`), so each pipeline's own
+ * JSX/TypeScript transform lowers its output afterward. `gtkxResources` and
+ * `gtkxReactCompiler` self-load their settings from `gtkx.config.ts`, so no
+ * caller threads build-time configuration through.
  *
  * @returns The ordered list of core GTKX plugins.
  */
-export const gtkxVitePlugins = (): Plugin[] => [gtkxGSettings(), gtkxResources(), gtkxAssets()];
+export const gtkxVitePlugins = (): Plugin[] => [gtkxGSettings(), gtkxResources(), gtkxAssets(), gtkxReactCompiler()];

--- a/packages/cli/src/vite-plugins/react-compiler.ts
+++ b/packages/cli/src/vite-plugins/react-compiler.ts
@@ -1,0 +1,94 @@
+import { transformAsync } from "@babel/core";
+import babelPresetTypescriptNs from "@babel/preset-typescript";
+import babelPluginReactCompilerNs from "babel-plugin-react-compiler";
+import type { Plugin, ResolvedConfig, UserConfig } from "vite";
+import { loadReactCompilerOptions } from "../codegen/config-loader.js";
+import { type ResolvedReactCompilerOptions, resolveReactCompilerOptions } from "../config.js";
+
+const babelPresetTypescript = babelPresetTypescriptNs.default ?? babelPresetTypescriptNs;
+const babelPluginReactCompiler = babelPluginReactCompilerNs.default ?? babelPluginReactCompilerNs;
+
+const SOURCE_EXTENSION = /\.tsx?$/;
+const NODE_MODULES = /(?:^|\/)node_modules\//;
+
+type ReactCompilerState = {
+    /** Absolute Vite project root; compilation is scoped to files beneath it. */
+    root: string;
+    /** Resolved compiler options, or `null` when disabled via config. */
+    options: ResolvedReactCompilerOptions | null;
+};
+
+/**
+ * Decides whether a module is a project source file the React Compiler should
+ * process: a `.ts`/`.tsx` file under the project root and outside
+ * `node_modules`. Query-suffixed ids (e.g. `foo.tsx?raw` asset-text imports)
+ * fail the extension test and are left untouched. With no resolved root (e.g. a
+ * direct unit-test call before `configResolved`), the root check is skipped.
+ */
+const isProjectSource = (root: string, id: string): boolean => {
+    if (!SOURCE_EXTENSION.test(id)) return false;
+    if (NODE_MODULES.test(id)) return false;
+    if (root !== "" && !id.startsWith(`${root}/`)) return false;
+    return true;
+};
+
+/**
+ * Vite plugin that runs the React Compiler (`babel-plugin-react-compiler`) over
+ * a project's own `.ts`/`.tsx` source before the JSX/TypeScript transform that
+ * follows it in each pipeline (SWC for `gtkx dev`, Rolldown for `gtkx build`,
+ * esbuild under Vitest).
+ *
+ * The compiler auto-memoizes components and hooks, so the reconciler commits
+ * fewer GObject property sets and signal reconnections per render. Babel parses
+ * and strips TypeScript while leaving JSX in place; the downstream transform
+ * lowers the JSX as usual. The compiler's `react/compiler-runtime` import
+ * resolves from the application's React 19 dependency.
+ *
+ * It is enabled by default and reads its options from `gtkx.config.ts` during
+ * the `config` hook (`reactCompiler: false` disables it). Compilation is scoped
+ * to files under the resolved Vite root, so workspace dependencies and
+ * published packages — which ship pre-compiled — are never recompiled.
+ *
+ * @returns The `gtkx:react-compiler` Vite plugin.
+ */
+export function gtkxReactCompiler(): Plugin {
+    const state: ReactCompilerState = {
+        root: "",
+        options: resolveReactCompilerOptions(true),
+    };
+
+    return {
+        name: "gtkx:react-compiler",
+        enforce: "pre",
+
+        async config(config: UserConfig) {
+            state.options = await loadReactCompilerOptions(config.root ?? process.cwd());
+        },
+
+        configResolved(config: ResolvedConfig) {
+            state.root = config.root;
+        },
+
+        async transform(code, id) {
+            const options = state.options;
+            if (options === null || !isProjectSource(state.root, id)) {
+                return;
+            }
+
+            const result = await transformAsync(code, {
+                filename: id,
+                babelrc: false,
+                configFile: false,
+                sourceMaps: true,
+                presets: [babelPresetTypescript],
+                plugins: [[babelPluginReactCompiler, options]],
+            });
+
+            if (!result?.code) {
+                return;
+            }
+
+            return { code: result.code, map: result.map };
+        },
+    };
+}

--- a/packages/cli/tests/builder.test.ts
+++ b/packages/cli/tests/builder.test.ts
@@ -71,7 +71,7 @@ describe("build (plugin order)", () => {
     beforeEach(resetBuildMocks);
     afterEach(restoreSpies);
 
-    it("registers all five gtkx vite plugins in order", async () => {
+    it("registers all six gtkx vite plugins in order", async () => {
         await build({ entry: "src/index.tsx" });
 
         const pluginNames = getViteConfig().plugins.map((p) => p?.name);
@@ -79,6 +79,7 @@ describe("build (plugin order)", () => {
             "gtkx:gsettings",
             "gtkx:gresources",
             "gtkx:assets",
+            "gtkx:react-compiler",
             "gtkx:built-url",
             "gtkx:native",
         ]);
@@ -94,6 +95,7 @@ describe("build (plugin order)", () => {
             "gtkx:gsettings",
             "gtkx:gresources",
             "gtkx:assets",
+            "gtkx:react-compiler",
             "gtkx:built-url",
             "gtkx:native",
         ]);

--- a/packages/cli/tests/codegen/config-loader.test.ts
+++ b/packages/cli/tests/codegen/config-loader.test.ts
@@ -2,7 +2,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { GtkxConfigNotFoundError, loadApplicationId, loadGtkxConfig } from "../../src/codegen/config-loader.js";
+import {
+    GtkxConfigNotFoundError,
+    loadApplicationId,
+    loadGtkxConfig,
+    loadReactCompilerOptions,
+} from "../../src/codegen/config-loader.js";
 
 let cwd: string;
 
@@ -105,5 +110,47 @@ describe("loadApplicationId", () => {
     it("propagates validation errors from defineConfig", async () => {
         writeFileSync(join(cwd, "gtkx.config.ts"), `export default { applicationId: "not valid" };\n`);
         await expect(loadApplicationId(cwd)).rejects.toThrow(/invalid `applicationId`/);
+    });
+});
+
+describe("loadReactCompilerOptions", () => {
+    let cwd: string;
+
+    beforeEach(() => {
+        cwd = mkdtempSync(join(tmpdir(), "gtkx-load-react-compiler-"));
+    });
+
+    afterEach(() => {
+        rmSync(cwd, { recursive: true, force: true });
+    });
+
+    it("defaults to enabled with target 19 when the config omits reactCompiler", async () => {
+        writeFileSync(join(cwd, "gtkx.config.ts"), `export default { libraries: ["Gtk-4.0"] };\n`);
+        await expect(loadReactCompilerOptions(cwd)).resolves.toEqual({ target: "19" });
+    });
+
+    it("defaults to enabled when no config file exists", async () => {
+        await expect(loadReactCompilerOptions(cwd)).resolves.toEqual({ target: "19" });
+    });
+
+    it("returns null when disabled via config", async () => {
+        writeFileSync(join(cwd, "gtkx.config.ts"), `export default { reactCompiler: false };\n`);
+        await expect(loadReactCompilerOptions(cwd)).resolves.toBeNull();
+    });
+
+    it("merges configured options while forcing target 19", async () => {
+        writeFileSync(
+            join(cwd, "gtkx.config.ts"),
+            `export default { reactCompiler: { compilationMode: "annotation" } };\n`,
+        );
+        await expect(loadReactCompilerOptions(cwd)).resolves.toEqual({
+            target: "19",
+            compilationMode: "annotation",
+        });
+    });
+
+    it("propagates validation errors from defineConfig", async () => {
+        writeFileSync(join(cwd, "gtkx.config.ts"), `export default { reactCompiler: { compilationMode: "eager" } };\n`);
+        await expect(loadReactCompilerOptions(cwd)).rejects.toThrow(/invalid `reactCompiler\.compilationMode`/);
     });
 });

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defineConfig, type GtkxConfig, isValidApplicationId } from "../src/config.js";
+import { defineConfig, type GtkxConfig, isValidApplicationId, resolveReactCompilerOptions } from "../src/config.js";
 import { isValidProjectName } from "../src/create/options.js";
 
 const defineUnknown = (config: unknown): GtkxConfig => defineConfig(config as GtkxConfig);
@@ -179,6 +179,67 @@ describe("defineConfig arrayProps validation", () => {
         expect(() => defineUnknown({ arrayProps: { MyAppChart: { series: 123 } } })).toThrow(
             /invalid `arrayProps\.MyAppChart\.series` item type "123"/,
         );
+    });
+});
+
+describe("defineConfig reactCompiler validation", () => {
+    it("accepts a boolean", () => {
+        expect(() => defineConfig({ reactCompiler: false })).not.toThrow();
+        expect(() => defineConfig({ reactCompiler: true })).not.toThrow();
+    });
+
+    it("accepts an options object", () => {
+        const config: GtkxConfig = {
+            reactCompiler: { compilationMode: "annotation", panicThreshold: "all_errors" },
+        };
+        expect(defineConfig(config)).toBe(config);
+    });
+
+    it("accepts a config that omits reactCompiler", () => {
+        expect(() => defineConfig({ libraries: ["Gtk-4.0"] })).not.toThrow();
+    });
+
+    it("rejects a non-boolean, non-object value", () => {
+        expect(() => defineUnknown({ reactCompiler: "yes" })).toThrow(
+            /`reactCompiler` must be a boolean or an options object/,
+        );
+    });
+
+    it("rejects an array value", () => {
+        expect(() => defineUnknown({ reactCompiler: [] })).toThrow(
+            /`reactCompiler` must be a boolean or an options object/,
+        );
+    });
+
+    it("rejects an invalid compilationMode", () => {
+        expect(() => defineUnknown({ reactCompiler: { compilationMode: "eager" } })).toThrow(
+            /invalid `reactCompiler\.compilationMode` "eager"/,
+        );
+    });
+
+    it("rejects an invalid panicThreshold", () => {
+        expect(() => defineUnknown({ reactCompiler: { panicThreshold: "warn" } })).toThrow(
+            /invalid `reactCompiler\.panicThreshold` "warn"/,
+        );
+    });
+});
+
+describe("resolveReactCompilerOptions", () => {
+    it("returns null when disabled", () => {
+        expect(resolveReactCompilerOptions(false)).toBeNull();
+    });
+
+    it("enables with target 19 by default", () => {
+        expect(resolveReactCompilerOptions(undefined)).toEqual({ target: "19" });
+        expect(resolveReactCompilerOptions(true)).toEqual({ target: "19" });
+    });
+
+    it("merges overrides while forcing target 19", () => {
+        expect(resolveReactCompilerOptions({ compilationMode: "all", panicThreshold: "none" })).toEqual({
+            target: "19",
+            compilationMode: "all",
+            panicThreshold: "none",
+        });
     });
 });
 

--- a/packages/cli/tests/dev/runner-deps.test.ts
+++ b/packages/cli/tests/dev/runner-deps.test.ts
@@ -58,6 +58,7 @@ describe("defaultDevRunnerDeps (wiring)", () => {
             "gtkx:gsettings",
             "gtkx:gresources",
             "gtkx:assets",
+            "gtkx:react-compiler",
             "gtkx:swc-ssr-refresh",
             "gtkx:refresh",
             "gtkx:skip-react-dom-optimize",

--- a/packages/cli/tests/vite-plugins/react-compiler.test.ts
+++ b/packages/cli/tests/vite-plugins/react-compiler.test.ts
@@ -1,0 +1,131 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { gtkxReactCompiler } from "../../src/vite-plugins/react-compiler.js";
+
+type TransformResult = { code: string; map?: unknown } | undefined;
+type TransformFn = (code: string, id: string) => Promise<TransformResult>;
+type ConfigFn = (config: { root?: string }) => Promise<unknown>;
+type ConfigResolvedFn = (config: { root: string }) => void;
+
+const isHandler = <F>(hook: unknown): hook is F => typeof hook === "function";
+
+const hookOf = <F>(hook: unknown, name: string): F => {
+    if (!isHandler<F>(hook)) throw new Error(`${name} must be a function hook`);
+    return hook;
+};
+
+const transformOf = (plugin: ReturnType<typeof gtkxReactCompiler>): TransformFn =>
+    hookOf<TransformFn>(plugin.transform, "transform");
+const configOf = (plugin: ReturnType<typeof gtkxReactCompiler>): ConfigFn => hookOf<ConfigFn>(plugin.config, "config");
+const configResolvedOf = (plugin: ReturnType<typeof gtkxReactCompiler>): ConfigResolvedFn =>
+    hookOf<ConfigResolvedFn>(plugin.configResolved, "configResolved");
+
+const HOOK = `import { useState } from "react";
+export function useCounter(initial: number) {
+    const [count, setCount] = useState(initial);
+    const increment = () => setCount((c) => c + 1);
+    return { count, increment };
+}
+`;
+
+const COMPONENT = `export function Counter({ label }: { label: string }) {
+    const [n, setN] = React.useState(0);
+    return <button onClicked={() => setN(n + 1)}>{label}: {n}</button>;
+}
+`;
+
+describe("gtkxReactCompiler", () => {
+    it("returns a plugin with the expected name and pre-enforce", () => {
+        const plugin = gtkxReactCompiler();
+        expect(plugin.name).toBe("gtkx:react-compiler");
+        expect(plugin.enforce).toBe("pre");
+    });
+
+    it("compiles a project source file, injecting the memo cache and compiler runtime", async () => {
+        const transform = transformOf(gtkxReactCompiler());
+        const result = await transform(COMPONENT, "/proj/src/counter.tsx");
+
+        expect(result).toBeDefined();
+        expect(result?.code).toContain('from "react/compiler-runtime"');
+        expect(result?.code).toContain("_c(");
+        expect(result?.map).toBeDefined();
+    });
+
+    it("strips TypeScript while leaving JSX for the downstream transform", async () => {
+        const transform = transformOf(gtkxReactCompiler());
+        const result = await transform(COMPONENT, "/proj/src/counter.tsx");
+
+        expect(result?.code).not.toContain(": { label: string }");
+        expect(result?.code).toContain("<button");
+    });
+
+    it("skips files that are not .ts or .tsx", async () => {
+        const transform = transformOf(gtkxReactCompiler());
+        await expect(transform("body { color: red; }", "/proj/src/styles.css")).resolves.toBeUndefined();
+    });
+
+    it("skips files in node_modules", async () => {
+        const transform = transformOf(gtkxReactCompiler());
+        await expect(transform(COMPONENT, "/proj/node_modules/lib/counter.tsx")).resolves.toBeUndefined();
+    });
+
+    it("skips files outside the resolved project root", async () => {
+        const plugin = gtkxReactCompiler();
+        configResolvedOf(plugin)({ root: "/proj" });
+        const transform = transformOf(plugin);
+
+        await expect(transform(COMPONENT, "/elsewhere/src/counter.tsx")).resolves.toBeUndefined();
+        await expect(transform(COMPONENT, "/proj/src/counter.tsx")).resolves.toBeDefined();
+    });
+
+    it("compiles .ts source files, not only .tsx", async () => {
+        const transform = transformOf(gtkxReactCompiler());
+        const result = await transform(HOOK, "/proj/src/use-counter.ts");
+
+        expect(result).toBeDefined();
+        expect(result?.code).not.toContain(": number");
+        expect(result?.code).toContain('from "react/compiler-runtime"');
+    });
+
+    it("skips query-suffixed ids such as ?raw asset-text imports", async () => {
+        const transform = transformOf(gtkxReactCompiler());
+        await expect(transform(COMPONENT, "/proj/src/counter.tsx?raw")).resolves.toBeUndefined();
+    });
+});
+
+describe("gtkxReactCompiler (config-driven enable/disable)", () => {
+    let cwd: string;
+
+    beforeEach(() => {
+        cwd = mkdtempSync(join(tmpdir(), "gtkx-react-compiler-"));
+    });
+
+    afterEach(() => {
+        rmSync(cwd, { recursive: true, force: true });
+    });
+
+    it("does not transform when the project disables the compiler", async () => {
+        writeFileSync(join(cwd, "gtkx.config.ts"), `export default { reactCompiler: false };\n`);
+
+        const plugin = gtkxReactCompiler();
+        await configOf(plugin)({ root: cwd });
+        configResolvedOf(plugin)({ root: cwd });
+
+        const transform = transformOf(plugin);
+        await expect(transform(COMPONENT, join(cwd, "src/counter.tsx"))).resolves.toBeUndefined();
+    });
+
+    it("transforms when the project enables the compiler explicitly", async () => {
+        writeFileSync(join(cwd, "gtkx.config.ts"), `export default { reactCompiler: true };\n`);
+
+        const plugin = gtkxReactCompiler();
+        await configOf(plugin)({ root: cwd });
+        configResolvedOf(plugin)({ root: cwd });
+
+        const transform = transformOf(plugin);
+        const result = await transform(COMPONENT, join(cwd, "src/counter.tsx"));
+        expect(result?.code).toContain('from "react/compiler-runtime"');
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,12 @@ importers:
 
   packages/cli:
     dependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7
+      '@babel/preset-typescript':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7)
       '@clack/prompts':
         specifier: ^1.5.1
         version: 1.5.1
@@ -166,6 +172,9 @@ importers:
       '@swc/core':
         specifier: ^1.15.40
         version: 1.15.40
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       c12:
         specifier: ^3.3.4
         version: 3.3.4(magicast@0.5.3)
@@ -200,6 +209,9 @@ importers:
       '@gtkx/testing':
         specifier: workspace:*
         version: link:../testing
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
       '@types/ejs':
         specifier: ^3.1.5
         version: 3.1.5
@@ -471,6 +483,72 @@ packages:
     resolution: {integrity: sha512-6mF9LZMUk0QqWvrnxkxBqhswwz6Xfiwy6/gmTzL5HrlhdVG3ITAqGV2k3XmVThP1h0Ulc3VQwiNCD7/Nr4JNlQ==}
     engines: {node: '>= 14.0.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -479,10 +557,56 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7':
+    resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.29.7':
+    resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.29.7':
+    resolution: {integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
@@ -1069,6 +1193,12 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -2685,6 +2815,9 @@ packages:
       react-native-b4a:
         optional: true
 
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -2705,6 +2838,11 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.34:
+    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -2739,6 +2877,11 @@ packages:
 
   browserify-zlib@0.1.4:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -2776,6 +2919,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001797:
+    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -3010,6 +3156,9 @@ packages:
     resolution: {integrity: sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==}
     engines: {node: '>=0.12.18'}
     hasBin: true
+
+  electron-to-chromium@1.5.370:
+    resolution: {integrity: sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==}
 
   emnapi@1.10.0:
     resolution: {integrity: sha512-swoyZjupDvLoe/KC3HZ4SY1JUN+tviT6eOZ3Px28TZAYdBHtRIiMWWrIUUH+2/9CYY4fNTID1YhYZ+kdFHszHg==}
@@ -3279,6 +3428,10 @@ packages:
     resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
     engines: {node: '>=10'}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3537,6 +3690,9 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -3547,6 +3703,11 @@ packages:
 
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -3723,6 +3884,9 @@ packages:
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -3977,6 +4141,10 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
 
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
@@ -4345,6 +4513,10 @@ packages:
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -4723,6 +4895,12 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
@@ -4954,6 +5132,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -5096,13 +5277,186 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.53.0
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.7':
     dependencies:
@@ -5553,6 +5907,16 @@ snapshots:
   '@inquirer/type@4.0.7(@types/node@25.9.2)':
     optionalDependencies:
       '@types/node': 25.9.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -6998,6 +7362,10 @@ snapshots:
 
   b4a@1.8.1: {}
 
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -7007,6 +7375,8 @@ snapshots:
   bare-events@2.9.1: {}
 
   base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.34: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -7065,6 +7435,14 @@ snapshots:
     dependencies:
       pako: 0.2.9
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
+      electron-to-chromium: 1.5.370
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -7114,6 +7492,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  caniuse-lite@1.0.30001797: {}
 
   caseless@0.12.0: {}
 
@@ -7325,6 +7705,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   ejs@6.0.1: {}
+
+  electron-to-chromium@1.5.370: {}
 
   emnapi@1.10.0: {}
 
@@ -7665,6 +8047,8 @@ snapshots:
 
   fuse.js@7.3.0: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -7922,6 +8306,8 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -7932,6 +8318,8 @@ snapshots:
       argparse: 2.0.1
 
   jsbn@0.1.1: {}
+
+  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -8092,6 +8480,10 @@ snapshots:
       steno: 0.4.4
 
   lowercase-keys@2.0.0: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lru-cache@7.18.3: {}
 
@@ -8424,6 +8816,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
+
+  node-releases@2.0.47: {}
 
   normalize-url@6.1.0: {}
 
@@ -8872,6 +9266,8 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
+  semver@6.3.1: {}
+
   semver@7.7.4: {}
 
   semver@7.8.0: {}
@@ -9288,6 +9684,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
@@ -9545,6 +9947,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.9.0: {}
 

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -99,6 +99,31 @@ After `gtkx create`, your `package.json` includes:
 | `npm start`     | Run production bundle                  |
 | `npm test`      | Run tests (if configured)              |
 
+## React Compiler
+
+The [React Compiler](https://react.dev/learn/react-compiler) is enabled by default for every `gtkx dev`, `gtkx build`, and test run. It auto-memoizes your components and hooks at build time, so the reconciler commits fewer GTK property sets and signal reconnections per render — you get the benefit without hand-writing `useMemo`/`useCallback`.
+
+Compilation is scoped to your project's own `.ts`/`.tsx` source under the project root; dependencies in `node_modules` (which ship pre-compiled) are left untouched. The compiler targets React 19 and its `react/compiler-runtime` import resolves from your app's React dependency, so no extra setup is required.
+
+To tune or disable it, set `reactCompiler` in `gtkx.config.ts`:
+
+```ts
+import { defineConfig } from "@gtkx/cli";
+
+export default defineConfig({
+    libraries: ["Gtk-4.0"],
+    // Disable the compiler entirely:
+    reactCompiler: false,
+    // …or pass options:
+    // reactCompiler: { compilationMode: "annotation" },
+});
+```
+
+| Option            | Values                                          | Description                                                          |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------- |
+| `compilationMode` | `"infer"` `"syntax"` `"annotation"` `"all"`     | Which functions to optimize. Defaults to `"infer"`.                 |
+| `panicThreshold`  | `"none"` `"critical_errors"` `"all_errors"`     | How to react to code the compiler cannot safely optimize. Defaults to `"none"` (skip silently). |
+
 ## Programmatic API
 
 You can also use the CLI functions programmatically:


### PR DESCRIPTION
Closes #360.

Enables the React Compiler (`babel-plugin-react-compiler@1.0.0`) across the `@gtkx/cli` dev, build, and test pipelines, and removes the manual memoization it makes redundant from the example apps.

## CLI integration
- New `gtkx:react-compiler` Vite plugin runs `@babel/core` + `babel-plugin-react-compiler` (target `19`) ahead of the existing SWC (dev) / Rolldown (build) / esbuild (test) JSX transform. Added to the shared `gtkxVitePlugins()` factory, so it covers `gtkx dev`, `gtkx build`, and the `@gtkx/cli/vitest` test pipeline in one place.
- Enabled by default; `reactCompiler` in `gtkx.config.ts` disables (`false`) or tunes it (`compilationMode`, `panicThreshold`). Compilation is scoped to the project's own `.ts`/`.tsx` source under the Vite root, so `node_modules` and workspace library source are never recompiled.
- Compatible with the custom reconciler: `react@19.2.7` ships `react/compiler-runtime` and `react-reconciler@0.33.0` implements `useMemoCache`; auto-memoization only reduces `commitUpdate`/`applyProps`/signal reconnects.
- Documented on the CLI docs page.

## Example cleanup
- Removed every now-redundant `useMemo`/`useCallback` (232 + 94 calls across 56 files; net −282 lines) via a deterministic codemod.
- Converted create-once stateful `Gtk.Svg` paintables to `useState` lazy-init where a stable identity is required (`dnd`, `images`).
- Restructured four effects whose `useCallback` existed only to serve as a stable dependency.
- Left `React.memo` (a component HOC, not a hook) in place.

## Verification
- `pnpm build` (all packages + 4 examples), `pnpm test` (23/23 turbo tasks), CLI 358 tests, gtk-demo 664 tests, `pnpm lint` (biome + knip + depcruiser), typecheck, and jscpd (0% duplication) — all green.