### PR TITLE
Convert record field values through toNative before writing them

### DIFF
--- a/packages/codegen/src/store/gi/record-field-accessor.ts
+++ b/packages/codegen/src/store/gi/record-field-accessor.ts
@@ -118,7 +118,12 @@ const emitFieldWrite = (context: ModuleContext, spec: FieldWriteSpec): string =>
     context.addRuntimeImport("write");
 
     if (slot.bitWidth === undefined) {
-        return `write(${targetExpr}, ${descriptor}, ${String(slot.byteOffset)}, ${valueExpr});`;
+        context.addRuntimeImport("toNative");
+
+        return (
+            `write(${targetExpr}, ${descriptor}, ${String(slot.byteOffset)}, ` +
+            `toNative(${descriptor}, ${valueExpr}));`
+        );
     }
 
     context.addRuntimeImport("read");

--- a/packages/codegen/tests/unit/record-field-accessor.test.ts
+++ b/packages/codegen/tests/unit/record-field-accessor.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { GirNamespace } from "../../src/gir/namespace.js";
+import type { FieldSlot } from "../../src/gir/size.js";
+import { Library } from "../../src/gir/library.js";
+import { emitFieldWrite } from "../../src/store/gi/record-field-accessor.js";
+import { ModuleContext } from "../../src/writer/context.js";
+
+const EMPTY_NAMESPACE: GirNamespace = {
+    id: 0,
+    name: "Test",
+    sharedLibrary: undefined,
+    cSymbolPrefixes: [],
+    classes: [],
+    interfaces: [],
+    records: [],
+    enums: [],
+    callbacks: [],
+    functions: [],
+    constants: [],
+    aliases: [],
+};
+
+const makeContext = (): ModuleContext => new ModuleContext(EMPTY_NAMESPACE, new Library());
+const plainSlot = (byteOffset: number): FieldSlot => ({ byteOffset, bitOffset: undefined, bitWidth: undefined });
+
+const bitfieldSlot = (byteOffset: number, bitOffset: number, bitWidth: number): FieldSlot => ({
+    byteOffset,
+    bitOffset,
+    bitWidth,
+});
+
+describe("emitFieldWrite", () => {
+    // A record field write crosses into native code the same way a GI function argument does, so a
+    // wrapper instance (e.g. a `Gdk.RGBA` handed to `Gsk.ColorStop`'s constructor or setter) has to be
+    // converted to its native handle first. Without this, `write` receives the wrapper object itself,
+    // and the native side rejects it: "Expected an Object for Boxed field write type, got Object".
+    it("converts the value through toNative before writing it", () => {
+        const statement = emitFieldWrite(makeContext(), {
+            descriptor: "GDK_RGBA_DESCRIPTOR",
+            slot: plainSlot(8),
+            targetExpr: "handle",
+            valueExpr: "props.color",
+        });
+
+        expect(statement).toBe("write(handle, GDK_RGBA_DESCRIPTOR, 8, toNative(GDK_RGBA_DESCRIPTOR, props.color));");
+    });
+
+    it("registers a runtime import for toNative", () => {
+        const context = makeContext();
+
+        emitFieldWrite(context, {
+            descriptor: "GDK_RGBA_DESCRIPTOR",
+            slot: plainSlot(8),
+            targetExpr: "handle",
+            valueExpr: "props.color",
+        });
+
+        expect(context.module.toSource()).toContain('import { toNative, write } from "@gtkx/runtime";');
+    });
+
+    // Bitfields are always packed integers, never handle-passing values, so the merge expression is
+    // left as-is.
+    it("leaves a bitfield merge untouched", () => {
+        const statement = emitFieldWrite(makeContext(), {
+            descriptor: "UINT32_DESCRIPTOR",
+            slot: bitfieldSlot(0, 2, 3),
+            targetExpr: "handle",
+            valueExpr: "value",
+        });
+
+        expect(statement).not.toContain("toNative");
+    });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -4,7 +4,7 @@ export { createErrorDomain, type ErrorDomain } from "./error.js";
 export { type ApplicationLike, onExit, quit, quitApplication, runApplication } from "./lifecycle.js";
 export { offSignal, onceSignal, onSignal } from "./listeners.js";
 export { installMixins, type Mixin } from "./mixin.js";
-export { fromNative } from "./native-value.js";
+export { fromNative, toNative } from "./native-value.js";
 export { getObjectProperty, newObjectWithProperties, setObjectProperty } from "./object.js";
 export { type FinishResult, promisify } from "./promisify.js";
 export { registerClass } from "./register-class.js";

--- a/packages/runtime/tests/index.test.ts
+++ b/packages/runtime/tests/index.test.ts
@@ -19,6 +19,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
     "registerWrapperClass",
     "getSignalBaseName",
     "fromNative",
+    "toNative",
     "alloc",
     "read",
     "write",


### PR DESCRIPTION
## Summary

`new Gsk.ColorStop({ offset: 0, color: rgba })`, the equivalent setter, and the same shape on `Graphene.Rect` (`origin`/`size`) all throw:

```
Error during field write: Expected an Object for Boxed field write type, got Object
```

A record field write crosses into native code through the same `write(handle, descriptor, offset, value)` binding a GI function call uses for its handle-passing arguments, and on the native side both land in `value::handle_ptr` (`packages/native/src/value.rs`), which requires `value` to already be the field's native `External` handle. Function-argument codegen converts a wrapper instance to that handle with `getHandle`/`tryGetHandle` before the call (`handleArgument` in `packages/codegen/src/store/gi/method.ts`). Record field writes never did this: `emitFieldWrite`, shared by the generated constructor and the generated property setter, passed the raw JS value straight into `write(...)`.

There's already a runtime helper for exactly this conversion: `toNative` in `packages/runtime/src/native-value.ts`, the write-side counterpart of the `fromNative` the same file's getter already calls to wrap a value read back out of a field. `toNative` was already used elsewhere (`value.ts`, `callback.ts`) but was never exported from `@gtkx/runtime`, and `emitFieldWrite` never called it. This change exports it and has `emitFieldWrite` route the value through it. `toNative` no-ops for every non-handle-passing descriptor kind, so plain numeric/string/enum fields are untouched; bitfields (always packed integers) are left as-is too.

This is general — it can affect any writable field whose type is an object, boxed, struct, or fundamental, not only inline embedded ones — `ColorStop.color` and `Rect.origin`/`size` are just the two reachable instances.

Also adds a regression test (`packages/codegen/tests/unit/record-field-accessor.test.ts`) that asserts `emitFieldWrite` wraps the value in `toNative(...)`, and extends the existing `@gtkx/runtime` barrel export test to require `toNative`. It fails on `main` and passes with this change.

## Related Issue

Fixes #472

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] All packages build (`pnpm build`)
- [ ] All tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)

## What I could and could not verify here

I develop on macOS, so I could not run anything needing the native addon or real GIR data: `@gtkx/native` only declares the two `unknown-linux-gnu` targets, and codegen needs the gobject-introspection development packages to load `Gtk-4.0`/`Adw-1`, which is what the existing `packages/codegen/tests/helpers/library.ts` fixture and every test built on it require. That rules out reproducing `ColorStop`/`Rect` end to end and running `packages/runtime`'s test suite at all — its `vitest.config.ts` wires up a headless Wayland display via Linux-only tooling (`setpriv`) in `globalSetup` regardless of what an individual test needs.

What I did run, both before and after this change, to isolate what's actually attributable to it:

- `packages/codegen/tests/unit/record-field-accessor.test.ts` (added here): 3 passed. Reverting just `packages/codegen/src/store/gi/record-field-accessor.ts` fails 2 of the 3, so they cover the defect rather than describing the new code.
- `packages/codegen`'s whole unit suite, 7 files including the one added here: 60 passed, 1 failed — the same before and after this branch once the 3 new tests are set aside. The one failure (`resolveGirPath — pkg-config invocation > surfaces pkg-config failures with stderr included`) needs `pkg-config` on `PATH`, which this checkout doesn't have, and is present on an unmodified checkout too.
- `tsc -b packages/codegen/tsconfig.json packages/runtime/tsconfig.json --force`: 105 errors, identical before and after this branch, all in `packages/react` from `@gtkx/gi` not being generated in this checkout — none in `packages/codegen` or `packages/runtime`.
- `eslint packages/codegen packages/runtime`: 223 errors, identical before and after this branch, all in `packages/runtime/src/{t,type,value}.ts` from `@gtkx/native`'s types not resolving without a native build (the same environment-only `no-unsafe-*` noise noted in #469). None of the four files this PR touches report anything.

I could not run `packages/runtime/tests/index.test.ts` (the barrel-export assertion this PR extends with `"toNative"`) for the reason above, but the addition follows the same list the test already enforces, and the export itself (`packages/runtime/src/index.ts`) is a one-line, mechanical change.
