### PR TITLE
Emit every GIR and Khronos doc we reach

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -20,18 +20,6 @@
         "packages/utils/src/process/index.ts": [
             "exports"
         ],
-        "packages/codegen/src/gir/annotations.ts": [
-            "exports"
-        ],
-        "packages/codegen/src/store/gi/callables.ts": [
-            "exports"
-        ],
-        "packages/codegen/src/store/gi/doc-spec.ts": [
-            "exports"
-        ],
-        "packages/codegen/src/store/gi/vtable.ts": [
-            "exports"
-        ],
         "**/gtkx.config.ts": [
             "exports"
         ],

--- a/packages/codegen/overrides/gdk/rgba.ts.ejs
+++ b/packages/codegen/overrides/gdk/rgba.ts.ejs
@@ -1,11 +1,37 @@
 import { RGBA as GeneratedRGBA } from "../gdk.js";
 
+/**
+ * Parses a CSS color string into a new `RGBA`.
+ *
+ * @param value a CSS color string, such as `#rgb`, `rgb(r,g,b)`, or a named color
+ * @returns the parsed color
+ */
 const create = (value: string): GeneratedRGBA => {
     const rgba = new GeneratedRGBA();
     rgba.parse(value);
     return rgba;
 };
 
+/**
+ * Represents a color, in a way that is compatible with cairo's notion of color.
+ *
+ * `GdkRGBA` is a convenient way to pass colors around. It's based on
+ * cairo's way to deal with colors and mirrors its behavior. All values
+ * are in the range from 0.0 to 1.0 inclusive. So the color
+ * (0.0, 0.0, 0.0, 0.0) represents transparent black and
+ * (1.0, 1.0, 1.0, 1.0) is opaque white. Other values will
+ * be clamped to this range when drawing.
+ */
 export const RGBA: typeof GeneratedRGBA & { create: typeof create } = Object.assign(GeneratedRGBA, { create });
 
+/**
+ * Represents a color, in a way that is compatible with cairo's notion of color.
+ *
+ * `GdkRGBA` is a convenient way to pass colors around. It's based on
+ * cairo's way to deal with colors and mirrors its behavior. All values
+ * are in the range from 0.0 to 1.0 inclusive. So the color
+ * (0.0, 0.0, 0.0, 0.0) represents transparent black and
+ * (1.0, 1.0, 1.0, 1.0) is opaque white. Other values will
+ * be clamped to this range when drawing.
+ */
 export type RGBA = GeneratedRGBA;

--- a/packages/codegen/overrides/gobject/object.ts.ejs
+++ b/packages/codegen/overrides/gobject/object.ts.ejs
@@ -5,18 +5,63 @@ type Listener = (...args: unknown[]) => unknown;
 
 declare module "../gobject.js" {
     interface Object {
+        /** GType the instance's class is registered under, carried on the prototype. */
         __type__: Type;
 
+        /**
+         * Disconnects the handler `connect` returned the given id for.
+         *
+         * @param handlerId Id of the handler to disconnect.
+         */
         disconnect(handlerId: number): void;
 
+        /**
+         * Connects a handler that runs on every emission of `sigName`, remembering it so `off` can
+         * take the same callback back off again.
+         *
+         * @param sigName Signal to connect to.
+         * @param callback Handler invoked on each emission.
+         * @param isAfter Run the handler after the default handler rather than before it.
+         * @returns The same object, so calls chain.
+         */
         on(sigName: string, callback: (...args: unknown[]) => unknown, isAfter?: boolean): Object;
 
+        /**
+         * Connects a handler that runs at most once and disconnects itself after the first emission.
+         *
+         * @param sigName Signal to connect to.
+         * @param callback Handler invoked on the first emission.
+         * @param isAfter Run the handler after the default handler rather than before it.
+         * @returns The same object, so calls chain.
+         */
         once(sigName: string, callback: (...args: unknown[]) => unknown, isAfter?: boolean): Object;
 
+        /**
+         * Disconnects a handler previously connected with `on` or `once`, given the same callback.
+         *
+         * @param sigName Signal the handler was connected to.
+         * @param callback The handler that was connected.
+         * @returns The same object, so calls chain.
+         */
         off(sigName: string, callback: (...args: unknown[]) => unknown): Object;
 
+        /**
+         * Alias of `on`, for callers who prefer the DOM spelling.
+         *
+         * @param sigName Signal to connect to.
+         * @param callback Handler invoked on each emission.
+         * @param isAfter Run the handler after the default handler rather than before it.
+         * @returns The same object, so calls chain.
+         */
         addEventListener(sigName: string, callback: (...args: unknown[]) => unknown, isAfter?: boolean): Object;
 
+        /**
+         * Alias of `off`, for callers who prefer the DOM spelling.
+         *
+         * @param sigName Signal the handler was connected to.
+         * @param callback The handler that was connected.
+         * @returns The same object, so calls chain.
+         */
         removeEventListener(sigName: string, callback: (...args: unknown[]) => unknown): Object;
     }
 }

--- a/packages/codegen/overrides/gobject/value.ts.ejs
+++ b/packages/codegen/overrides/gobject/value.ts.ejs
@@ -1,6 +1,13 @@
 import { getBoxedValue, getHandle, setBoxedValue } from "@gtkx/runtime";
 import { type Type, Value } from "../gobject.js";
 
+/**
+ * Allocates a `Value`, initializes it to `gtype`, and hands it to `populate` to fill in.
+ *
+ * @param gtype GType the value holds.
+ * @param populate Called with the initialized value to write the contents.
+ * @returns The populated value.
+ */
 export const buildValue = (gtype: Type, populate: (value: Value) => void): Value => {
     const value = new Value();
     value.init(gtype);

--- a/packages/codegen/overrides/graphene/structs.ts.ejs
+++ b/packages/codegen/overrides/graphene/structs.ts.ejs
@@ -1,37 +1,92 @@
 import { Point as GeneratedPoint, Rect as GeneratedRect, Size as GeneratedSize } from "../graphene.js";
 
+/**
+ * Allocates a new `Point` and initializes it to the given coordinates.
+ *
+ * @param x the X coordinate
+ * @param y the Y coordinate
+ * @returns the initialized point
+ */
 const createPoint = (x: number, y: number): GeneratedPoint => {
     const point = GeneratedPoint.alloc();
     point.init(x, y);
     return point;
 };
 
+/**
+ * Allocates a new `Rect` and initializes it to the given origin and size.
+ *
+ * @param x the X coordinate of the origin
+ * @param y the Y coordinate of the origin
+ * @param width the width of the rectangle
+ * @param height the height of the rectangle
+ * @returns the initialized rectangle
+ */
 const createRect = (x: number, y: number, width: number, height: number): GeneratedRect => {
     const rect = GeneratedRect.alloc();
     rect.init(x, y, width, height);
     return rect;
 };
 
+/**
+ * Allocates a new `Size` and initializes it to the given width and height.
+ *
+ * @param width the width
+ * @param height the height
+ * @returns the initialized size
+ */
 const createSize = (width: number, height: number): GeneratedSize => {
     const size = GeneratedSize.alloc();
     size.init(width, height);
     return size;
 };
 
+/** A point with two coordinates. */
 export const Point: typeof GeneratedPoint & { create: typeof createPoint } = Object.assign(GeneratedPoint, {
     create: createPoint,
 });
 
+/** A point with two coordinates. */
 export type Point = GeneratedPoint;
 
+/**
+ * The location and size of a rectangle region.
+ *
+ * The width and height of a `graphene_rect_t` can be negative; for instance,
+ * a `graphene_rect_t` with an origin of [ 0, 0 ] and a size of [ 10, 10 ] is
+ * equivalent to a `graphene_rect_t` with an origin of [ 10, 10 ] and a size
+ * of [ -10, -10 ].
+ *
+ * Application code can normalize rectangles using `graphene_rect_normalize()`;
+ * this function will ensure that the width and height of a rectangle are
+ * positive values. All functions taking a `graphene_rect_t` as an argument
+ * will internally operate on a normalized copy; all functions returning a
+ * `graphene_rect_t` will always return a normalized rectangle.
+ */
 export const Rect: typeof GeneratedRect & { create: typeof createRect } = Object.assign(GeneratedRect, {
     create: createRect,
 });
 
+/**
+ * The location and size of a rectangle region.
+ *
+ * The width and height of a `graphene_rect_t` can be negative; for instance,
+ * a `graphene_rect_t` with an origin of [ 0, 0 ] and a size of [ 10, 10 ] is
+ * equivalent to a `graphene_rect_t` with an origin of [ 10, 10 ] and a size
+ * of [ -10, -10 ].
+ *
+ * Application code can normalize rectangles using `graphene_rect_normalize()`;
+ * this function will ensure that the width and height of a rectangle are
+ * positive values. All functions taking a `graphene_rect_t` as an argument
+ * will internally operate on a normalized copy; all functions returning a
+ * `graphene_rect_t` will always return a normalized rectangle.
+ */
 export type Rect = GeneratedRect;
 
+/** A size. */
 export const Size: typeof GeneratedSize & { create: typeof createSize } = Object.assign(GeneratedSize, {
     create: createSize,
 });
 
+/** A size. */
 export type Size = GeneratedSize;

--- a/packages/codegen/src/docs/api-reference.ts
+++ b/packages/codegen/src/docs/api-reference.ts
@@ -9,7 +9,7 @@ import { namespaceFunctionExportName } from "../store/gi/function.js";
 import { type ElementProps, setElementProps } from "../store/jsx/element-prop-imports.js";
 import { collectIntrinsicElementClasses, type GlibNamedClass } from "../store/jsx/intrinsic-elements.js";
 import { type OmittedProps, setOmittedProps } from "../store/jsx/omitted-props.js";
-import { createElementPageContext, type ElementPageContext, renderElementPage } from "./element-page.js";
+import { type ElementPageContext, renderElementPage } from "./element-page.js";
 import { docsSignatureContext, firstSentence, namespaceOrder } from "./render.js";
 import { type GiSymbolEntry, renderSymbolPage, type SymbolPageOptions } from "./symbol-page.js";
 
@@ -34,7 +34,16 @@ type ApiSymbolQuery = {
 };
 
 /** What an indexed symbol is: one of the GIR symbol kinds, or a JSX element. */
-type ApiSymbolKind = GiSymbolEntry["kind"] | "element";
+type ApiSymbolKind =
+    "alias" |
+    "callback" |
+    "class" |
+    "constant" |
+    "element" |
+    "enum" |
+    "function" |
+    "interface" |
+    "record";
 
 /** An indexed symbol, without its reference page. */
 type ApiSymbol = {
@@ -93,16 +102,30 @@ type ApiSearchOptions = {
     limit?: number;
 };
 
+/** An indexed JSX element, carrying the widget class its page renders from. */
 type ElementEntry = {
+    /** Discriminant marking the entry as a JSX element rather than a GIR symbol. */
     kind: "element";
+    /** GIR namespace declaring the widget class. */
     namespace: GirNamespace;
+    /** Element name, which is the class's GLib type name such as `GtkButton`. */
     name: string;
+    /** Documentation text carried by the widget class's GIR node. */
     doc: string | undefined;
+    /** The widget class the element is generated from. */
     element: GlibNamedClass;
 };
 
+/** Anything the index holds: a GIR symbol or a JSX element. */
 type SymbolEntry = GiSymbolEntry | ElementEntry;
-type ScoredEntry = { score: number; entry: SymbolEntry };
+
+/** A search hit: an indexed entry and how well its name answered the query. */
+type ScoredEntry = {
+    /** Match strength, ranked best first: an exact name, then a prefix, then a substring. */
+    score: number;
+    /** The entry that matched. */
+    entry: SymbolEntry;
+};
 
 /** Every kind the reference indexes, in the order a namespace overview groups its symbols. */
 const API_SYMBOL_KINDS: ApiSymbolKind[] = [
@@ -138,6 +161,9 @@ const compareNames = (a: string, b: string): number => {
 
     return a > b ? 1 : 0;
 };
+
+const symbolKindSet = (kinds: ApiSymbolKind[] | undefined): Set<ApiSymbolKind> | undefined =>
+    kinds === undefined ? undefined : new Set(kinds);
 
 const isQueriedEntry = (
     entry: SymbolEntry,
@@ -280,29 +306,13 @@ const narrowToExactMatches = (candidates: SymbolEntry[], trimmed: string, isQual
     return exact.length > 0 ? exact : candidates;
 };
 
-const isSearchFilterMatch = (
-    entry: SymbolEntry,
-    namespaceFilter: string | undefined,
-    kinds: ApiSymbolKind[] | undefined,
-): boolean => {
-    if (namespaceFilter !== undefined && entry.namespace.name.toLowerCase() !== namespaceFilter) {
-        return false;
-    }
-
-    if (kinds !== undefined && !kinds.includes(entry.kind)) {
-        return false;
-    }
-
-    return true;
-};
-
 const getScoredEntry = (
     entry: SymbolEntry,
     query: string,
     namespaceFilter: string | undefined,
-    kinds: ApiSymbolKind[] | undefined,
+    kinds: Set<ApiSymbolKind> | undefined,
 ): ScoredEntry | undefined => {
-    if (!isSearchFilterMatch(entry, namespaceFilter, kinds)) {
+    if (!isQueriedEntry(entry, namespaceFilter, kinds)) {
         return undefined;
     }
 
@@ -355,12 +365,13 @@ class ApiReference {
     private props: ElementProps;
     private omittedProps: OmittedProps;
 
+    /** Indexes every symbol and JSX element in the GIR data the options point at. */
     constructor(options: ApiReferenceOptions) {
         this.libraries = options.libraries;
         this.props = options.props ?? {};
         this.omittedProps = options.omittedProps ?? {};
         this.library = Library.load(options.libraries, options.girPath);
-        this.elementContext = createElementPageContext(this.library, (): string | undefined => undefined);
+        this.elementContext = { library: this.library, linkFor: (): string | undefined => undefined };
         this.buildIndex();
     }
 
@@ -484,7 +495,7 @@ class ApiReference {
     private scoreEntries(
         query: string,
         namespaceFilter: string | undefined,
-        kinds: ApiSymbolKind[] | undefined,
+        kinds: Set<ApiSymbolKind> | undefined,
     ): ScoredEntry[] {
         const scored: ScoredEntry[] = [];
 
@@ -535,7 +546,7 @@ class ApiReference {
     /** Every indexed symbol the query keeps, ordered by namespace (Gtk, then Adw, then alphabetically) and name. */
     symbols(query: ApiSymbolQuery = {}): ApiSymbol[] {
         const namespaceFilter = query.namespace?.toLowerCase();
-        const kinds = query.kinds === undefined ? undefined : new Set(query.kinds);
+        const kinds = symbolKindSet(query.kinds);
 
         return this.entries
             .filter((entry) => isQueriedEntry(entry, namespaceFilter, kinds))
@@ -556,7 +567,7 @@ class ApiReference {
 
         const limit = Math.max(1, Math.floor(options.limit ?? DEFAULT_SEARCH_LIMIT));
         const namespaceFilter = options.namespace?.toLowerCase();
-        const scored = this.scoreEntries(query, namespaceFilter, options.kinds);
+        const scored = this.scoreEntries(query, namespaceFilter, symbolKindSet(options.kinds));
         scored.sort(compareScoredEntries);
 
         return scored.slice(0, limit).map((item) => this.toApiSymbol(item.entry));

--- a/packages/codegen/src/docs/element-page.ts
+++ b/packages/codegen/src/docs/element-page.ts
@@ -1,11 +1,12 @@
-import { sortStringsBy, toCamelIdentifier, upperFirst } from "@gtkx/utils";
+import { toCamelIdentifier, upperFirst } from "@gtkx/utils";
 import type { GirClass } from "../gir/class.js";
 import type { Library } from "../gir/library.js";
+import type { HandwrittenProp } from "./handwritten-props.js";
 import { ancestorChain } from "../gir/ancestry.js";
 import { type GirNamespace, namespaceDirectory } from "../gir/namespace.js";
 import { type GirProperty, isConstructableProperty } from "../gir/property.js";
+import { annotationSpec } from "../store/gi/doc-spec.js";
 import { elementPropTypeFor } from "../store/jsx/element-prop-imports.js";
-import { buildGirIndex, type GirIndex } from "../store/jsx/gir-index.js";
 import {
     getGlibName,
     type GlibNamedClass,
@@ -15,23 +16,30 @@ import {
 } from "../store/jsx/intrinsic-elements.js";
 import { isOmittedProp } from "../store/jsx/omitted-props.js";
 import { isObjectProp } from "../store/jsx/props.js";
+import { handwrittenPropsFor } from "./handwritten-props.js";
 import {
+    annotationNotes,
     classMethodEntries,
     docMarkdown,
-    docsDefaultValue,
     firstSentence,
     implementsLine,
     joinSections,
-    metaBlock,
+    type MetaDocEntry,
     methodsSectionBlocks,
     originSignatureBlocks,
+    type OriginSignatureEntry,
+    propertyMetaLine,
     renderDocsSignalSignature,
     renderDocsType,
+    signalTags,
+    sortedMetaBlocks,
 } from "./render.js";
 
+/** Shared state an element's reference page renders from. */
 type ElementPageContext = {
+    /** Parsed GIR the element, its ancestors, and the interfaces it implements are read from. */
     library: Library;
-    girIndex: GirIndex;
+    /** Resolves a GLib type name to the URL of its page, undefined when it has none. */
     linkFor: (glibName: string) => string | undefined;
 };
 
@@ -41,24 +49,6 @@ type MemberOwner = {
     origin: string | undefined;
     glibName: string | undefined;
 };
-
-type PropEntry = {
-    name: string;
-    meta: string;
-    doc: string;
-};
-
-type SignalEntry = {
-    name: string;
-    signature: string;
-    doc: string;
-    origin: string | undefined;
-};
-
-const createElementPageContext = (
-    library: Library,
-    linkFor: (glibName: string) => string | undefined,
-): ElementPageContext => ({ library, girIndex: buildGirIndex(library), linkFor });
 
 const frontmatter = (entry: GlibNamedClass): string => {
     const sentence = firstSentence(entry.klass.doc);
@@ -120,29 +110,45 @@ const propertyEntry = (
     owner: MemberOwner,
     property: GirProperty,
     jsName: string,
-): PropEntry => {
+): MetaDocEntry => {
     const isObject = isObjectProp(context.library, property);
     const baseType = renderDocsType(context.library, property.type, false);
     const type = isObject ? `${baseType} | ReactElement` : baseType;
-    const meta: string[] = [`\`${type}\``];
 
-    if (property.defaultValue !== undefined) {
-        meta.push(`default \`${docsDefaultValue(property.defaultValue)}\``);
+    const accessNotes = isConstructableProperty(property)
+        ? []
+        : [`read-only, observe with \`onNotify${upperFirst(jsName)}\``];
+
+    return {
+        name: jsName,
+        meta: propertyMetaLine({ type, property, accessNotes, origin: owner.origin }),
+        doc: docMarkdown(property.doc),
+        tags: annotationSpec(property.annotations),
+    };
+};
+
+const handwrittenPropMeta = (prop: HandwrittenProp, owner: MemberOwner): string =>
+    [`\`${prop.type}\``, ...(owner.origin === undefined ? [] : [`from \`${owner.origin}\``])].join(" · ");
+
+const handwrittenPropEntries = (owner: MemberOwner, seen: Set<string>): MetaDocEntry[] => {
+    const declared = owner.glibName === undefined ? undefined : elementPropTypeFor(owner.glibName);
+
+    if (declared === undefined) {
+        return [];
     }
 
-    if (property.constructOnly) {
-        meta.push("construct-only");
+    const entries: MetaDocEntry[] = [];
+
+    for (const prop of handwrittenPropsFor(declared)) {
+        if (seen.has(prop.name)) {
+            continue;
+        }
+
+        seen.add(prop.name);
+        entries.push({ name: prop.name, meta: handwrittenPropMeta(prop, owner), doc: prop.doc });
     }
 
-    if (!isConstructableProperty(property)) {
-        meta.push(`read-only, observe with \`onNotify${upperFirst(jsName)}\``);
-    }
-
-    if (owner.origin !== undefined) {
-        meta.push(`from \`${owner.origin}\``);
-    }
-
-    return { name: jsName, meta: meta.join(" · "), doc: docMarkdown(property.doc) };
+    return entries;
 };
 
 const propJsName = (property: GirProperty, owner: MemberOwner, seen: Set<string>): string | undefined => {
@@ -161,8 +167,8 @@ const propJsName = (property: GirProperty, owner: MemberOwner, seen: Set<string>
     return jsName;
 };
 
-const ownerPropEntries = (context: ElementPageContext, owner: MemberOwner, seen: Set<string>): PropEntry[] => {
-    const entries: PropEntry[] = [];
+const ownerPropEntries = (context: ElementPageContext, owner: MemberOwner, seen: Set<string>): MetaDocEntry[] => {
+    const entries: MetaDocEntry[] = [...handwrittenPropEntries(owner, seen)];
 
     for (const property of owner.klass.properties) {
         const jsName = propJsName(property, owner, seen);
@@ -175,8 +181,8 @@ const ownerPropEntries = (context: ElementPageContext, owner: MemberOwner, seen:
     return entries;
 };
 
-const propertyEntries = (entry: GlibNamedClass, context: ElementPageContext, seen: Set<string>): PropEntry[] => {
-    const entries: PropEntry[] = [];
+const propertyEntries = (entry: GlibNamedClass, context: ElementPageContext, seen: Set<string>): MetaDocEntry[] => {
+    const entries: MetaDocEntry[] = [];
 
     for (const owner of memberOwners(entry, context)) {
         entries.push(...ownerPropEntries(context, owner, seen));
@@ -200,9 +206,7 @@ const propsSection = (entry: GlibNamedClass, context: ElementPageContext, selfTy
         return ["## Props", intro];
     }
 
-    const sorted = sortStringsBy(entries, (item) => item.name);
-
-    return ["## Props", intro, ...sorted.map((item) => metaBlock(item.name, item.meta, item.doc))];
+    return ["## Props", intro, ...sortedMetaBlocks(entries)];
 };
 
 const ownerSignalEntries = (
@@ -210,8 +214,8 @@ const ownerSignalEntries = (
     owner: MemberOwner,
     selfType: string,
     seen: Set<string>,
-): SignalEntry[] => {
-    const entries: SignalEntry[] = [];
+): OriginSignatureEntry[] => {
+    const entries: OriginSignatureEntry[] = [];
 
     for (const signal of owner.klass.signals) {
         const name = signalHandlerName(signal.name);
@@ -226,6 +230,7 @@ const ownerSignalEntries = (
             name,
             signature: renderDocsSignalSignature(context.library, signal, selfType),
             doc: docMarkdown(signal.doc),
+            tags: signalTags(signal, true),
             origin: owner.origin,
         });
     }
@@ -235,7 +240,7 @@ const ownerSignalEntries = (
 
 const signalsSection = (entry: GlibNamedClass, context: ElementPageContext, selfType: string): string[] => {
     const seen: Set<string> = new Set();
-    const entries: SignalEntry[] = [];
+    const entries: OriginSignatureEntry[] = [];
 
     for (const owner of memberOwners(entry, context)) {
         entries.push(...ownerSignalEntries(context, owner, selfType, seen));
@@ -266,6 +271,7 @@ const renderElementPage = (entry: GlibNamedClass, context: ElementPageContext): 
         frontmatter(entry),
         `# ${entry.glibName}`,
         docMarkdown(entry.klass.doc),
+        ...annotationNotes(entry.klass.annotations),
         importBlock(entry),
         ...hierarchySection(entry, context),
         ...propsSection(entry, context, selfType),
@@ -274,4 +280,4 @@ const renderElementPage = (entry: GlibNamedClass, context: ElementPageContext): 
     ]);
 };
 
-export { createElementPageContext, renderElementPage, type ElementPageContext };
+export { renderElementPage, type ElementPageContext };

--- a/packages/codegen/src/docs/handwritten-props.ts
+++ b/packages/codegen/src/docs/handwritten-props.ts
@@ -1,0 +1,230 @@
+import type { ModuleExport } from "@gtkx/react/config";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+type HandwrittenProp = {
+    name: string;
+    type: string;
+    doc: string;
+};
+
+type AliasSite = {
+    sourceFile: ts.SourceFile;
+    declaration: ts.TypeAliasDeclaration;
+};
+
+type NamedBinding = ts.ImportSpecifier | ts.ExportSpecifier;
+
+const RESOLUTION_OPTIONS: ts.CompilerOptions = {
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    customConditions: ["source"],
+};
+
+const CONTAINING_FILE = fileURLToPath(import.meta.url);
+const WHITESPACE_RUN = /\s+/g;
+const propsByRef: Map<string, HandwrittenProp[]> = new Map();
+
+const moduleFileFor = (specifier: string, containingFile: string): string | undefined =>
+    ts.resolveModuleName(specifier, containingFile, RESOLUTION_OPTIONS, ts.sys).resolvedModule?.resolvedFileName;
+
+const parseModule = (filePath: string): ts.SourceFile =>
+    ts.createSourceFile(filePath, ts.sys.readFile(filePath) ?? "", ts.ScriptTarget.Latest, true);
+
+const specifierText = (node: ts.Expression | undefined): string | undefined =>
+    node !== undefined && ts.isStringLiteral(node) ? node.text : undefined;
+
+const boundName = (elements: readonly NamedBinding[], name: string): string | undefined => {
+    for (const element of elements) {
+        if (element.name.text === name) {
+            return (element.propertyName ?? element.name).text;
+        }
+    }
+
+    return undefined;
+};
+
+const findAliasInModule = (specifier: string, sourceFile: ts.SourceFile, name: string): AliasSite | undefined => {
+    const filePath = moduleFileFor(specifier, sourceFile.fileName);
+
+    return filePath === undefined ? undefined : findAlias(parseModule(filePath), name);
+};
+
+const importedAlias = (
+    statement: ts.ImportDeclaration,
+    sourceFile: ts.SourceFile,
+    name: string,
+): AliasSite | undefined => {
+    const bindings = statement.importClause?.namedBindings;
+    const specifier = specifierText(statement.moduleSpecifier);
+
+    if (specifier === undefined || bindings === undefined || !ts.isNamedImports(bindings)) {
+        return undefined;
+    }
+
+    const imported = boundName(bindings.elements, name);
+
+    return imported === undefined ? undefined : findAliasInModule(specifier, sourceFile, imported);
+};
+
+const exportedAlias = (
+    statement: ts.ExportDeclaration,
+    sourceFile: ts.SourceFile,
+    name: string,
+): AliasSite | undefined => {
+    const specifier = specifierText(statement.moduleSpecifier);
+
+    if (specifier === undefined) {
+        return undefined;
+    }
+
+    const clause = statement.exportClause;
+
+    if (clause === undefined) {
+        return findAliasInModule(specifier, sourceFile, name);
+    }
+
+    const exported = ts.isNamedExports(clause) ? boundName(clause.elements, name) : undefined;
+
+    return exported === undefined ? undefined : findAliasInModule(specifier, sourceFile, exported);
+};
+
+const statementAlias = (statement: ts.Statement, sourceFile: ts.SourceFile, name: string): AliasSite | undefined => {
+    if (ts.isTypeAliasDeclaration(statement)) {
+        return statement.name.text === name ? { sourceFile, declaration: statement } : undefined;
+    }
+
+    if (ts.isImportDeclaration(statement)) {
+        return importedAlias(statement, sourceFile, name);
+    }
+
+    return ts.isExportDeclaration(statement) ? exportedAlias(statement, sourceFile, name) : undefined;
+};
+
+const propType = (type: ts.TypeNode, sourceFile: ts.SourceFile): string => {
+    const parts: readonly ts.TypeNode[] = ts.isUnionTypeNode(type) ? type.types : [type];
+
+    return parts
+        .filter((part) => part.kind !== ts.SyntaxKind.UndefinedKeyword)
+        .map((part) => part.getText(sourceFile).replaceAll(WHITESPACE_RUN, " "))
+        .join(" | ");
+};
+
+const propDoc = (member: ts.TypeElement): string => {
+    const comments = ts
+        .getJSDocCommentsAndTags(member)
+        .map((node) => (ts.isJSDoc(node) ? ts.getTextOfJSDocComment(node.comment) : undefined));
+
+    return comments.filter((text) => text !== undefined).join(" ").replaceAll(WHITESPACE_RUN, " ").trim();
+};
+
+const propertyProp = (member: ts.PropertySignature, sourceFile: ts.SourceFile): HandwrittenProp | undefined => {
+    const { name, type } = member;
+
+    if (type === undefined || !(ts.isIdentifier(name) || ts.isStringLiteral(name))) {
+        return undefined;
+    }
+
+    return { name: name.text, type: propType(type, sourceFile), doc: propDoc(member) };
+};
+
+const indexProp = (member: ts.IndexSignatureDeclaration, sourceFile: ts.SourceFile): HandwrittenProp | undefined => {
+    const keyType = member.parameters[0]?.type;
+
+    if (keyType === undefined) {
+        return undefined;
+    }
+
+    return {
+        name: keyType.getText(sourceFile).replaceAll("`", ""),
+        type: propType(member.type, sourceFile),
+        doc: propDoc(member),
+    };
+};
+
+const memberProp = (member: ts.TypeElement, sourceFile: ts.SourceFile): HandwrittenProp | undefined => {
+    if (ts.isPropertySignature(member)) {
+        return propertyProp(member, sourceFile);
+    }
+
+    return ts.isIndexSignatureDeclaration(member) ? indexProp(member, sourceFile) : undefined;
+};
+
+const literalProps = (type: ts.TypeLiteralNode, sourceFile: ts.SourceFile): HandwrittenProp[] => {
+    const props: HandwrittenProp[] = [];
+
+    for (const member of type.members) {
+        const prop = memberProp(member, sourceFile);
+
+        if (prop !== undefined) {
+            props.push(prop);
+        }
+    }
+
+    return props;
+};
+
+const referenceProps = (type: ts.TypeReferenceNode, sourceFile: ts.SourceFile): HandwrittenProp[] => {
+    if (!ts.isIdentifier(type.typeName)) {
+        return [];
+    }
+
+    const site = findAlias(sourceFile, type.typeName.text);
+
+    return site === undefined ? [] : typeNodeProps(site.declaration.type, site.sourceFile);
+};
+
+const declaredProps = (ref: ModuleExport): HandwrittenProp[] => {
+    const filePath = moduleFileFor(ref.module, CONTAINING_FILE);
+
+    if (filePath === undefined) {
+        throw new Error(`Cannot resolve ${ref.module}, which declares the ${ref.export} element props`);
+    }
+
+    const site = findAlias(parseModule(filePath), ref.export);
+
+    if (site === undefined) {
+        throw new Error(`${ref.module} declares no type named ${ref.export}`);
+    }
+
+    return typeNodeProps(site.declaration.type, site.sourceFile);
+};
+
+const handwrittenPropsFor = (ref: ModuleExport): HandwrittenProp[] => {
+    const key = `${ref.module}#${ref.export}`;
+    const cached = propsByRef.get(key);
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const props = declaredProps(ref);
+    propsByRef.set(key, props);
+
+    return props;
+};
+
+function findAlias(sourceFile: ts.SourceFile, name: string): AliasSite | undefined {
+    for (const statement of sourceFile.statements) {
+        const site = statementAlias(statement, sourceFile, name);
+
+        if (site !== undefined) {
+            return site;
+        }
+    }
+
+    return undefined;
+}
+
+function typeNodeProps(type: ts.TypeNode, sourceFile: ts.SourceFile): HandwrittenProp[] {
+    if (ts.isTypeLiteralNode(type)) {
+        return literalProps(type, sourceFile);
+    }
+
+    if (ts.isIntersectionTypeNode(type)) {
+        return type.types.flatMap((part) => typeNodeProps(part, sourceFile));
+    }
+
+    return ts.isTypeReferenceNode(type) ? referenceProps(type, sourceFile) : [];
+}
+
+export { handwrittenPropsFor, type HandwrittenProp };

--- a/packages/codegen/src/docs/pipeline.ts
+++ b/packages/codegen/src/docs/pipeline.ts
@@ -7,7 +7,7 @@ import { namespaceDirectory } from "../gir/namespace.js";
 import { type ElementProps, setElementProps } from "../store/jsx/element-prop-imports.js";
 import { collectIntrinsicElementClasses, type GlibNamedClass } from "../store/jsx/intrinsic-elements.js";
 import { type OmittedProps, setOmittedProps } from "../store/jsx/omitted-props.js";
-import { createElementPageContext, type ElementPageContext, renderElementPage } from "./element-page.js";
+import { type ElementPageContext, renderElementPage } from "./element-page.js";
 import { elementSlug, firstSentence, namespaceOrder } from "./render.js";
 
 type DocsElementLink = {
@@ -175,7 +175,7 @@ const generatePages = (options: DocsOptions, basePath: string, library: Library)
     const intrinsicElements = collectIntrinsicElementClasses(library);
     const byNamespace = groupElementsByNamespace(intrinsicElements);
     const linkByGlibName = buildElementLinks(intrinsicElements, basePath);
-    const pageContext = createElementPageContext(library, (glibName: string) => linkByGlibName.get(glibName));
+    const pageContext: ElementPageContext = { library, linkFor: (glibName) => linkByGlibName.get(glibName) };
     const pages: Page[] = [];
     const namespaces: DocsNamespace[] = [];
     const orderedNames = sortStringsBy(byNamespace.keys(), namespaceOrder);

--- a/packages/codegen/src/docs/render.ts
+++ b/packages/codegen/src/docs/render.ts
@@ -1,31 +1,57 @@
 import { pascalCase, sortStringsBy } from "@gtkx/utils";
+import type { GirAnnotations } from "../gir/annotations.js";
 import type { GirClass } from "../gir/class.js";
 import type { GirFunction } from "../gir/function.js";
 import type { Library } from "../gir/library.js";
 import type { GirNamespace } from "../gir/namespace.js";
 import type { GirCallable } from "../gir/parameter.js";
+import type { GirProperty } from "../gir/property.js";
 import type { TypeId } from "../gir/type-id.js";
+import type { JsDocDeprecation, JsDocParam, JsDocSpec } from "../writer/doc-tags.js";
 import { collectInheritedMethods, conflictRename } from "../analysis/inheritance.js";
 import { renderHandlerParameters, renderHandlerResultType } from "../analysis/param-structure.js";
 import { recordTypeTarget, renderBaseType, type TsTypeTarget } from "../analysis/ts-type.js";
-import { dedupeCallables, instanceScope, renderInstanceMethodSignature } from "../store/gi/callables.js";
+import {
+    dedupeCallables,
+    instanceMemberSpec,
+    instanceScope,
+    renderInstanceMethodSignature,
+} from "../store/gi/callables.js";
+import { annotationSpec, handlerSpec, selfHandlerSpec } from "../store/gi/doc-spec.js";
 import { methodExportName } from "../store/gi/method.js";
 import { ModuleContext } from "../writer/context.js";
+import { stripDocMedia } from "../writer/doc-tags.js";
 import { gtkDocToMarkdown } from "../writer/gtk-doc.js";
 
 type SignatureEntry = {
     name: string;
     signature: string;
     doc: string;
+    tags?: JsDocSpec | undefined;
 };
 
 type OriginSignatureEntry = SignatureEntry & { origin: string | undefined };
+
+type MetaDocEntry = {
+    name: string;
+    meta: string;
+    doc: string;
+    tags?: JsDocSpec | undefined;
+};
+
+type PropertyMetaOptions = {
+    type: string;
+    property: GirProperty;
+    accessNotes: string[];
+    origin: string | undefined;
+};
 
 const DOCS_DEFAULT_VALUES: Record<string, string> = { TRUE: "true", FALSE: "false", NULL: "null" };
 const FENCE_LINE = /^\s*(```|~~~)/;
 const HEADING_LINE = /^#{1,5}\s/;
 const LEADING_NAMESPACES = ["Gtk", "Adw"];
 const DOCS_SIGNATURE_NAMESPACE = "$docs";
+const WHITESPACE_RUN = /\s+/g;
 
 const docsTarget = (library: Library): TsTypeTarget =>
     recordTypeTarget(
@@ -63,12 +89,6 @@ const renderDocsSignalHandlerType = (library: Library, signal: GirCallable): str
 
 const docsDefaultValue = (value: string): string => DOCS_DEFAULT_VALUES[value] ?? value;
 
-const stripDocMedia = (markdown: string): string =>
-    markdown
-        .replaceAll(/<picture[\s\S]*?<\/picture>/g, "")
-        .replaceAll(/<video[\s\S]*?(?:<\/video>|\/>)/g, "")
-        .replaceAll(/<img[^>]*>/g, "");
-
 const demoteLine = (line: string, isInFence: boolean): { text: string; isInFence: boolean } => {
     if (FENCE_LINE.test(line)) {
         return { text: line, isInFence: !isInFence };
@@ -102,12 +122,15 @@ const stripMarkdown = (markdown: string): string =>
         .replaceAll(/```[\s\S]*?```/g, " ")
         .replaceAll(/`([^`]*)`/g, "$1")
         .replaceAll(/\[([^[\]]*)\]\([^)]*\)/g, "$1")
-        .replaceAll(/[*_#>]/g, "")
-        .replaceAll(/\s+/g, " ")
+        .replaceAll(/[*#>]/g, "")
+        .replaceAll(WHITESPACE_RUN, " ")
         .trim();
 
+const inlineMarkdown = (doc: string | undefined): string => docMarkdown(doc).replaceAll(WHITESPACE_RUN, " ").trim();
+const plainText = (doc: string | undefined): string => stripMarkdown(docMarkdown(doc));
+
 const firstSentence = (doc: string | undefined): string => {
-    const text = stripMarkdown(docMarkdown(doc));
+    const text = plainText(doc);
 
     if (text.length === 0) {
         return "";
@@ -138,14 +161,100 @@ const implementsLine = (names: string[]): string[] => {
 const joinSections = (sections: string[]): string =>
     `${sections.filter((section) => section.length > 0).join("\n\n")}\n`;
 
-const metaBlock = (name: string, meta: string, doc: string): string => {
-    const lines = [`### \`${name}\``, "", meta];
+const paramNotes = (params: JsDocParam[] | undefined): string[] => {
+    const entries = (params ?? [])
+        .map((param) => ({ name: param.name, text: inlineMarkdown(param.doc) }))
+        .filter((entry) => entry.text.length > 0);
 
-    if (doc.length > 0) {
-        lines.push("", doc);
+    if (entries.length === 0) {
+        return [];
+    }
+
+    const bullets = entries.map((entry) => `- \`${entry.name}\`: ${entry.text}`);
+
+    return [["**Parameters**", "", ...bullets].join("\n")];
+};
+
+const labelledNote = (label: string, text: string): string[] => (text.length === 0 ? [] : [`${label} ${text}`]);
+
+const deprecationNote = (deprecation: JsDocDeprecation | undefined): string[] => {
+    if (deprecation === undefined) {
+        return [];
+    }
+
+    const since = deprecation.since;
+    const heading = since === undefined ? "**Deprecated.**" : `**Deprecated since ${since}.**`;
+    const text = inlineMarkdown(deprecation.doc);
+    const body = text.length === 0 ? heading : `${heading} ${text}`;
+
+    return [`> ${body}`];
+};
+
+const sinceNote = (since: string | undefined): string[] =>
+    since === undefined || since.length === 0 ? [] : [`_Available since ${since}._`];
+
+const tagNotes = (spec: JsDocSpec | undefined): string[] => {
+    if (spec === undefined) {
+        return [];
+    }
+
+    return [
+        ...paramNotes(spec.params),
+        ...labelledNote("**Returns**", docMarkdown(spec.returns)),
+        ...labelledNote("**Throws**", inlineMarkdown(spec.throws)),
+        ...deprecationNote(spec.deprecated),
+        ...sinceNote(spec.since),
+    ];
+};
+
+const deprecationMeta = (annotations: GirAnnotations): string[] => {
+    if (!annotations.isDeprecated) {
+        return [];
+    }
+
+    const since = annotations.deprecatedSince;
+
+    return [since === undefined ? "deprecated" : `deprecated since ${since}`];
+};
+
+const annotationNotes = (annotations: GirAnnotations): string[] => tagNotes(annotationSpec(annotations));
+
+const signalTags = (signal: GirCallable, isSelfIncluded: boolean): JsDocSpec =>
+    isSelfIncluded ? selfHandlerSpec(signal) : handlerSpec(signal, signal.parameters);
+
+const metaBlock = (entry: MetaDocEntry): string => {
+    const lines = [`### \`${entry.name}\``, "", entry.meta];
+
+    for (const note of [entry.doc, ...tagNotes(entry.tags)]) {
+        if (note.length > 0) {
+            lines.push("", note);
+        }
     }
 
     return lines.join("\n");
+};
+
+const sortedMetaBlocks = (entries: MetaDocEntry[]): string[] =>
+    sortStringsBy(entries, (item) => item.name).map((item) => metaBlock(item));
+
+const propertyMetaLine = ({ type, property, accessNotes, origin }: PropertyMetaOptions): string => {
+    const meta = [`\`${type}\``];
+
+    if (property.defaultValue !== undefined) {
+        meta.push(`default \`${docsDefaultValue(property.defaultValue)}\``);
+    }
+
+    if (property.constructOnly) {
+        meta.push("construct-only");
+    }
+
+    meta.push(...accessNotes, ...deprecationMeta(property.annotations));
+
+    if (origin !== undefined) {
+        meta.push(`from \`${origin}\``);
+    }
+
+    return meta.join(" · ");
 };
 
 const signatureBlock = (name: string, signature: string, notes: string[]): string => {
@@ -160,6 +269,9 @@ const signatureBlock = (name: string, signature: string, notes: string[]): strin
     return lines.join("\n");
 };
 
+const signatureEntryBlock = (entry: SignatureEntry, leadingNotes: string[] = []): string =>
+    signatureBlock(entry.name, entry.signature, [...leadingNotes, entry.doc, ...tagNotes(entry.tags)]);
+
 const namespaceOrder = (name: string): string => {
     const index = LEADING_NAMESPACES.indexOf(name);
 
@@ -171,10 +283,7 @@ const docsSignatureContext = (namespace: GirNamespace, library: Library): Module
 
 const originSignatureBlocks = (entries: OriginSignatureEntry[]): string[] =>
     sortStringsBy(entries, (item) => item.name).map((item) =>
-        signatureBlock(item.name, item.signature, [
-            item.origin === undefined ? "" : `From \`${item.origin}\`.`,
-            item.doc,
-        ]),
+        signatureEntryBlock(item, item.origin === undefined ? [] : [`From \`${item.origin}\`.`]),
     );
 
 const classMethodEntries = (library: Library, namespace: GirNamespace, klass: GirClass): SignatureEntry[] => {
@@ -189,9 +298,7 @@ const classMethodEntries = (library: Library, namespace: GirNamespace, klass: Gi
 };
 
 const methodsSectionBlocks = (entries: SignatureEntry[], intro: string): string[] =>
-    entries.length === 0
-        ? []
-        : ["## Methods", intro, ...entries.map((item) => signatureBlock(item.name, item.signature, [item.doc]))];
+    entries.length === 0 ? [] : ["## Methods", intro, ...entries.map((item) => signatureEntryBlock(item))];
 
 const instanceMethodEntries = (
     signatureContext: ModuleContext,
@@ -210,13 +317,7 @@ const instanceMethodEntries = (
 
     for (const method of deduped) {
         const nameOverride = rename(method);
-
-        const rendered = renderInstanceMethodSignature(
-            signatureContext,
-            { ...method, doc: undefined },
-            scope,
-            nameOverride,
-        );
+        const rendered = renderInstanceMethodSignature(signatureContext, method, scope, nameOverride);
 
         if (rendered === undefined) {
             continue;
@@ -224,32 +325,45 @@ const instanceMethodEntries = (
 
         entries.push({
             name: nameOverride ?? methodExportName(method),
-            signature: rendered.trim().replace(/;$/, ""),
+            signature: signatureText(rendered),
             doc: docMarkdown(method.doc),
+            tags: instanceMemberSpec(signatureContext, method, scope),
         });
     }
 
     return sortStringsBy(entries, (entry) => entry.name);
 };
 
+const signatureText = (rendered: string): string => {
+    const start = rendered.startsWith("/**") ? rendered.indexOf("*/") + 2 : 0;
+
+    return rendered.slice(start).trim().replace(/;$/, "");
+};
+
 export {
     renderDocsType,
     renderDocsSignalSignature,
     renderDocsSignalHandlerType,
-    docsDefaultValue,
+    annotationNotes,
+    deprecationMeta,
     docMarkdown,
     firstSentence,
     elementSlug,
     implementsLine,
     joinSections,
-    metaBlock,
+    plainText,
+    propertyMetaLine,
+    signalTags,
     signatureBlock,
+    signatureEntryBlock,
+    sortedMetaBlocks,
     namespaceOrder,
     docsSignatureContext,
     originSignatureBlocks,
     classMethodEntries,
     methodsSectionBlocks,
-    instanceMethodEntries,
+    tagNotes,
+    type MetaDocEntry,
     type SignatureEntry,
     type OriginSignatureEntry,
 };

--- a/packages/codegen/src/docs/symbol-page.ts
+++ b/packages/codegen/src/docs/symbol-page.ts
@@ -1,17 +1,19 @@
-import { pascalCase, sortStringsBy } from "@gtkx/utils";
+import { pascalCase, sortStringsBy, upperFirst } from "@gtkx/utils";
+import type { GirAnnotations } from "../gir/annotations.js";
 import type { GirClass } from "../gir/class.js";
-import type { GirEnum } from "../gir/enum.js";
+import type { EnumMember, GirEnum } from "../gir/enum.js";
 import type { GirFunction } from "../gir/function.js";
 import type { Library } from "../gir/library.js";
-import type { GirProperty } from "../gir/property.js";
 import type { GirRecord } from "../gir/record.js";
 import type { ModuleContext } from "../writer/context.js";
+import type { JsDocSpec } from "../writer/doc.js";
 import { reservedSignalMemberRename } from "../analysis/inheritance.js";
 import { renderTsType } from "../analysis/ts-type.js";
 import { ancestorChain } from "../gir/ancestry.js";
 import { callbackAsFunction, type GirCallback } from "../gir/callback.js";
 import { type GirAlias, type GirConstant, type GirNamespace, namespaceDirectory } from "../gir/namespace.js";
 import { PRIMITIVE_TS_TYPE, primitiveCategory } from "../gir/primitives.js";
+import { callableSpec } from "../store/gi/callable-doc.js";
 import {
     dedupeCallables,
     indexMethodsByName,
@@ -21,6 +23,7 @@ import {
     renderStaticSignature,
 } from "../store/gi/callables.js";
 import { constantLiteral } from "../store/gi/constant.js";
+import { annotationSpec } from "../store/gi/doc-spec.js";
 import { enumMemberKey } from "../store/gi/enum.js";
 import {
     methodExportName,
@@ -31,22 +34,31 @@ import {
 import { resolveAccessor, type ResolvedAccessor } from "../store/gi/property-accessor.js";
 import { resolveRecordFieldEntry } from "../store/gi/record-field-accessor.js";
 import { computeRecordFieldSlots } from "../store/gi/record-layout.js";
+import { vfuncEntries } from "../store/gi/vtable.js";
 import { implementedInterfaces, newlyImplementedInterfaces } from "../store/jsx/intrinsic-elements.js";
 import {
+    annotationNotes,
     classMethodEntries,
+    deprecationMeta,
     docMarkdown,
-    docsDefaultValue,
     docsSignatureContext,
     firstSentence,
     implementsLine,
     joinSections,
-    metaBlock,
+    type MetaDocEntry,
     methodsSectionBlocks,
     originSignatureBlocks,
+    type OriginSignatureEntry,
+    plainText,
+    propertyMetaLine,
     renderDocsSignalHandlerType,
     renderDocsType,
+    signalTags,
     signatureBlock,
     type SignatureEntry,
+    signatureEntryBlock,
+    sortedMetaBlocks,
+    tagNotes,
 } from "./render.js";
 
 /** What every indexed GIR symbol carries, whatever its kind. */
@@ -61,16 +73,57 @@ type GiSymbolBase = {
 
 /** A GIR symbol the reference indexes, discriminated by `kind` and carrying the GIR node its page renders from. */
 type GiSymbolEntry =
-    | (GiSymbolBase & { kind: "class" | "interface"; klass: GirClass }) |
-    (GiSymbolBase & { kind: "record"; record: GirRecord }) |
-    (GiSymbolBase & { kind: "enum"; enumeration: GirEnum }) |
-    (GiSymbolBase & { kind: "callback"; callback: GirCallback }) |
-    (GiSymbolBase & { kind: "alias"; alias: GirAlias }) |
-    (GiSymbolBase & { kind: "function"; fn: GirFunction }) |
-    (GiSymbolBase & { kind: "constant"; constant: GirConstant });
+    | (GiSymbolBase & {
+        /** Renders the class page: hierarchy, constructors, static methods, properties, signals, and methods. */
+        kind: "class" | "interface";
+        /** Supplies the ancestry, members, and, on an interface, the vtable slots an implementer fills. */
+        klass: GirClass;
+    }) |
+    (GiSymbolBase & {
+        /** Renders the record page, labeled `union` when the record is one. */
+        kind: "record";
+        /** Supplies the constructors, static methods, fields, and instance methods. */
+        record: GirRecord;
+    }) |
+    (GiSymbolBase & {
+        /** Renders the page for an enumeration, a flags type, or an error domain, as a table of members. */
+        kind: "enum";
+        /** Supplies the members, their values, and the GError domain when the enum carries one. */
+        enumeration: GirEnum;
+    }) |
+    (GiSymbolBase & {
+        /** Renders the callback page as a single function type signature. */
+        kind: "callback";
+        /** Supplies the parameters and return type the signature is rendered from. */
+        callback: GirCallback;
+    }) |
+    (GiSymbolBase & {
+        /** Renders the alias page as the type the alias resolves to. */
+        kind: "alias";
+        /** Supplies the target type the page prints. */
+        alias: GirAlias;
+    }) |
+    (GiSymbolBase & {
+        /** Renders the page for a namespace-level function, promisified when a finish function matches it. */
+        kind: "function";
+        /** Supplies the parameters and return type the signature is rendered from. */
+        fn: GirFunction;
+    }) |
+    (GiSymbolBase & {
+        /** Renders the page for a namespace-level constant, showing its type and literal value. */
+        kind: "constant";
+        /** Supplies the type and the value the literal is emitted from. */
+        constant: GirConstant;
+    });
 
+type ClassSymbol = GiSymbolBase & { klass: GirClass };
+type ClassPageSymbol = ClassSymbol & { kind: "class" | "interface" };
+
+/** What {@link renderSymbolPage} needs besides the entry itself. */
 type SymbolPageOptions = {
+    /** Parsed GIR the page resolves ancestry, interfaces, and referenced types against. */
     library: Library;
+    /** Looks up the JSX element a class is also available as, undefined when it has none. */
     elementNameFor: (namespaceName: string, className: string) => string | undefined;
 };
 
@@ -95,11 +148,10 @@ type PropertyAccessorSetup = {
     methodByName: Map<string, GirFunction>;
 };
 
-type MetaDocEntry = { name: string; meta: string; doc: string };
-type SignalDocEntry = { name: string; signature: string; doc: string; origin: string | undefined };
 type ResolvedRecordField = NonNullable<ReturnType<typeof resolveRecordFieldEntry>>;
 
 const qualifiedName = (entry: GiSymbolBase): string => `${entry.namespace.name}.${entry.name}`;
+const pageTagNotes = (spec: JsDocSpec): string[] => tagNotes({ ...spec, deprecated: undefined, since: undefined });
 
 const frontmatter = (entry: GiSymbolBase, kindLabel: string): string => {
     const sentence = firstSentence(entry.doc);
@@ -114,18 +166,46 @@ const kindLine = (kindLabel: string, namespace: GirNamespace): string =>
 const importBlock = (entry: GiSymbolBase): string =>
     `\`\`\`ts\nimport * as ${entry.namespace.name} from "@gtkx/gi/${namespaceDirectory(entry.namespace)}";\n\`\`\``;
 
+const entryAnnotations = (entry: GiSymbolEntry): GirAnnotations => {
+    switch (entry.kind) {
+        case "class":
+        case "interface": {
+            return entry.klass.annotations;
+        }
+        case "record": {
+            return entry.record.annotations;
+        }
+        case "enum": {
+            return entry.enumeration.annotations;
+        }
+        case "callback": {
+            return entry.callback.annotations;
+        }
+        case "alias": {
+            return entry.alias.annotations;
+        }
+        case "function": {
+            return entry.fn.annotations;
+        }
+        case "constant": {
+            return entry.constant.annotations;
+        }
+    }
+};
+
 const pageHeader = (entry: GiSymbolEntry, kindLabel: string): string[] => [
     frontmatter(entry, kindLabel),
     `# ${qualifiedName(entry)}`,
     kindLine(kindLabel, entry.namespace),
     docMarkdown(entry.doc),
+    ...annotationNotes(entryAnnotations(entry)),
     importBlock(entry),
 ];
 
 const qualifiedClassName = (namespaceName: string, className: string): string =>
     `${namespaceName}.${pascalCase(className)}`;
 
-const elementNote = (entry: GiSymbolBase & { klass: GirClass }, options: SymbolPageOptions): string[] => {
+const elementNote = (entry: ClassSymbol, options: SymbolPageOptions): string[] => {
     const glibName = options.elementNameFor(entry.namespace.name, entry.klass.name);
 
     if (glibName === undefined) {
@@ -139,7 +219,7 @@ const elementNote = (entry: GiSymbolBase & { klass: GirClass }, options: SymbolP
     ];
 };
 
-const hierarchySection = (entry: GiSymbolBase & { klass: GirClass }, library: Library): string[] => {
+const hierarchySection = (entry: ClassSymbol, library: Library): string[] => {
     const ancestors = [...ancestorChain(library, entry.klass, entry.namespace.name)].slice(1).toReversed();
 
     const interfaces = implementedInterfaces(entry.klass, entry.namespace, library).map((iface) =>
@@ -166,7 +246,7 @@ const hierarchySection = (entry: GiSymbolBase & { klass: GirClass }, library: Li
     return lines;
 };
 
-const prerequisitesLine = (entry: GiSymbolBase & { klass: GirClass }, library: Library): string[] => {
+const prerequisitesLine = (entry: ClassSymbol, library: Library): string[] => {
     const names = entry.klass.prerequisites.map((name) => {
         const resolved = library.resolveType(entry.namespace.name, name);
 
@@ -184,33 +264,86 @@ const prerequisitesLine = (entry: GiSymbolBase & { klass: GirClass }, library: L
     return [`Requires ${names.join(", ")}.`];
 };
 
-const staticSection = (options: StaticSectionOptions): string[] => {
-    const rendered: { name: string; block: string }[] = [];
+const interfaceImplementingIntro = (entry: ClassSymbol): string => {
+    const qualified = qualifiedName(entry);
 
-    for (const callable of dedupeCallables(options.callables)) {
-        const signature = renderStaticSignature(options.context, callable, {
-            returnTypeOverride: options.returnTypeOverride,
-            siblings: options.siblings,
-        });
+    return (
+        `A class fills these vtable slots to adopt the interface: declare \`implements ${qualified}Impl\` ` +
+        `on it and pass \`${qualified}\` in the \`implements\` option of \`registerClass\`. Every slot is ` +
+        "optional, and one the class leaves out keeps whatever the interface installs by default. The " +
+        "methods, properties, and signals above come from GLib dispatch."
+    );
+};
 
-        if (signature === undefined) {
-            continue;
-        }
+const classImplementingIntro = (entry: ClassSymbol): string => {
+    const qualified = qualifiedName(entry);
 
-        rendered.push({
-            name: signature.name,
-            block: signatureBlock(signature.name, signature.signature, [docMarkdown(callable.doc)]),
-        });
-    }
+    return (
+        "A subclass declared with `registerClass` overrides these virtual methods to change what " +
+        `\`${qualified}\` does: define the slot as a method on the subclass and call \`super.<slot>(...)\` ` +
+        "to chain up to the inherited implementation. A slot the subclass leaves out keeps that " +
+        "implementation unchanged."
+    );
+};
 
-    if (rendered.length === 0) {
+const implementingIntro = (entry: ClassPageSymbol): string =>
+    entry.kind === "interface" ? interfaceImplementingIntro(entry) : classImplementingIntro(entry);
+
+const implementingSection = (entry: ClassPageSymbol, library: Library): string[] => {
+    const context = docsSignatureContext(entry.namespace, library);
+    const entries = vfuncEntries(context, entry.namespace.name, entry.klass);
+
+    if (entries.length === 0) {
         return [];
     }
 
-    return [options.title, options.intro, ...sortStringsBy(rendered, (item) => item.name).map((item) => item.block)];
+    const blocks = sortStringsBy(entries, (item) => item.name).map((item) =>
+        signatureBlock(item.name, item.signature, [docMarkdown(item.doc)]));
+
+    return ["## Implementing", implementingIntro(entry), ...blocks];
 };
 
-const memberOwners = (entry: GiSymbolBase & { klass: GirClass }, library: Library): MemberOwner[] => [
+const staticEntry = (options: StaticSectionOptions, callable: GirFunction): SignatureEntry | undefined => {
+    const signature = renderStaticSignature(options.context, callable, {
+        returnTypeOverride: options.returnTypeOverride,
+        siblings: options.siblings,
+    });
+
+    if (signature === undefined) {
+        return undefined;
+    }
+
+    const finishFn = matchStaticFinishFunction(options.context, callable, options.siblings);
+
+    return {
+        name: signature.name,
+        signature: signature.signature,
+        doc: docMarkdown(callable.doc),
+        tags: callableSpec(options.context, callable, { finishFn }),
+    };
+};
+
+const staticSection = (options: StaticSectionOptions): string[] => {
+    const entries: SignatureEntry[] = [];
+
+    for (const callable of dedupeCallables(options.callables)) {
+        const entry = staticEntry(options, callable);
+
+        if (entry !== undefined) {
+            entries.push(entry);
+        }
+    }
+
+    if (entries.length === 0) {
+        return [];
+    }
+
+    const blocks = sortStringsBy(entries, (item) => item.name).map((item) => signatureEntryBlock(item));
+
+    return [options.title, options.intro, ...blocks];
+};
+
+const memberOwners = (entry: ClassSymbol, library: Library): MemberOwner[] => [
     { klass: entry.klass, namespace: entry.namespace, origin: undefined },
     ...newlyImplementedInterfaces(entry.klass, entry.namespace, library).map((iface) => ({
         klass: iface.klass,
@@ -264,32 +397,13 @@ const propertyAccessorSetup = (
     };
 };
 
-const propertyMeta = (property: GirProperty, accessor: ResolvedAccessor, origin: string | undefined): string => {
-    const meta: string[] = [`\`${accessor.tsType}\``];
-
-    if (property.defaultValue !== undefined) {
-        meta.push(`default \`${docsDefaultValue(property.defaultValue)}\``);
-    }
-
-    if (property.constructOnly) {
-        meta.push("construct-only");
-    }
-
+const getAccessNotes = (accessor: ResolvedAccessor): string[] => {
     if (!accessor.isWritable) {
-        meta.push("read-only");
-    } else if (!accessor.hasGetter) {
-        meta.push("write-only");
+        return ["read-only"];
     }
 
-    if (origin !== undefined) {
-        meta.push(`from \`${origin}\``);
-    }
-
-    return meta.join(" · ");
+    return accessor.hasGetter ? [] : ["write-only"];
 };
-
-const sortedMetaBlocks = (entries: MetaDocEntry[]): string[] =>
-    sortStringsBy(entries, (item) => item.name).map((item) => metaBlock(item.name, item.meta, item.doc));
 
 const ownerPropertyEntries = (owner: MemberOwner, setup: PropertyAccessorSetup, seen: Set<string>): MetaDocEntry[] => {
     const entries: MetaDocEntry[] = [];
@@ -310,18 +424,21 @@ const ownerPropertyEntries = (owner: MemberOwner, setup: PropertyAccessorSetup, 
 
         entries.push({
             name: accessor.jsName,
-            meta: propertyMeta(property, accessor, owner.origin),
+            meta: propertyMetaLine({
+                type: accessor.tsType,
+                property,
+                accessNotes: getAccessNotes(accessor),
+                origin: owner.origin,
+            }),
             doc: docMarkdown(property.doc),
+            tags: annotationSpec(property.annotations),
         });
     }
 
     return entries;
 };
 
-const propertiesSection = (
-    entry: GiSymbolBase & { kind: "class" | "interface"; klass: GirClass },
-    library: Library,
-): string[] => {
+const propertiesSection = (entry: ClassPageSymbol, library: Library): string[] => {
     const seen: Set<string> = new Set();
     const entries: MetaDocEntry[] = [];
 
@@ -343,8 +460,8 @@ const propertiesSection = (
     return ["## Properties", intro, ...sortedMetaBlocks(entries)];
 };
 
-const ownerSignalEntries = (owner: MemberOwner, library: Library, seen: Set<string>): SignalDocEntry[] => {
-    const entries: SignalDocEntry[] = [];
+const ownerSignalEntries = (owner: MemberOwner, library: Library, seen: Set<string>): OriginSignatureEntry[] => {
+    const entries: OriginSignatureEntry[] = [];
 
     for (const signal of owner.klass.signals) {
         if (seen.has(signal.name)) {
@@ -357,6 +474,7 @@ const ownerSignalEntries = (owner: MemberOwner, library: Library, seen: Set<stri
             name: signal.name,
             signature: renderDocsSignalHandlerType(library, signal),
             doc: docMarkdown(signal.doc),
+            tags: signalTags(signal, false),
             origin: owner.origin,
         });
     }
@@ -364,9 +482,9 @@ const ownerSignalEntries = (owner: MemberOwner, library: Library, seen: Set<stri
     return entries;
 };
 
-const signalsSection = (entry: GiSymbolBase & { klass: GirClass }, library: Library): string[] => {
+const signalsSection = (entry: ClassSymbol, library: Library): string[] => {
     const seen: Set<string> = new Set();
-    const entries: SignalDocEntry[] = [];
+    const entries: OriginSignatureEntry[] = [];
 
     for (const owner of memberOwners(entry, library)) {
         entries.push(...ownerSignalEntries(owner, library, seen));
@@ -383,16 +501,13 @@ const signalsSection = (entry: GiSymbolBase & { klass: GirClass }, library: Libr
     return ["## Signals", intro, ...originSignatureBlocks(entries)];
 };
 
-const classMethodsSection = (entry: GiSymbolBase & { klass: GirClass }, library: Library): string[] =>
+const classMethodsSection = (entry: ClassSymbol, library: Library): string[] =>
     methodsSectionBlocks(
         classMethodEntries(library, entry.namespace, entry.klass),
         "Methods are called on instances. Methods inherited from ancestors are documented on their own pages.",
     );
 
-const classPage = (
-    entry: GiSymbolBase & { kind: "class" | "interface"; klass: GirClass },
-    options: SymbolPageOptions,
-): string => {
+const classPage = (entry: ClassPageSymbol, options: SymbolPageOptions): string => {
     const { library } = options;
     const qualified = qualifiedName(entry);
     const docsContext = docsSignatureContext(entry.namespace, library);
@@ -422,6 +537,7 @@ const classPage = (
         ...propertiesSection(entry, library),
         ...signalsSection(entry, library),
         ...classMethodsSection(entry, library),
+        ...implementingSection(entry, library),
     ]);
 };
 
@@ -462,7 +578,12 @@ const recordInstanceEntries = (context: ModuleContext, record: GirRecord): Signa
             continue;
         }
 
-        entries.push({ name: rendered.name, signature: rendered.signature, doc: docMarkdown(callable.doc) });
+        entries.push({
+            name: rendered.name,
+            signature: rendered.signature,
+            doc: docMarkdown(callable.doc),
+            tags: callableSpec(context, callable, {}),
+        });
     }
 
     return sortStringsBy(entries, (item) => item.name);
@@ -500,7 +621,11 @@ const recordPage = (entry: GiSymbolBase & { kind: "record"; record: GirRecord },
 };
 
 const fieldMeta = (field: ResolvedRecordField): string =>
-    [`\`${field.tsType}\``, ...(field.isWritable ? [] : ["read-only"])].join(" · ");
+    [
+        `\`${field.tsType}\``,
+        ...(field.isWritable ? [] : ["read-only"]),
+        ...deprecationMeta(field.annotations),
+    ].join(" · ");
 
 const fieldsSection = (record: GirRecord, context: ModuleContext, claimedNames: Set<string>): string[] => {
     const { slots } = computeRecordFieldSlots(context, record.fields, record.isUnion);
@@ -513,7 +638,12 @@ const fieldsSection = (record: GirRecord, context: ModuleContext, claimedNames: 
             continue;
         }
 
-        entries.push({ name: field.jsName, meta: fieldMeta(field), doc: docMarkdown(field.doc) });
+        entries.push({
+            name: field.jsName,
+            meta: fieldMeta(field),
+            doc: docMarkdown(field.doc),
+            tags: annotationSpec(field.annotations),
+        });
     }
 
     if (entries.length === 0) {
@@ -523,16 +653,23 @@ const fieldsSection = (record: GirRecord, context: ModuleContext, claimedNames: 
     return ["## Fields", ...sortedMetaBlocks(entries)];
 };
 
+const memberDescription = (member: EnumMember): string => {
+    const markers = deprecationMeta(member.annotations).map((note) => `**${upperFirst(note)}.**`);
+
+    return [...markers, plainText(member.doc)]
+        .filter((part) => part.length > 0)
+        .join(" ")
+        .replaceAll("|", String.raw`\|`);
+};
+
 const enumPage = (entry: GiSymbolBase & { kind: "enum"; enumeration: GirEnum }): string => {
     const { enumeration } = entry;
     const kindLabel = enumeration.errorDomain === undefined ? enumeration.kind : "error domain";
     const qualified = qualifiedName(entry);
 
-    const rows = enumeration.members.map((member) => {
-        const description = firstSentence(member.doc).replaceAll("|", String.raw`\|`);
-
-        return `| \`${enumMemberKey(member.name)}\` | \`${member.value}\` | ${description} |`;
-    });
+    const rows = enumeration.members.map(
+        (member) => `| \`${enumMemberKey(member.name)}\` | \`${member.value}\` | ${memberDescription(member)} |`,
+    );
 
     const usage =
         enumeration.errorDomain === undefined
@@ -551,7 +688,12 @@ const callbackPage = (entry: GiSymbolBase & { kind: "callback"; callback: GirCal
     const parameters = renderMethodSignature(docsContext, fn);
     const signature = `type ${entry.name} = (${parameters}) => ${renderMethodReturnType(docsContext, fn)}`;
 
-    return joinSections([...pageHeader(entry, "callback"), "## Signature", `\`\`\`ts\n${signature}\n\`\`\``]);
+    return joinSections([
+        ...pageHeader(entry, "callback"),
+        "## Signature",
+        `\`\`\`ts\n${signature}\n\`\`\``,
+        ...pageTagNotes(callableSpec(docsContext, fn, {})),
+    ]);
 };
 
 const aliasPage = (entry: GiSymbolBase & { kind: "alias"; alias: GirAlias }, library: Library): string => {
@@ -576,9 +718,12 @@ const functionSignature = (context: ModuleContext, name: string, fn: GirFunction
 
 const functionPage = (entry: GiSymbolBase & { kind: "function"; fn: GirFunction }, library: Library): string => {
     const docsContext = docsSignatureContext(entry.namespace, library);
-    const signature = functionSignature(docsContext, entry.name, entry.fn, entry.namespace.functions);
+    const siblings = entry.namespace.functions;
+    const signature = functionSignature(docsContext, entry.name, entry.fn, siblings);
+    const finishFn = matchStaticFinishFunction(docsContext, entry.fn, siblings);
+    const spec = callableSpec(docsContext, entry.fn, { finishFn });
 
-    return joinSections([...pageHeader(entry, "function"), `\`\`\`ts\n${signature}\n\`\`\``]);
+    return joinSections([...pageHeader(entry, "function"), `\`\`\`ts\n${signature}\n\`\`\``, ...pageTagNotes(spec)]);
 };
 
 const constantPage = (entry: GiSymbolBase & { kind: "constant"; constant: GirConstant }, library: Library): string => {

--- a/packages/codegen/src/khronos/args.ts
+++ b/packages/codegen/src/khronos/args.ts
@@ -1,6 +1,6 @@
 import { toCamelIdentifier } from "@gtkx/utils";
 import type { GlCommand, GlParam } from "./model.js";
-import type { CommandPlan, GlScalar, ParamPlan } from "./plan.js";
+import type { CommandPlan, GlScalar, ParamPlan, ReturnPlan } from "./plan.js";
 import {
     tArray,
     tBoolean,
@@ -15,14 +15,14 @@ import {
 import { paramPairAt } from "./param-pair.js";
 
 type InArg = {
-    out: false;
+    isOut: false;
     name: string;
     tsType: string;
     descriptor: string;
 };
 
 type OutArg = {
-    out: true;
+    isOut: true;
     cellName: string;
     seed: string;
     tsType: string;
@@ -31,7 +31,7 @@ type OutArg = {
 };
 
 type PlannedArg = InArg | OutArg;
-type OutArgCell = Pick<OutArg, "out" | "cellName" | "paramIndex">;
+type OutArgCell = Pick<OutArg, "isOut" | "cellName" | "paramIndex">;
 type OutArgFields = Pick<OutArg, "seed" | "tsType" | "descriptor">;
 
 type OutArgFieldsOptions = {
@@ -54,6 +54,29 @@ const OUT_PLAN_KINDS: Set<string> = new Set(["ref-out", "ref-array-out", "ref-fi
 const scalarAliasOrGroup = (scalar: GlScalar, group: string | undefined): string =>
     group !== undefined && scalar.isGroupBearing === true ? group : scalar.tsAlias;
 
+const returnPlanTsType = (plan: ReturnPlan, group: string | undefined): string => {
+    switch (plan.kind) {
+        case "void": {
+            return "void";
+        }
+        case "scalar": {
+            return scalarAliasOrGroup(plan.scalar, group);
+        }
+        case "boolean": {
+            return "boolean";
+        }
+        case "string": {
+            return "string";
+        }
+        case "sync": {
+            return "GLsync";
+        }
+        case "opaque-pointer": {
+            return "GLpointer";
+        }
+    }
+};
+
 const paramIndexByName = (command: GlCommand, name: string): number => {
     const index = command.params.findIndex((param) => param.name === name);
 
@@ -71,7 +94,7 @@ const arrayInTsType = (scalar: GlScalar, group: string | undefined): string => {
 };
 
 const inArg = (name: string, tsType: string, descriptor: string): InArg => ({
-    out: false,
+    isOut: false,
     name,
     tsType,
     descriptor,
@@ -141,7 +164,7 @@ const outArgFields = (options: OutArgFieldsOptions): OutArgFields => {
 
             return {
                 seed: `const ${cellName} = { value: new Array<number>(${lenIdentifier}).fill(0) };`,
-                tsType: `${track(plan.scalar.tsAlias)}[]`,
+                tsType: `${track(scalarAliasOrGroup(plan.scalar, param.group))}[]`,
                 descriptor: tRef(tSizedArray(plan.scalar.descriptor, sizeIndex)),
             };
         }
@@ -182,14 +205,14 @@ const buildOutArg = (options: BuildArgOptions, track: (alias: string) => string)
     }
 
     const cellName = `out${String(outIndex)}`;
-    const cell: OutArgCell = { out: true, cellName, paramIndex: index };
+    const cell: OutArgCell = { isOut: true, cellName, paramIndex: index };
 
     return { ...cell, ...outArgFields({ command, plan, param, cellName, track }) };
 };
 
 const isOutPlan = (plan: ParamPlan): boolean => OUT_PLAN_KINDS.has(plan.kind);
-const isInArg = (arg: PlannedArg): arg is InArg => !arg.out;
-const isOutArg = (arg: PlannedArg): arg is OutArg => arg.out;
+const isInArg = (arg: PlannedArg): arg is InArg => !arg.isOut;
+const isOutArg = (arg: PlannedArg): arg is OutArg => arg.isOut;
 
 const buildArg = (options: BuildArgOptions, name: string, track: (alias: string) => string): PlannedArg =>
     isOutPlan(options.plan) ? buildOutArg(options, track) : buildInArg(options, name, track);
@@ -203,7 +226,7 @@ const trackInto =
         };
 
 const planArgs = (
-    plan: CommandPlan & { ok: true },
+    plan: CommandPlan & { isOk: true },
     usedTypes: Set<string>,
 ): { args: PlannedArg[]; ins: InArg[]; outs: OutArg[] } => {
     const track = trackInto(usedTypes);
@@ -230,7 +253,7 @@ const planArgs = (
 };
 
 const scalarPrefixArg = (
-    plan: CommandPlan & { ok: true },
+    plan: CommandPlan & { isOk: true },
     index: number,
     track: (alias: string) => string,
 ): InArg | undefined => {
@@ -251,7 +274,7 @@ const scalarPrefixArg = (
     );
 };
 
-const scalarPrefixArgs = (plan: CommandPlan & { ok: true }, usedTypes: Set<string>): InArg[] | undefined => {
+const scalarPrefixArgs = (plan: CommandPlan & { isOk: true }, usedTypes: Set<string>): InArg[] | undefined => {
     const track = trackInto(usedTypes);
     const prefix: InArg[] = [];
 
@@ -268,4 +291,4 @@ const scalarPrefixArgs = (plan: CommandPlan & { ok: true }, usedTypes: Set<strin
     return prefix;
 };
 
-export { scalarAliasOrGroup, trackInto, planArgs, scalarPrefixArgs, type InArg, type OutArg };
+export { returnPlanTsType, scalarAliasOrGroup, trackInto, planArgs, scalarPrefixArgs, type InArg, type OutArg };

--- a/packages/codegen/src/khronos/doc-context.ts
+++ b/packages/codegen/src/khronos/doc-context.ts
@@ -1,0 +1,62 @@
+import { sortStrings } from "@gtkx/utils";
+import type { GlExtensionAttribution, GlExtensionIndex } from "./extensions.js";
+import type { GlEnum, GlRegistry, GlType } from "./model.js";
+import type { CommandPlan } from "./plan.js";
+
+type GlDocEnumRow = {
+    token: GlEnum;
+    exportName: string;
+};
+
+type GlDocContext = {
+    registryComment?: string;
+    kinds: Map<string, string>;
+    types: Map<string, GlType>;
+    aliasTargets: Map<string, string[]>;
+    extensionCommands: Map<string, GlExtensionAttribution[]>;
+    extensionEnums: Map<string, GlExtensionAttribution[]>;
+    bitmaskGroups: Set<string>;
+    emittedCommands: Set<string>;
+    groupMembers: Map<string, string[]>;
+};
+
+type BuildDocContextOptions = {
+    registry: GlRegistry;
+    extensions: GlExtensionIndex;
+    plans: (CommandPlan & { isOk: true })[];
+    enumRows: GlDocEnumRow[];
+};
+
+const buildGroupMembers = (rows: GlDocEnumRow[]): Map<string, string[]> => {
+    const members: Map<string, string[]> = new Map();
+
+    for (const row of rows) {
+        for (const group of row.token.groups) {
+            members.set(group, [...(members.get(group) ?? []), row.exportName]);
+        }
+    }
+
+    for (const [group, names] of members) {
+        members.set(group, sortStrings(names));
+    }
+
+    return members;
+};
+
+const buildDocContext = (options: BuildDocContextOptions): GlDocContext => {
+    const { registry, extensions, plans, enumRows } = options;
+
+    return {
+        ...(registry.comment !== undefined && { registryComment: registry.comment }),
+        kinds: registry.kinds,
+        types: registry.types,
+        aliasTargets: registry.aliasTargets,
+        extensionCommands: extensions.commands,
+        extensionEnums: extensions.enums,
+        bitmaskGroups: registry.bitmaskGroups,
+        emittedCommands: new Set(plans.map((plan) => plan.command.name)),
+        groupMembers: buildGroupMembers(enumRows),
+    };
+};
+
+export { buildDocContext, type GlDocContext };

--- a/packages/codegen/src/khronos/extensions.ts
+++ b/packages/codegen/src/khronos/extensions.ts
@@ -1,0 +1,85 @@
+import { sortStrings } from "@gtkx/utils";
+import type { GlExtension, GlInterfaceBlock, GlRegistry } from "./model.js";
+import type { GlSelection } from "./select.js";
+
+type GlExtensionAttribution = {
+    name: string;
+    notes: string[];
+};
+
+type GlExtensionIndex = {
+    commands: Map<string, GlExtensionAttribution[]>;
+    enums: Map<string, GlExtensionAttribution[]>;
+};
+
+type PendingIndex = Map<string, Map<string, string[]>>;
+
+type PendingExtensionIndex = {
+    commands: PendingIndex;
+    enums: PendingIndex;
+};
+
+const SUPPORTED_APIS: Set<string> = new Set(["gl", "glcore"]);
+
+const isExtensionSupported = (extension: GlExtension): boolean =>
+    extension.supported.some((api) => SUPPORTED_APIS.has(api));
+
+const isBlockIncluded = (block: GlInterfaceBlock, selection: GlSelection): boolean =>
+    block.kind === "require" &&
+    (block.api === undefined || block.api === selection.api) &&
+    (block.profile === undefined || block.profile === selection.profile);
+
+const blockNotes = (extension: GlExtension, block: GlInterfaceBlock): string[] => [
+    ...(extension.comment === undefined ? [] : [extension.comment]),
+    ...(block.comment === undefined ? [] : [block.comment]),
+];
+
+const appendMembers = (index: PendingIndex, names: string[], extension: string, notes: string[]): void => {
+    for (const name of names) {
+        const byExtension = index.get(name) ?? new Map<string, string[]>();
+        byExtension.set(extension, [...(byExtension.get(extension) ?? []), ...notes]);
+        index.set(name, byExtension);
+    }
+};
+
+const indexExtension = (index: PendingExtensionIndex, extension: GlExtension, selection: GlSelection): void => {
+    for (const block of extension.blocks) {
+        if (!isBlockIncluded(block, selection)) {
+            continue;
+        }
+
+        const notes = blockNotes(extension, block);
+        appendMembers(index.commands, block.commands, extension.name, notes);
+        appendMembers(index.enums, block.enums, extension.name, notes);
+    }
+};
+
+const attributionsFor = (byExtension: Map<string, string[]>): GlExtensionAttribution[] =>
+    sortStrings(byExtension.keys()).map((name) => ({
+        name,
+        notes: [...new Set(byExtension.get(name))],
+    }));
+
+const finalizeIndex = (pending: PendingIndex): Map<string, GlExtensionAttribution[]> => {
+    const index: Map<string, GlExtensionAttribution[]> = new Map();
+
+    for (const [name, byExtension] of pending) {
+        index.set(name, attributionsFor(byExtension));
+    }
+
+    return index;
+};
+
+const buildExtensionIndex = (registry: GlRegistry, selection: GlSelection): GlExtensionIndex => {
+    const pending: PendingExtensionIndex = { commands: new Map(), enums: new Map() };
+
+    for (const extension of registry.extensions) {
+        if (isExtensionSupported(extension)) {
+            indexExtension(pending, extension, selection);
+        }
+    }
+
+    return { commands: finalizeIndex(pending.commands), enums: finalizeIndex(pending.enums) };
+};
+
+export { buildExtensionIndex, type GlExtensionAttribution, type GlExtensionIndex };

--- a/packages/codegen/src/khronos/jsdoc.ts
+++ b/packages/codegen/src/khronos/jsdoc.ts
@@ -1,24 +1,52 @@
 import { toCamelIdentifier } from "@gtkx/utils";
 import type { InArg, OutArg } from "./args.js";
-import type { GlCommand } from "./model.js";
-import type { ReturnPlan } from "./plan.js";
+import type { GlDocContext } from "./doc-context.js";
+import type { GlCommand, GlGlx, GlParam } from "./model.js";
+import type { CommandPlan, ParamPlan, ReturnPlan } from "./plan.js";
+import type { GlSymbolProvenance } from "./select.js";
+import { returnPlanTsType, scalarAliasOrGroup } from "./args.js";
+import {
+    asSentence,
+    backtick,
+    backtickList,
+    commandExportName,
+    kindDescriptions,
+    metadataNotes,
+    type MetadataNotesOptions,
+    provenanceLines,
+} from "./notes.js";
+import { paramPairAt } from "./param-pair.js";
+
+type OkPlan = CommandPlan & { isOk: true };
+
+type ParamPair = {
+    param: GlParam;
+    paramPlan: ParamPlan;
+};
 
 type CommandJsDocOptions = {
-    command: GlCommand;
-    feature: string;
+    plan: OkPlan;
+    provenance: GlSymbolProvenance;
     ins: InArg[];
     outs: OutArg[];
-    returnPlan: ReturnPlan;
+    docs: GlDocContext;
 };
 
-type SingularJsDocOptions = {
-    commandName: string;
-    feature: string;
+type DerivedJsDocOptions = {
+    command: GlCommand;
+    provenance: GlSymbolProvenance;
     summary: string;
     body: string[];
+    docs: GlDocContext;
 };
 
-const REFPAGES_BASE = "https://registry.khronos.org/OpenGL-Refpages/gl4/html";
+const GROUPED_PLAN_KINDS: Set<string> = new Set(["scalar", "array-in", "ref-out", "ref-array-out"]);
+const LENGTHLESS_PLAN_KINDS: Set<string> = new Set(["byte-offset", "byte-offset-array", "ref-out"]);
+
+const OFFSET_NOTES: Map<string, string> = new Map([
+    ["byte-offset", "byte offset into the bound buffer"],
+    ["byte-offset-array", "byte offsets into the bound buffer"],
+]);
 
 const formatPrototype = (command: GlCommand): string => {
     const params = command.params
@@ -28,87 +56,155 @@ const formatPrototype = (command: GlCommand): string => {
     return `${command.returnCType} ${command.name}(${params})`;
 };
 
-const inParamDocLine = (command: GlCommand, arg: InArg): string => {
-    const param = command.params.find((candidate) => toCamelIdentifier(candidate.name) === arg.name);
+const glxLine = (glx: GlGlx): string => {
+    const opcode = ` * GLX ${glx.type} opcode ${glx.opcode}.`;
 
-    if (param === undefined) {
-        return ` * @param ${arg.name}`;
-    }
-
-    const notes: string[] = [`\`${param.cType}\``];
-
-    if (param.group !== undefined) {
-        notes.push(`group \`${param.group}\``);
-    }
-
-    if (param.len !== undefined) {
-        notes.push(`length \`${param.len}\``);
-    }
-
-    if (param.objectClass !== undefined) {
-        notes.push(`object class \`${param.objectClass}\``);
-    }
-
-    return ` * @param ${arg.name} - ${notes.join(", ")}`;
+    return glx.comment === undefined ? opcode : `${opcode} ${asSentence(glx.comment)}`;
 };
 
-const outMember = (command: GlCommand, out: OutArg): string => {
-    const param = command.params[out.paramIndex];
+const aliasLine = (aliases: string[]): string => ` * Also known as ${backtickList(aliases)}.`;
 
-    if (param === undefined) {
-        throw new Error(`Output parameter index ${String(out.paramIndex)} out of range on ${command.name}`);
+const vectorFormLines = (command: GlCommand, docs: GlDocContext): string[] => {
+    const target = command.vecEquiv;
+
+    if (target === undefined || !docs.emittedCommands.has(target)) {
+        return [];
     }
 
-    return `\`${param.name}\` (\`${param.cType}\`)`;
+    return [` * Vector form: ${backtick(commandExportName(target))}.`];
 };
 
-const returnsDocLine = (command: GlCommand, returnPlan: ReturnPlan, outs: OutArg[]): string | undefined => {
-    const members: string[] = [];
+const commandNotes = (command: GlCommand, docs: GlDocContext): string[] => {
+    const aliases = docs.aliasTargets.get(command.name) ?? [];
 
-    if (returnPlan.kind !== "void") {
-        members.push(`\`${command.returnCType}\``);
-    }
+    return [
+        ...(command.comment === undefined ? [] : [` * Registry note: ${command.comment}`]),
+        ...(aliases.length > 0 ? [aliasLine(aliases)] : []),
+        ...vectorFormLines(command, docs),
+        ...(command.glx === undefined ? [] : [glxLine(command.glx)]),
+    ];
+};
 
-    for (const out of outs) {
-        members.push(outMember(command, out));
-    }
+const isGroupFolded = (plan: ParamPlan | ReturnPlan, group: string): boolean =>
+    GROUPED_PLAN_KINDS.has(plan.kind) &&
+    "scalar" in plan &&
+    scalarAliasOrGroup(plan.scalar, group) !== plan.scalar.tsAlias;
 
-    if (members.length === 0) {
+const groupEntry = (param: GlParam, paramPlan: ParamPlan): { group?: string } =>
+    param.group === undefined || isGroupFolded(paramPlan, param.group) ? {} : { group: param.group };
+
+const lengthEntry = (param: GlParam, paramPlan: ParamPlan): { len?: string } =>
+    param.len === undefined || LENGTHLESS_PLAN_KINDS.has(paramPlan.kind) ? {} : { len: param.len };
+
+const paramShape = (param: GlParam, paramPlan: ParamPlan, type: string): MetadataNotesOptions => {
+    const note = OFFSET_NOTES.get(paramPlan.kind);
+
+    return {
+        type,
+        ...groupEntry(param, paramPlan),
+        ...lengthEntry(param, paramPlan),
+        ...(param.objectClass !== undefined && { objectClass: param.objectClass }),
+        ...(note !== undefined && { note }),
+        kinds: param.kinds,
+    };
+};
+
+const returnShape = (plan: OkPlan): MetadataNotesOptions => {
+    const { command, returnPlan } = plan;
+    const group = command.returnGroup;
+
+    return {
+        type: returnPlanTsType(returnPlan, group),
+        ...(group !== undefined && !isGroupFolded(returnPlan, group) && { group }),
+        ...(command.returnObjectClass !== undefined && { objectClass: command.returnObjectClass }),
+        kinds: command.returnKinds,
+    };
+};
+
+const paramPairFor = (plan: OkPlan, argName: string): ParamPair | undefined => {
+    const index = plan.command.params.findIndex((candidate) => toCamelIdentifier(candidate.name) === argName);
+    const { param, paramPlan } = paramPairAt(plan, index);
+
+    if (param === undefined || paramPlan === undefined) {
         return undefined;
     }
 
+    return { param, paramPlan };
+};
+
+const inParamDocLine = (plan: OkPlan, arg: InArg, docs: GlDocContext): string => {
+    const pair = paramPairFor(plan, arg.name);
+
+    if (pair === undefined) {
+        return ` * @param ${arg.name}`;
+    }
+
+    const descriptions = kindDescriptions(pair.param.kinds, docs.kinds);
+    const sentence = descriptions.length === 0 ? "" : `. ${descriptions}`;
+    const notes = metadataNotes(paramShape(pair.param, pair.paramPlan, arg.tsType));
+
+    return ` * @param ${arg.name} - ${notes}${sentence}`;
+};
+
+const outMember = (plan: OkPlan, out: OutArg): string => {
+    const { param, paramPlan } = paramPairAt(plan, out.paramIndex);
+
+    if (param === undefined || paramPlan === undefined) {
+        throw new Error(`Output parameter index ${String(out.paramIndex)} out of range on ${plan.command.name}`);
+    }
+
+    return `${backtick(param.name)} (${metadataNotes(paramShape(param, paramPlan, out.tsType))})`;
+};
+
+const returnsDocLine = (plan: OkPlan, outs: OutArg[]): string | undefined => {
+    const members = [
+        ...(plan.returnPlan.kind === "void" ? [] : [metadataNotes(returnShape(plan))]),
+        ...outs.map((out) => outMember(plan, out)),
+    ];
+
     const [single] = members;
 
-    if (single !== undefined && members.length === 1) {
+    if (single === undefined) {
+        return undefined;
+    }
+
+    if (members.length === 1) {
         return ` * @returns ${single}`;
     }
 
     return ` * @returns Tuple of ${members.join(", ")}`;
 };
 
-const singularJsDoc = ({ commandName, feature, summary, body }: SingularJsDocOptions): string =>
+const tagBlock = (tags: string[]): string[] => (tags.length === 0 ? [] : [" *", ...tags]);
+
+const derivedJsDoc = ({ command, provenance, summary, body, docs }: DerivedJsDocOptions): string =>
     [
         "/**",
         ` * ${summary}`,
         " *",
-        ` * Provided by \`${feature}\`.`,
-        ...body,
-        ` * @see ${REFPAGES_BASE}/${commandName}.xhtml`,
+        ...provenanceLines(provenance, docs.extensionCommands.get(command.name) ?? []),
+        ...tagBlock(body),
         " */",
     ].join("\n");
 
-const commandJsDoc = ({ command, feature, ins, outs, returnPlan }: CommandJsDocOptions): string => {
-    const returnsLine = returnsDocLine(command, returnPlan, outs);
+const commandJsDoc = ({ plan, provenance, ins, outs, docs }: CommandJsDocOptions): string => {
+    const { command } = plan;
+    const returnsLine = returnsDocLine(plan, outs);
 
-    return singularJsDoc({
-        commandName: command.name,
-        feature,
-        summary: `\`${formatPrototype(command)}\``,
-        body: [
-            ...(ins.length > 0 ? [" *", ...ins.map((arg) => inParamDocLine(command, arg))] : []),
-            ...(returnsLine === undefined ? [] : [returnsLine]),
-        ],
-    });
+    const tags = [
+        ...ins.map((arg) => inParamDocLine(plan, arg, docs)),
+        ...(returnsLine === undefined ? [] : [returnsLine]),
+    ];
+
+    return [
+        "/**",
+        ` * ${backtick(formatPrototype(command))}`,
+        " *",
+        ...provenanceLines(provenance, docs.extensionCommands.get(command.name) ?? []),
+        ...commandNotes(command, docs),
+        ...tagBlock(tags),
+        " */",
+    ].join("\n");
 };
 
-export { inParamDocLine, singularJsDoc, commandJsDoc };
+export { commandJsDoc, derivedJsDoc, inParamDocLine };

--- a/packages/codegen/src/khronos/model.ts
+++ b/packages/codegen/src/khronos/model.ts
@@ -1,3 +1,4 @@
+import { sortStrings } from "@gtkx/utils";
 import { collectText, nodeAttr, nodeChildren, nodeTag, type OrderedNode, parseRegistryFile } from "./parse.js";
 
 type GlParam = {
@@ -6,12 +7,25 @@ type GlParam = {
     group?: string;
     len?: string;
     objectClass?: string;
+    kinds: string[];
+};
+
+type GlGlx = {
+    type: string;
+    opcode: string;
+    comment?: string;
 };
 
 type GlCommand = {
     name: string;
     returnCType: string;
     returnGroup?: string;
+    returnObjectClass?: string;
+    returnKinds: string[];
+    comment?: string;
+    aliasTarget?: string;
+    vecEquiv?: string;
+    glx?: GlGlx;
     params: GlParam[];
 };
 
@@ -19,10 +33,27 @@ type GlEnum = {
     name: string;
     value: string;
     groups: string[];
+    comment?: string;
+    alias?: string;
+    api?: string;
+    valueType?: string;
+    vendor?: string;
+    blockComment?: string;
+    isBitmask: boolean;
+};
+
+type GlEnumBlock = {
+    group?: string;
+    vendor?: string;
+    comment?: string;
+    isBitmask: boolean;
 };
 
 type GlInterfaceBlock = {
+    kind: "require" | "remove";
+    api?: string;
     profile?: string;
+    comment?: string;
     commands: string[];
     enums: string[];
 };
@@ -31,20 +62,62 @@ type GlFeature = {
     api: string;
     name: string;
     number: number;
-    requires: GlInterfaceBlock[];
-    removes: GlInterfaceBlock[];
+    blocks: GlInterfaceBlock[];
+};
+
+type GlExtension = {
+    name: string;
+    supported: string[];
+    comment?: string;
+    blocks: GlInterfaceBlock[];
+};
+
+type GlType = {
+    name: string;
+    declaration: string;
+    requires?: string;
+    comment?: string;
 };
 
 type GlRegistry = {
+    comment?: string;
+    types: Map<string, GlType>;
+    kinds: Map<string, string>;
     commands: Map<string, GlCommand>;
     enums: GlEnum[];
     features: GlFeature[];
+    extensions: GlExtension[];
+    aliasTargets: Map<string, string[]>;
+    bitmaskGroups: Set<string>;
 };
+
+type CommandExtras = {
+    params: GlParam[];
+    aliasTarget: string | undefined;
+    vecEquiv: string | undefined;
+    glx: GlGlx | undefined;
+};
+
+type SectionHandler = (section: OrderedNode, registry: GlRegistry) => void;
 
 const NAME_TAG = "name";
 const SKIP_IN_C_TYPE: Set<string> = new Set([NAME_TAG, "comment"]);
+const EMPTY_SKIP: Set<string> = new Set();
+
+const definedEntry = <K extends string, V>(key: K, value: V | undefined): Partial<Record<K, V>> =>
+    value === undefined ? {} : ({ [key]: value } as Partial<Record<K, V>>);
 
 const normalizeWhitespace = (text: string): string => text.replaceAll(/\s+/g, " ").trim();
+
+const normalizeBlockText = (text: string): string =>
+    text
+        .split("\n")
+        .map((line) => line.trim())
+        .join("\n")
+        .trim();
+
+const splitAttr = (value: string | undefined, separator: string): string[] =>
+    value === undefined ? [] : value.split(separator).map((part) => part.trim());
 
 const childNamed = (node: OrderedNode, tag: string): OrderedNode | undefined => {
     for (const child of nodeChildren(node)) {
@@ -63,25 +136,51 @@ const elementName = (node: OrderedNode): string => {
         return "";
     }
 
-    return normalizeWhitespace(collectText(nameChild, new Set()));
+    return normalizeWhitespace(collectText(nameChild, EMPTY_SKIP));
 };
 
-const parseParam = (node: OrderedNode): GlParam => {
-    const param: GlParam = {
-        name: elementName(node),
-        cType: normalizeWhitespace(collectText(node, SKIP_IN_C_TYPE)),
-    };
+const parseParam = (node: OrderedNode): GlParam => ({
+    name: elementName(node),
+    cType: normalizeWhitespace(collectText(node, SKIP_IN_C_TYPE)),
+    kinds: splitAttr(nodeAttr(node, "kind"), ","),
+    ...definedEntry("group", nodeAttr(node, "group")),
+    ...definedEntry("len", nodeAttr(node, "len")),
+    ...definedEntry("objectClass", nodeAttr(node, "class")),
+});
 
-    const group = nodeAttr(node, "group");
-    const len = nodeAttr(node, "len");
-    const objectClass = nodeAttr(node, "class");
+const parseGlx = (node: OrderedNode): GlGlx | undefined => {
+    const type = nodeAttr(node, "type");
+    const opcode = nodeAttr(node, "opcode");
 
-    return {
-        ...param,
-        ...((group !== undefined) && { group }),
-        ...((len !== undefined) && { len }),
-        ...((objectClass !== undefined) && { objectClass }),
-    };
+    if (type === undefined || opcode === undefined || nodeAttr(node, NAME_TAG) !== undefined) {
+        return undefined;
+    }
+
+    return { type, opcode, ...definedEntry("comment", nodeAttr(node, "comment")) };
+};
+
+const collectCommandChild = (child: OrderedNode, into: CommandExtras): void => {
+    switch (nodeTag(child)) {
+        case "param": {
+            into.params.push(parseParam(child));
+            break;
+        }
+        case "alias": {
+            into.aliasTarget = nodeAttr(child, NAME_TAG);
+            break;
+        }
+        case "vecequiv": {
+            into.vecEquiv = nodeAttr(child, NAME_TAG);
+            break;
+        }
+        case "glx": {
+            into.glx ??= parseGlx(child);
+            break;
+        }
+        default: {
+            break;
+        }
+    }
 };
 
 const parseCommand = (node: OrderedNode): GlCommand | undefined => {
@@ -91,57 +190,73 @@ const parseCommand = (node: OrderedNode): GlCommand | undefined => {
         return undefined;
     }
 
-    const params: GlParam[] = [];
+    const extras: CommandExtras = { params: [], aliasTarget: undefined, vecEquiv: undefined, glx: undefined };
 
     for (const child of nodeChildren(node)) {
-        if (nodeTag(child) === "param") {
-            params.push(parseParam(child));
-        }
+        collectCommandChild(child, extras);
     }
-
-    const returnGroup = nodeAttr(proto, "group");
 
     return {
         name: elementName(proto),
         returnCType: normalizeWhitespace(collectText(proto, SKIP_IN_C_TYPE)),
-        ...((returnGroup !== undefined) && { returnGroup }),
-        params,
+        returnKinds: splitAttr(nodeAttr(proto, "kind"), ","),
+        ...definedEntry("returnGroup", nodeAttr(proto, "group")),
+        ...definedEntry("returnObjectClass", nodeAttr(proto, "class")),
+        ...definedEntry("comment", nodeAttr(node, "comment")),
+        ...definedEntry("aliasTarget", extras.aliasTarget),
+        ...definedEntry("vecEquiv", extras.vecEquiv),
+        ...definedEntry("glx", extras.glx),
+        params: extras.params,
     };
 };
 
-const parseEnum = (child: OrderedNode): GlEnum | undefined => {
-    if (nodeTag(child) !== "enum") {
-        return undefined;
-    }
-
-    const name = nodeAttr(child, "name");
+const parseEnum = (child: OrderedNode, block: GlEnumBlock): GlEnum | undefined => {
+    const name = nodeAttr(child, NAME_TAG);
     const value = nodeAttr(child, "value");
 
-    if (name === undefined || value === undefined) {
+    if (name === undefined || value === undefined || nodeTag(child) !== "enum") {
         return undefined;
     }
-
-    const group = nodeAttr(child, "group");
 
     return {
         name,
         value,
-        groups: group === undefined ? [] : group.split(",").map((part) => part.trim()),
+        groups: splitAttr(nodeAttr(child, "group") ?? block.group, ","),
+        isBitmask: block.isBitmask,
+        ...definedEntry("comment", nodeAttr(child, "comment")),
+        ...definedEntry("alias", nodeAttr(child, "alias")),
+        ...definedEntry("api", nodeAttr(child, "api")),
+        ...definedEntry("valueType", nodeAttr(child, "type")),
+        ...definedEntry("vendor", block.vendor),
+        ...definedEntry("blockComment", block.comment),
     };
 };
 
-const parseEnums = (node: OrderedNode, into: GlEnum[]): void => {
+const enumBlockFor = (node: OrderedNode): GlEnumBlock => ({
+    isBitmask: nodeAttr(node, "type") === "bitmask",
+    ...definedEntry("group", nodeAttr(node, "group")),
+    ...definedEntry("vendor", nodeAttr(node, "vendor")),
+    ...definedEntry("comment", nodeAttr(node, "comment")),
+});
+
+const parseEnums = (node: OrderedNode, registry: GlRegistry): void => {
+    const block = enumBlockFor(node);
+
+    if (block.isBitmask && block.group !== undefined) {
+        registry.bitmaskGroups.add(block.group);
+    }
+
     for (const child of nodeChildren(node)) {
-        const parsed = parseEnum(child);
+        const parsed = parseEnum(child, block);
 
         if (parsed !== undefined) {
-            into.push(parsed);
+            registry.enums.push(parsed);
         }
     }
 };
 
 const collectInterfaceMember = (child: OrderedNode, commands: string[], enums: string[]): void => {
-    const name = nodeAttr(child, "name");
+    const name = nodeAttr(child, NAME_TAG);
 
     if (name === undefined) {
         return;
@@ -156,7 +271,7 @@ const collectInterfaceMember = (child: OrderedNode, commands: string[], enums: s
     }
 };
 
-const parseInterfaceBlock = (node: OrderedNode): GlInterfaceBlock => {
+const parseInterfaceBlock = (node: OrderedNode, kind: GlInterfaceBlock["kind"]): GlInterfaceBlock => {
     const commands: string[] = [];
     const enums: string[] = [];
 
@@ -164,42 +279,80 @@ const parseInterfaceBlock = (node: OrderedNode): GlInterfaceBlock => {
         collectInterfaceMember(child, commands, enums);
     }
 
-    const profile = nodeAttr(node, "profile");
-
     return {
-        ...((profile !== undefined) && { profile }),
+        kind,
+        ...definedEntry("api", nodeAttr(node, "api")),
+        ...definedEntry("profile", nodeAttr(node, "profile")),
+        ...definedEntry("comment", nodeAttr(node, "comment")),
         commands,
         enums,
     };
 };
 
-const collectFeatureBlock = (child: OrderedNode, requires: GlInterfaceBlock[], removes: GlInterfaceBlock[]): void => {
-    const tag = nodeTag(child);
+const collectInterfaceBlocks = (node: OrderedNode): GlInterfaceBlock[] => {
+    const blocks: GlInterfaceBlock[] = [];
 
-    if (tag === "require") {
-        requires.push(parseInterfaceBlock(child));
-    } else if (tag === "remove") {
-        removes.push(parseInterfaceBlock(child));
+    for (const child of nodeChildren(node)) {
+        const tag = nodeTag(child);
+
+        if (tag === "require" || tag === "remove") {
+            blocks.push(parseInterfaceBlock(child, tag));
+        }
     }
+
+    return blocks;
 };
 
 const parseFeature = (node: OrderedNode): GlFeature | undefined => {
     const api = nodeAttr(node, "api");
-    const name = nodeAttr(node, "name");
+    const name = nodeAttr(node, NAME_TAG);
     const number = nodeAttr(node, "number");
 
     if (api === undefined || name === undefined || number === undefined) {
         return undefined;
     }
 
-    const requires: GlInterfaceBlock[] = [];
-    const removes: GlInterfaceBlock[] = [];
+    return { api, name, number: Number(number), blocks: collectInterfaceBlocks(node) };
+};
 
-    for (const child of nodeChildren(node)) {
-        collectFeatureBlock(child, requires, removes);
+const parseExtension = (node: OrderedNode): GlExtension | undefined => {
+    const name = nodeAttr(node, NAME_TAG);
+
+    if (name === undefined || nodeTag(node) !== "extension") {
+        return undefined;
     }
 
-    return { api, name, number: Number(number), requires, removes };
+    return {
+        name,
+        supported: splitAttr(nodeAttr(node, "supported"), "|"),
+        ...definedEntry("comment", nodeAttr(node, "comment")),
+        blocks: collectInterfaceBlocks(node),
+    };
+};
+
+const typeName = (node: OrderedNode): string => {
+    const fromChild = elementName(node);
+
+    if (fromChild.length > 0) {
+        return fromChild;
+    }
+
+    return nodeAttr(node, NAME_TAG) ?? "";
+};
+
+const parseType = (node: OrderedNode): GlType | undefined => {
+    const name = typeName(node);
+
+    if (name.length === 0 || nodeTag(node) !== "type") {
+        return undefined;
+    }
+
+    return {
+        name,
+        declaration: normalizeWhitespace(collectText(node, EMPTY_SKIP)),
+        ...definedEntry("requires", nodeAttr(node, "requires")),
+        ...definedEntry("comment", nodeAttr(node, "comment")),
+    };
 };
 
 const addCommand = (child: OrderedNode, into: Map<string, GlCommand>): void => {
@@ -214,31 +367,48 @@ const addCommand = (child: OrderedNode, into: Map<string, GlCommand>): void => {
     }
 };
 
-const parseCommandsSection = (section: OrderedNode, into: Map<string, GlCommand>): void => {
+const parseCommandsSection = (section: OrderedNode, registry: GlRegistry): void => {
     for (const child of nodeChildren(section)) {
-        addCommand(child, into);
+        addCommand(child, registry.commands);
     }
 };
 
-const parseSection = (section: OrderedNode, registry: GlRegistry): void => {
-    const tag = nodeTag(section);
+const parseTypesSection = (section: OrderedNode, registry: GlRegistry): void => {
+    for (const child of nodeChildren(section)) {
+        const parsed = parseType(child);
 
-    if (tag === "commands") {
-        parseCommandsSection(section, registry.commands);
-
-        return;
+        if (parsed !== undefined) {
+            registry.types.set(parsed.name, parsed);
+        }
     }
+};
 
-    if (tag === "enums") {
-        parseEnums(section, registry.enums);
+const addKind = (child: OrderedNode, into: Map<string, string>): void => {
+    const name = nodeAttr(child, NAME_TAG);
+    const desc = nodeAttr(child, "desc");
 
-        return;
+    if (name !== undefined && desc !== undefined && nodeTag(child) === "kind") {
+        into.set(name, desc);
     }
+};
 
-    if (tag !== "feature") {
-        return;
+const parseKindsSection = (section: OrderedNode, registry: GlRegistry): void => {
+    for (const child of nodeChildren(section)) {
+        addKind(child, registry.kinds);
     }
+};
 
+const parseExtensionsSection = (section: OrderedNode, registry: GlRegistry): void => {
+    for (const child of nodeChildren(section)) {
+        const parsed = parseExtension(child);
+
+        if (parsed !== undefined) {
+            registry.extensions.push(parsed);
+        }
+    }
+};
+
+const parseFeatureSection = (section: OrderedNode, registry: GlRegistry): void => {
     const feature = parseFeature(section);
 
     if (feature !== undefined) {
@@ -246,12 +416,84 @@ const parseSection = (section: OrderedNode, registry: GlRegistry): void => {
     }
 };
 
+const parseCommentSection = (section: OrderedNode, registry: GlRegistry): void => {
+    registry.comment = normalizeBlockText(collectText(section, EMPTY_SKIP));
+};
+
+const sectionHandlerFor = (tag: string): SectionHandler | undefined => {
+    switch (tag) {
+        case "comment": {
+            return parseCommentSection;
+        }
+        case "commands": {
+            return parseCommandsSection;
+        }
+        case "enums": {
+            return parseEnums;
+        }
+        case "extensions": {
+            return parseExtensionsSection;
+        }
+        case "feature": {
+            return parseFeatureSection;
+        }
+        case "kinds": {
+            return parseKindsSection;
+        }
+        case "types": {
+            return parseTypesSection;
+        }
+        default: {
+            return undefined;
+        }
+    }
+};
+
+const parseSection = (section: OrderedNode, registry: GlRegistry): void => {
+    sectionHandlerFor(nodeTag(section))?.(section, registry);
+};
+
+const sortAliasNames = (pending: Map<string, string[]>): Map<string, string[]> => {
+    const sorted: Map<string, string[]> = new Map();
+
+    for (const target of sortStrings(pending.keys())) {
+        sorted.set(target, sortStrings(pending.get(target) ?? []));
+    }
+
+    return sorted;
+};
+
+const buildAliasTargets = (commands: Map<string, GlCommand>): Map<string, string[]> => {
+    const pending: Map<string, string[]> = new Map();
+
+    for (const command of commands.values()) {
+        const target = command.aliasTarget;
+
+        if (target !== undefined) {
+            pending.set(target, [...(pending.get(target) ?? []), command.name]);
+        }
+    }
+
+    return sortAliasNames(pending);
+};
+
 const loadGlRegistry = (path: string): GlRegistry => {
-    const registry: GlRegistry = { commands: new Map<string, GlCommand>(), enums: [], features: [] };
+    const registry: GlRegistry = {
+        types: new Map<string, GlType>(),
+        kinds: new Map<string, string>(),
+        commands: new Map<string, GlCommand>(),
+        enums: [],
+        features: [],
+        extensions: [],
+        aliasTargets: new Map<string, string[]>(),
+        bitmaskGroups: new Set<string>(),
+    };
 
     for (const section of parseRegistryFile(path)) {
         parseSection(section, registry);
     }
+
+    registry.aliasTargets = buildAliasTargets(registry.commands);
 
     return registry;
 };
@@ -259,9 +501,12 @@ const loadGlRegistry = (path: string): GlRegistry => {
 export {
     loadGlRegistry,
     type GlParam,
+    type GlGlx,
     type GlCommand,
     type GlEnum,
     type GlInterfaceBlock,
     type GlFeature,
+    type GlExtension,
+    type GlType,
     type GlRegistry,
 };

--- a/packages/codegen/src/khronos/modules.ts
+++ b/packages/codegen/src/khronos/modules.ts
@@ -1,50 +1,132 @@
 import { sortStrings, sortStringsBy } from "@gtkx/utils";
-import type { GlEnum } from "./model.js";
+import type { GlDocContext } from "./doc-context.js";
+import type { GlEnum, GlType } from "./model.js";
 import type { RenderedCommand } from "./render.js";
+import type { GlSymbolProvenance } from "./select.js";
 import { ModuleBuilder } from "../writer/module.js";
+import { asSentence, backtick, backtickList, provenanceLines } from "./notes.js";
 import { GL_SCALARS } from "./plan.js";
 
-const LIB_CONSTANT = "export const LIB = \"libGL.so.1\";";
-
-const GENERATED_HEADER = `/**
- * GENERATED FILE: do not edit.
- */`;
-
-const TS_PRIMITIVES: Set<string> = new Set(["boolean", "string", "void", "number"]);
-
-const quotedGroupList = (groups: string[]): string => groups.map((group) => `\`${group}\``).join(", ");
-
-const renderEnumsModule = (
-    tokens: { token: GlEnum; exportName: string; literal: string; feature: string }[],
-): string => {
-    const builder = new ModuleBuilder();
-
-    for (const { token, exportName, literal, feature } of tokens) {
-        const groupNote = token.groups.length > 0 ? ` Groups: ${quotedGroupList(token.groups)}.` : "";
-
-        builder.appendDeclaration(
-            `/** \`${token.name}\`, provided by \`${feature}\`.${groupNote} */\n` +
-            `export const ${exportName} = ${literal};`,
-        );
-    }
-
-    return `${GENERATED_HEADER}\n\n${builder.toSource()}`;
+type EnumRow = {
+    token: GlEnum;
+    exportName: string;
+    literal: string;
+    provenance: GlSymbolProvenance;
 };
 
-const renderTypesModule = (groupAliases: Map<string, string>): string => {
+const LIB_CONSTANT =
+    "/** The shared library the generated OpenGL bindings are loaded from. */\n" +
+    "export const LIB = \"libGL.so.1\";";
+
+const SYNC_SUMMARY = "An opaque `GLsync` fence handle";
+const TS_PRIMITIVES: Set<string> = new Set(["boolean", "string", "void", "number"]);
+
+const attributionLine = (line: string): string => (line.length === 0 ? " *" : ` * ${line}`);
+
+const attributionLines = (registryComment: string | undefined): string[] =>
+    registryComment === undefined
+        ? []
+        : [" *", ...registryComment.split("\n").map((line) => attributionLine(line))];
+
+const generatedHeader = (docs: GlDocContext): string =>
+    [
+        "/**",
+        " * GENERATED FILE: do not edit.",
+        " *",
+        " * Derived from the Khronos OpenGL registry (gl.xml).",
+        ...attributionLines(docs.registryComment),
+        " */",
+    ].join("\n");
+
+const groupsLine = (groups: string[]): string[] => (groups.length === 0 ? [] : [` * Groups: ${backtickList(groups)}.`]);
+
+const rangePhrase = (vendor: string | undefined): string =>
+    vendor === undefined ? "Registry enumerant block" : `Allocated from the ${backtick(vendor)} enumerant range`;
+
+const rangeLine = ({ vendor, blockComment }: GlEnum): string[] => {
+    if (vendor === undefined && blockComment === undefined) {
+        return [];
+    }
+
+    const phrase = rangePhrase(vendor);
+    const text = blockComment === undefined ? phrase : `${phrase}: ${blockComment}`;
+
+    return [` * ${asSentence(text)}`];
+};
+
+const tokenNoteLines = (token: GlEnum): string[] => [
+    ...groupsLine(token.groups),
+    ...(token.comment === undefined ? [] : [` * Token note: ${asSentence(token.comment)}`]),
+    ...(token.alias === undefined ? [] : [` * Also known as ${backtick(token.alias)}.`]),
+    ...(token.valueType === undefined ? [] : [` * Tagged ${backtick(token.valueType)} in the registry.`]),
+    ...rangeLine(token),
+];
+
+const enumJsDoc = ({ token, provenance }: EnumRow, docs: GlDocContext): string =>
+    [
+        "/**",
+        ` * ${backtick(token.name)}.`,
+        " *",
+        ...provenanceLines(provenance, docs.extensionEnums.get(token.name) ?? []),
+        ...tokenNoteLines(token),
+        " */",
+    ].join("\n");
+
+const renderEnumsModule = (tokens: EnumRow[], docs: GlDocContext): string => {
     const builder = new ModuleBuilder();
-    builder.imports.addNamed("@gtkx/native", "ExternalObject", true);
-    builder.imports.addNamed("@gtkx/native", "Handle", true);
 
-    builder.appendDeclaration(
-        "/** An opaque `GLsync` fence handle. */\nexport type GLsync = ExternalObject<Handle>;",
-    );
+    for (const row of tokens) {
+        builder.appendDeclaration(`${enumJsDoc(row, docs)}\nexport const ${row.exportName} = ${row.literal};`);
+    }
 
-    builder.appendDeclaration(
-        "/** An opaque native pointer handle (e.g. a `glMapBufferRange` mapping). */\n" +
-        "export type GLpointer = ExternalObject<Handle>;",
-    );
+    return `${generatedHeader(docs)}\n\n${builder.toSource()}`;
+};
 
+const scalarSentences = (alias: string, type: GlType): string[] => [
+    `The C ${backtick(alias)} scalar: ${backtick(type.declaration)}.`,
+    ...(type.requires === undefined ? [] : [`Requires the ${backtick(type.requires)} header.`]),
+    ...(type.comment === undefined ? [] : [`Registry note: ${asSentence(type.comment)}`]),
+];
+
+const scalarJsDoc = (alias: string, docs: GlDocContext): string => {
+    const type = docs.types.get(alias);
+
+    if (type === undefined) {
+        return `/** The C ${backtick(alias)} scalar. */`;
+    }
+
+    return `/** ${scalarSentences(alias, type).join(" ")} */`;
+};
+
+const syncJsDoc = (docs: GlDocContext): string => {
+    const type = docs.types.get("GLsync");
+
+    if (type === undefined) {
+        return `/** ${SYNC_SUMMARY}. */`;
+    }
+
+    return `/** ${SYNC_SUMMARY}: ${backtick(type.declaration)}. */`;
+};
+
+const groupSummary = (group: string, isBitmask: boolean): string =>
+    isBitmask
+        ? `Registry enum group ${backtick(group)}, declared as a bitmask: members are combined with \`|\`.`
+        : `Registry enum group ${backtick(group)}.`;
+
+const memberLines = (members: string[]): string[] =>
+    members.length === 0 ? [] : [" *", ` * Members: ${backtickList(members)}.`];
+
+const groupAliasJsDoc = (group: string, base: string, docs: GlDocContext): string =>
+    [
+        "/**",
+        ` * ${groupSummary(group, docs.bitmaskGroups.has(group))}`,
+        " *",
+        ` * Open and documentation-only; any ${backtick(base)} value is accepted.`,
+        ...memberLines(docs.groupMembers.get(group) ?? []),
+        " */",
+    ].join("\n");
+
+const appendScalarAliases = (builder: ModuleBuilder, docs: GlDocContext): void => {
     const seen: Set<string> = new Set();
 
     for (const scalar of GL_SCALARS.values()) {
@@ -53,22 +135,33 @@ const renderTypesModule = (groupAliases: Map<string, string>): string => {
         }
 
         seen.add(scalar.tsAlias);
-
-        builder.appendDeclaration(
-            `/** The C \`${scalar.tsAlias}\` scalar. */\nexport type ${scalar.tsAlias} = number;`,
-        );
+        builder.appendDeclaration(`${scalarJsDoc(scalar.tsAlias, docs)}\nexport type ${scalar.tsAlias} = number;`);
     }
+};
 
-    const sortedAliases = sortStringsBy(groupAliases.entries(), ([key]) => key);
+const appendGroupAliases = (builder: ModuleBuilder, groupAliases: Map<string, string>, docs: GlDocContext): void => {
+    const sorted = sortStringsBy(groupAliases.entries(), ([key]) => key);
 
-    for (const [group, base] of sortedAliases) {
-        builder.appendDeclaration(
-            `/** Registry enum group \`${group}\`; open and documentation-only, ` +
-            `any \`${base}\` value is accepted. */\nexport type ${group} = ${base};`,
-        );
+    for (const [group, base] of sorted) {
+        builder.appendDeclaration(`${groupAliasJsDoc(group, base, docs)}\nexport type ${group} = ${base};`);
     }
+};
 
-    return `${GENERATED_HEADER}\n\n${builder.toSource()}`;
+const renderTypesModule = (groupAliases: Map<string, string>, docs: GlDocContext): string => {
+    const builder = new ModuleBuilder();
+    builder.imports.addNamed("@gtkx/native", "ExternalObject", true);
+    builder.imports.addNamed("@gtkx/native", "Handle", true);
+    builder.appendDeclaration(`${syncJsDoc(docs)}\nexport type GLsync = ExternalObject<Handle>;`);
+
+    builder.appendDeclaration(
+        "/** An opaque native pointer handle (e.g. a `glMapBufferRange` mapping). */\n" +
+        "export type GLpointer = ExternalObject<Handle>;",
+    );
+
+    appendScalarAliases(builder, docs);
+    appendGroupAliases(builder, groupAliases, docs);
+
+    return `${generatedHeader(docs)}\n\n${builder.toSource()}`;
 };
 
 const appendTypeImports = (builder: ModuleBuilder, usedTypes: Set<string>): void => {
@@ -99,6 +192,7 @@ const renderCommandsModule = (
     rendered: RenderedCommand[],
     singulars: RenderedCommand[],
     usedTypes: Set<string>,
+    docs: GlDocContext,
 ): string => {
     const builder = new ModuleBuilder();
     builder.imports.addNamed("@gtkx/runtime", "t");
@@ -109,7 +203,7 @@ const renderCommandsModule = (
     appendCommandDeclarations(builder, rendered);
     appendCommandDeclarations(builder, singulars);
 
-    return `${GENERATED_HEADER}\n\n${builder.toSource()}`;
+    return `${generatedHeader(docs)}\n\n${builder.toSource()}`;
 };
 
-export { renderEnumsModule, renderTypesModule, renderCommandsModule };
+export { renderEnumsModule, renderTypesModule, renderCommandsModule, type EnumRow };

--- a/packages/codegen/src/khronos/notes.ts
+++ b/packages/codegen/src/khronos/notes.ts
@@ -1,0 +1,74 @@
+import { lowerFirst, toCamelIdentifier } from "@gtkx/utils";
+import type { GlExtensionAttribution } from "./extensions.js";
+import type { GlRemoval, GlSymbolProvenance } from "./select.js";
+
+type MetadataNotesOptions = {
+    type: string;
+    group?: string;
+    len?: string;
+    objectClass?: string;
+    kinds: string[];
+    note?: string;
+};
+
+const commandExportName = (name: string): string =>
+    toCamelIdentifier(name.startsWith("gl") ? lowerFirst(name.slice(2)) : name);
+
+const backtick = (text: string): string => `\`${text}\``;
+const backtickList = (values: string[]): string => values.map((value) => backtick(value)).join(", ");
+const asSentence = (text: string): string => (text.endsWith(".") ? text : `${text}.`);
+
+const removalPhrase = (removal: GlRemoval): string =>
+    removal.comment === undefined
+        ? backtick(removal.feature)
+        : `${backtick(removal.feature)} (${removal.comment})`;
+
+const removalLine = (provenance: GlSymbolProvenance): string => {
+    const phrases = provenance.removals.map((removal) => removalPhrase(removal)).join(", ");
+
+    return ` * Removed from the core profile by ${phrases}, then restored by ${backtick(provenance.feature)}.`;
+};
+
+const extensionLine = (extensions: GlExtensionAttribution[]): string => {
+    const names = backtickList(extensions.map((extension) => extension.name));
+
+    return ` * Also provided by the ${names} extension${extensions.length === 1 ? "" : "s"}.`;
+};
+
+const extensionNoteLines = (extensions: GlExtensionAttribution[]): string[] =>
+    extensions.flatMap((extension) =>
+        extension.notes.map((note) => ` * ${backtick(extension.name)} note: ${asSentence(note)}`));
+
+const extensionLines = (extensions: GlExtensionAttribution[]): string[] =>
+    extensions.length === 0 ? [] : [extensionLine(extensions), ...extensionNoteLines(extensions)];
+
+const provenanceLines = (provenance: GlSymbolProvenance, extensions: GlExtensionAttribution[]): string[] => [
+    ` * Provided by ${backtick(provenance.feature)}.`,
+    ...(provenance.removals.length > 0 ? [removalLine(provenance)] : []),
+    ...(provenance.requireComment === undefined ? [] : [` * Registry note: ${provenance.requireComment}`]),
+    ...extensionLines(extensions),
+];
+
+const metadataNotes = ({ type, group, len, objectClass, kinds, note }: MetadataNotesOptions): string =>
+    [
+        backtick(type),
+        ...(group === undefined ? [] : [`group ${backtick(group)}`]),
+        ...(len === undefined ? [] : [`length ${backtick(len)}`]),
+        ...(objectClass === undefined ? [] : [`object class ${backtick(objectClass)}`]),
+        ...kinds.map((kind) => `kind ${backtick(kind)}`),
+        ...(note === undefined ? [] : [note]),
+    ].join(", ");
+
+const kindDescriptions = (kinds: string[], table: Map<string, string>): string =>
+    kinds.flatMap((kind) => table.get(kind) ?? []).join(" ");
+
+export {
+    asSentence,
+    backtick,
+    backtickList,
+    commandExportName,
+    kindDescriptions,
+    metadataNotes,
+    type MetadataNotesOptions,
+    provenanceLines,
+};

--- a/packages/codegen/src/khronos/param-pair.ts
+++ b/packages/codegen/src/khronos/param-pair.ts
@@ -6,7 +6,7 @@ type ParamPair = {
     param: GlParam | undefined;
 };
 
-const paramPairAt = (plan: CommandPlan & { ok: true }, index: number): ParamPair => ({
+const paramPairAt = (plan: CommandPlan & { isOk: true }, index: number): ParamPair => ({
     paramPlan: plan.params[index],
     param: plan.command.params[index],
 });

--- a/packages/codegen/src/khronos/pipeline.ts
+++ b/packages/codegen/src/khronos/pipeline.ts
@@ -1,6 +1,8 @@
 import { sanitizeIdentifier, sortStrings, sortStringsBy } from "@gtkx/utils";
+import { buildDocContext, type GlDocContext } from "./doc-context.js";
+import { buildExtensionIndex } from "./extensions.js";
 import { type GlEnum, loadGlRegistry } from "./model.js";
-import { renderCommandsModule, renderEnumsModule, renderTypesModule } from "./modules.js";
+import { type EnumRow, renderCommandsModule, renderEnumsModule, renderTypesModule } from "./modules.js";
 import { paramPairAt } from "./param-pair.js";
 import {
     type CommandPlan,
@@ -11,7 +13,7 @@ import {
     planCommand,
 } from "./plan.js";
 import { deriveDeleteSingular, deriveGenSingular, renderCommand, type RenderedCommand } from "./render.js";
-import { type GlSelection, resolveEnum, selectSubset } from "./select.js";
+import { type GlSelection, type GlSubset, type GlSymbolProvenance, resolveEnum, selectSubset } from "./select.js";
 
 type GlExclusion = {
     command: string;
@@ -24,6 +26,8 @@ type GlGenerationReport = {
     emittedCommands: number;
     derivedSingulars: number;
     exclusions: GlExclusion[];
+    enumExclusions: string[];
+    coreRemovals: GlSubset["removed"];
 };
 
 type GlGenerationResult = {
@@ -31,26 +35,29 @@ type GlGenerationResult = {
     report: GlGenerationReport;
 };
 
-type GroupBearingParamPlan = Extract<ParamPlan, { kind: "scalar" | "array-in" | "ref-out" }>;
+type GroupBearingParamPlan = Extract<ParamPlan, { kind: "scalar" | "array-in" | "ref-out" | "ref-array-out" }>;
 
 type GlGenerationOptions = {
     registryPath: string;
     overrideExports: Set<string>;
 };
 
-type OkPlan = CommandPlan & { ok: true };
+type OkPlan = CommandPlan & { isOk: true };
 
 type PlannedSelection = {
     okPlans: OkPlan[];
-    planFeatures: Map<string, string>;
+    planFeatures: Map<string, GlSymbolProvenance>;
     exclusions: GlExclusion[];
 };
 
-type EnumRow = {
-    token: GlEnum;
-    exportName: string;
-    literal: string;
-    feature: string;
+type EnumSelection = {
+    rows: EnumRow[];
+    enumExclusions: string[];
+};
+
+type RenderedCommands = {
+    rendered: RenderedCommand[];
+    singulars: RenderedCommand[];
 };
 
 const BYTE_OFFSET_PARAMS: Set<string> = new Set([
@@ -103,7 +110,14 @@ const PLAN_POLICY: GlPlanPolicy = {
 };
 
 const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
-const GROUP_BEARING_PARAM_KINDS: Set<ParamPlan["kind"]> = new Set(["scalar", "array-in", "ref-out"]);
+
+const GROUP_BEARING_PARAM_KINDS: Set<ParamPlan["kind"]> = new Set([
+    "scalar",
+    "array-in",
+    "ref-out",
+    "ref-array-out",
+]);
+
 const GL_SELECTION: GlSelection = { api: "gl", version: 4.6, profile: "core" };
 
 const enumExportName = (name: string): string =>
@@ -204,7 +218,7 @@ const planSelectedCommand = (registry: ReturnType<typeof loadGlRegistry>, name: 
 
     const plan = planCommand(command, PLAN_POLICY);
 
-    if (!plan.ok) {
+    if (!plan.isOk) {
         return { command: name, reason: plan.reason };
     }
 
@@ -213,19 +227,19 @@ const planSelectedCommand = (registry: ReturnType<typeof loadGlRegistry>, name: 
 
 const planSelectedCommands = (
     registry: ReturnType<typeof loadGlRegistry>,
-    commandNames: Map<string, string>,
+    commandNames: Map<string, GlSymbolProvenance>,
 ): PlannedSelection => {
     const exclusions: GlExclusion[] = [];
     const okPlans: OkPlan[] = [];
-    const planFeatures: Map<string, string> = new Map();
+    const planFeatures: Map<string, GlSymbolProvenance> = new Map();
     const sortedCommands = sortStringsBy(commandNames.entries(), ([key]) => key);
 
-    for (const [name, feature] of sortedCommands) {
+    for (const [name, provenance] of sortedCommands) {
         const result = planSelectedCommand(registry, name);
 
-        if ("ok" in result) {
+        if ("isOk" in result) {
             okPlans.push(result);
-            planFeatures.set(name, feature);
+            planFeatures.set(name, provenance);
         } else {
             exclusions.push(result);
         }
@@ -234,22 +248,62 @@ const planSelectedCommands = (
     return { okPlans, planFeatures, exclusions };
 };
 
-const buildEnumRows = (registry: ReturnType<typeof loadGlRegistry>, enumNames: Map<string, string>): EnumRow[] => {
-    const enumRows: EnumRow[] = [];
+const buildEnumRows = (
+    registry: ReturnType<typeof loadGlRegistry>,
+    enumNames: Map<string, GlSymbolProvenance>,
+    selection: GlSelection,
+): EnumSelection => {
+    const rows: EnumRow[] = [];
+    const enumExclusions: string[] = [];
     const sortedEnums = sortStringsBy(enumNames.entries(), ([key]) => key);
 
-    for (const [name, feature] of sortedEnums) {
-        const token = resolveEnum(registry, name);
+    for (const [name, provenance] of sortedEnums) {
+        const token = resolveEnum(registry, name, selection.api);
         const literal = enumLiteral(token);
 
         if (literal === undefined) {
-            continue;
+            enumExclusions.push(name);
+        } else {
+            rows.push({ token, exportName: enumExportName(name), literal, provenance });
         }
-
-        enumRows.push({ token, exportName: enumExportName(name), literal, feature });
     }
 
-    return enumRows;
+    return { rows, enumExclusions };
+};
+
+const provenanceFor = (planFeatures: Map<string, GlSymbolProvenance>, name: string): GlSymbolProvenance => {
+    const found = planFeatures.get(name);
+
+    if (found === undefined) {
+        throw new Error(`Command ${name} was planned without a selection provenance`);
+    }
+
+    return found;
+};
+
+const renderCommands = (
+    plans: OkPlan[],
+    planFeatures: Map<string, GlSymbolProvenance>,
+    usedTypes: Set<string>,
+    docs: GlDocContext,
+): RenderedCommands => {
+    const rendered: RenderedCommand[] = [];
+    const singulars: RenderedCommand[] = [];
+
+    for (const plan of plans) {
+        const provenance = provenanceFor(planFeatures, plan.command.name);
+        rendered.push(renderCommand(plan, provenance, usedTypes, docs));
+
+        const singular =
+            deriveGenSingular(plan, provenance, usedTypes, docs) ??
+            deriveDeleteSingular(plan, provenance, usedTypes, docs);
+
+        if (singular !== undefined) {
+            singulars.push(singular);
+        }
+    }
+
+    return { rendered, singulars };
 };
 
 const claimExportName = (exportNames: Map<string, string>, name: string, owner: string): void => {
@@ -299,27 +353,24 @@ const generateGlModules = (options: GlGenerationOptions): GlGenerationResult => 
     const registry = loadGlRegistry(options.registryPath);
     const subset = selectSubset(registry, selection);
     const { okPlans, planFeatures, exclusions } = planSelectedCommands(registry, subset.commands);
+    const { rows, enumExclusions } = buildEnumRows(registry, subset.enums, selection);
+    const groupAliases = collectGroupAliases(okPlans);
+
+    const docs = buildDocContext({
+        registry,
+        extensions: buildExtensionIndex(registry, selection),
+        plans: okPlans,
+        enumRows: rows,
+    });
+
     const usedTypes: Set<string> = new Set();
-    const rendered: RenderedCommand[] = [];
-    const singulars: RenderedCommand[] = [];
-
-    for (const plan of okPlans) {
-        const feature = planFeatures.get(plan.command.name) ?? "unknown feature";
-        rendered.push(renderCommand(plan, feature, usedTypes));
-        const singular = deriveGenSingular(plan, feature, usedTypes) ?? deriveDeleteSingular(plan, feature, usedTypes);
-
-        if (singular !== undefined) {
-            singulars.push(singular);
-        }
-    }
-
-    const enumRows = buildEnumRows(registry, subset.enums);
-    assertExportNamesDisjoint(rendered, singulars, enumRows, options.overrideExports);
+    const { rendered, singulars } = renderCommands(okPlans, planFeatures, usedTypes, docs);
+    assertExportNamesDisjoint(rendered, singulars, rows, options.overrideExports);
 
     const files: Map<string, string> = new Map([
-        ["types.ts", renderTypesModule(collectGroupAliases(okPlans))],
-        ["enums.ts", renderEnumsModule(enumRows)],
-        ["commands.ts", renderCommandsModule(rendered, singulars, usedTypes)],
+        ["types.ts", renderTypesModule(groupAliases, docs)],
+        ["enums.ts", renderEnumsModule(rows, docs)],
+        ["commands.ts", renderCommandsModule(rendered, singulars, usedTypes, docs)],
     ]);
 
     return {
@@ -330,6 +381,8 @@ const generateGlModules = (options: GlGenerationOptions): GlGenerationResult => 
             emittedCommands: rendered.length,
             derivedSingulars: singulars.length,
             exclusions,
+            enumExclusions,
+            coreRemovals: subset.removed,
         },
     };
 };

--- a/packages/codegen/src/khronos/plan.ts
+++ b/packages/codegen/src/khronos/plan.ts
@@ -51,12 +51,12 @@ type GlPlanPolicy = {
 
 type CommandPlan =
     | {
-        ok: true;
+        isOk: true;
         command: GlCommand;
         params: ParamPlan[];
         returnPlan: ReturnPlan;
     } |
-    { ok: false; command: GlCommand; reason: GlExclusionReason };
+    { isOk: false; command: GlCommand; reason: GlExclusionReason };
 
 type ParamOutcome = { plan: ParamPlan } | { reason: GlExclusionReason };
 
@@ -317,13 +317,13 @@ const planCommand = (command: GlCommand, policy: GlPlanPolicy): CommandPlan => {
         const outcome = planParam(command, param, policy);
 
         if ("reason" in outcome) {
-            return { ok: false, command, reason: outcome.reason };
+            return { isOk: false, command, reason: outcome.reason };
         }
 
         params.push(outcome.plan);
     }
 
-    return { ok: true, command, params, returnPlan: planReturn(command) };
+    return { isOk: true, command, params, returnPlan: planReturn(command) };
 };
 
 export {
@@ -331,7 +331,6 @@ export {
     parseCType,
     planCommand,
     type GlScalar,
-    type ParsedCType,
     type ParamPlan,
     type ReturnPlan,
     type GlExclusionReason,

--- a/packages/codegen/src/khronos/render.ts
+++ b/packages/codegen/src/khronos/render.ts
@@ -1,13 +1,22 @@
-import { lowerFirst, sourceStringLiteral, toCamelIdentifier } from "@gtkx/utils";
+import { sourceStringLiteral, toCamelIdentifier } from "@gtkx/utils";
+import type { GlDocContext } from "./doc-context.js";
 import type { CommandPlan, GlScalar, ReturnPlan } from "./plan.js";
+import type { GlSymbolProvenance } from "./select.js";
 import { tBind, tInlineStruct, tRef, tString, tUint8, tVoid } from "../analysis/descriptor.js";
-import { type OutArg, planArgs, scalarAliasOrGroup, scalarPrefixArgs, trackInto } from "./args.js";
-import { commandJsDoc, inParamDocLine, singularJsDoc } from "./jsdoc.js";
+import { type InArg, type OutArg, planArgs, returnPlanTsType, scalarPrefixArgs, trackInto } from "./args.js";
+import { commandJsDoc, derivedJsDoc, inParamDocLine } from "./jsdoc.js";
+import { commandExportName } from "./notes.js";
 
 type RenderedCommand = {
     exportName: string;
     binding?: string;
     declaration: string;
+};
+
+type SingularContext = {
+    plan: CommandPlan & { isOk: true };
+    provenance: GlSymbolProvenance;
+    docs: GlDocContext;
 };
 
 type EmittedReturn = {
@@ -34,9 +43,6 @@ const glBind = (name: string, argList: string, returnType: string): string =>
         returnType,
     });
 
-const commandExportName = (name: string): string =>
-    toCamelIdentifier(name.startsWith("gl") ? lowerFirst(name.slice(2)) : name);
-
 const singularize = (plural: string): string =>
     plural.endsWith("ies") ? `${plural.slice(0, -3)}y` : plural.replace(/s$/, "");
 
@@ -48,32 +54,27 @@ const buildEmittedReturn = (
     returnGroup: string | undefined,
     usedTypes: Set<string>,
 ): EmittedReturn => {
-    const track = trackInto(usedTypes);
+    const tsType = trackInto(usedTypes)(returnPlanTsType(plan, returnGroup));
+    const cast = (call: string): string => `${call} as ${tsType}`;
 
     switch (plan.kind) {
         case "void": {
-            return { tsType: "void", descriptor: tVoid };
+            return { tsType, descriptor: tVoid };
         }
         case "scalar": {
-            const alias = track(scalarAliasOrGroup(plan.scalar, returnGroup));
-
-            return { tsType: alias, descriptor: plan.scalar.descriptor, expr: (call) => `${call} as ${alias}` };
+            return { tsType, descriptor: plan.scalar.descriptor, expr: cast };
         }
         case "boolean": {
-            return { tsType: "boolean", descriptor: tUint8, expr: (call) => `(${call} as number) !== 0` };
+            return { tsType, descriptor: tUint8, expr: (call) => `(${call} as number) !== 0` };
         }
         case "string": {
-            return { tsType: "string", descriptor: tString("borrowed"), expr: (call) => `${call} as string` };
+            return { tsType, descriptor: tString("borrowed"), expr: cast };
         }
         case "sync": {
-            return { tsType: track("GLsync"), descriptor: tInlineStruct(), expr: (call) => `${call} as GLsync` };
+            return { tsType, descriptor: tInlineStruct(), expr: cast };
         }
         case "opaque-pointer": {
-            return {
-                tsType: track("GLpointer"),
-                descriptor: tInlineStruct(),
-                expr: (call) => `${call} as GLpointer`,
-            };
+            return { tsType, descriptor: tInlineStruct(), expr: cast };
         }
     }
 };
@@ -117,19 +118,20 @@ const returnStatements = (call: string, returned: EmittedReturn, outs: OutArg[])
 };
 
 const renderCommand = (
-    plan: CommandPlan & { ok: true },
-    feature: string,
+    plan: CommandPlan & { isOk: true },
+    provenance: GlSymbolProvenance,
     usedTypes: Set<string>,
+    docs: GlDocContext,
 ): RenderedCommand => {
     const { command } = plan;
     const exportName = commandExportName(command.name);
     const { args, ins, outs } = planArgs(plan, usedTypes);
     const returned = buildEmittedReturn(plan.returnPlan, command.returnGroup, usedTypes);
     const signature = ins.map((arg) => `${arg.name}: ${arg.tsType}`).join(", ");
-    const argNames = args.map((arg) => (arg.out ? arg.cellName : arg.name)).join(", ");
+    const argNames = args.map((arg) => (arg.isOut ? arg.cellName : arg.name)).join(", ");
     const descriptors = renderDescriptorList(args.map((arg) => arg.descriptor));
     const tsReturn = returnTsType(returned, outs);
-    const jsDoc = commandJsDoc({ command, feature, ins, outs, returnPlan: plan.returnPlan });
+    const jsDoc = commandJsDoc({ plan, provenance, ins, outs, docs });
     const seeds = outs.map((out) => out.seed);
     const bindExpression = glBind(command.name, descriptors, returned.descriptor);
     const isInline = plan.params.some((paramPlan) => paramPlan.kind === "string-out");
@@ -150,15 +152,17 @@ const renderCommand = (
     };
 };
 
-const singularCommandJsDoc = (
-    plan: CommandPlan & { ok: true },
-    feature: string,
-    summary: string,
-    body: string[],
-): string => singularJsDoc({ commandName: plan.command.name, feature, summary, body });
+const singularCommandJsDoc = (context: SingularContext, summary: string, body: string[]): string =>
+    derivedJsDoc({
+        command: context.plan.command,
+        provenance: context.provenance,
+        docs: context.docs,
+        summary,
+        body,
+    });
 
 const genSingularScalars = (
-    plan: CommandPlan & { ok: true },
+    plan: CommandPlan & { isOk: true },
 ): { countScalar: GlScalar; outScalar: GlScalar; lenParamName: string } | undefined => {
     const countPlan = plan.params.at(-2);
 
@@ -175,7 +179,7 @@ const genSingularScalars = (
     return { countScalar: countPlan.scalar, outScalar: outPlan.scalar, lenParamName: outPlan.lenParamName };
 };
 
-const genSingularObjectClass = (plan: CommandPlan & { ok: true }, lenParamName: string): string | undefined => {
+const genSingularObjectClass = (plan: CommandPlan & { isOk: true }, lenParamName: string): string | undefined => {
     const countParam = plan.command.params[plan.params.length - 2];
     const outParam = plan.command.params[plan.params.length - 1];
 
@@ -190,7 +194,7 @@ const genSingularObjectClass = (plan: CommandPlan & { ok: true }, lenParamName: 
     return outParam.objectClass;
 };
 
-const genSingularShape = (plan: CommandPlan & { ok: true }): GenSingularShape | undefined => {
+const genSingularShape = (plan: CommandPlan & { isOk: true }): GenSingularShape | undefined => {
     const scalars = genSingularScalars(plan);
 
     if (scalars === undefined) {
@@ -206,10 +210,25 @@ const genSingularShape = (plan: CommandPlan & { ok: true }): GenSingularShape | 
     return { countScalar: scalars.countScalar, outScalar: scalars.outScalar, objectClass };
 };
 
+const genSingularJsDoc = (context: SingularContext, prefix: InArg[], shape: GenSingularShape): string => {
+    const { command } = context.plan;
+
+    return singularCommandJsDoc(
+        context,
+        `Returns one ${shape.objectClass} object name via ` +
+        `\`${command.name}(${prefix.length > 0 ? "..., " : ""}1, ...)\`.`,
+        [
+            ...prefix.map((arg) => inParamDocLine(context.plan, arg, context.docs)),
+            ` * @returns \`${shape.outScalar.tsAlias}\`, object class \`${shape.objectClass}\``,
+        ],
+    );
+};
+
 const deriveGenSingular = (
-    plan: CommandPlan & { ok: true },
-    feature: string,
+    plan: CommandPlan & { isOk: true },
+    provenance: GlSymbolProvenance,
     usedTypes: Set<string>,
+    docs: GlDocContext,
 ): RenderedCommand | undefined => {
     if (!GEN_FAMILY.test(plan.command.name)) {
         return undefined;
@@ -227,21 +246,14 @@ const deriveGenSingular = (
         return undefined;
     }
 
-    const { countScalar, outScalar, objectClass } = shape;
+    const { countScalar, outScalar } = shape;
     const exportName = singularize(commandExportName(plan.command.name));
     const bindingName = `${plan.command.name}Single`;
     const descriptors = [...prefix.map((arg) => arg.descriptor), countScalar.descriptor, tRef(outScalar.descriptor)];
     usedTypes.add(outScalar.tsAlias);
     const signature = prefix.map((arg) => `${arg.name}: ${arg.tsType}`).join(", ");
     const callArgs = [...prefix.map((arg) => arg.name), "1", "out"].join(", ");
-
-    const jsDoc = singularCommandJsDoc(
-        plan,
-        feature,
-        `Returns one ${objectClass} object name via ` +
-        `\`${plan.command.name}(${prefix.length > 0 ? "..., " : ""}1, ...)\`.`,
-        [...prefix.map((arg) => inParamDocLine(plan.command, arg)), ` * @returns The new ${objectClass} object name`],
-    );
+    const jsDoc = genSingularJsDoc({ plan, provenance, docs }, prefix, shape);
 
     const body = ["    const out = { value: 0 };", `    ${bindingName}(${callArgs});`, "    return out.value;"].join(
         "\n",
@@ -256,7 +268,7 @@ const deriveGenSingular = (
     };
 };
 
-const deleteSingularAlias = (plan: CommandPlan & { ok: true }): string | undefined => {
+const deleteSingularAlias = (plan: CommandPlan & { isOk: true }): string | undefined => {
     if (plan.params.length !== 2) {
         return undefined;
     }
@@ -274,7 +286,7 @@ const deleteSingularAlias = (plan: CommandPlan & { ok: true }): string | undefin
     return arrayPlan.scalar.tsAlias;
 };
 
-const deleteSingularObjectClass = (plan: CommandPlan & { ok: true }): string | undefined => {
+const deleteSingularObjectClass = (plan: CommandPlan & { isOk: true }): string | undefined => {
     const [countParam, arrayParam] = plan.command.params;
 
     if (countParam === undefined || arrayParam === undefined) {
@@ -289,9 +301,10 @@ const deleteSingularObjectClass = (plan: CommandPlan & { ok: true }): string | u
 };
 
 const deriveDeleteSingular = (
-    plan: CommandPlan & { ok: true },
-    feature: string,
+    plan: CommandPlan & { isOk: true },
+    provenance: GlSymbolProvenance,
     usedTypes: Set<string>,
+    docs: GlDocContext,
 ): RenderedCommand | undefined => {
     if (!DELETE_FAMILY.test(plan.command.name)) {
         return undefined;
@@ -313,10 +326,9 @@ const deriveDeleteSingular = (
     const exportName = singularize(commandExportName(plan.command.name));
 
     const jsDoc = singularCommandJsDoc(
-        plan,
-        feature,
+        { plan, provenance, docs },
         `Deletes one ${objectClass} object name via \`${plan.command.name}(1, ...)\`.`,
-        [` * @param name - The ${objectClass} object name to delete`],
+        [` * @param name - \`${scalarAlias}\`, object class \`${objectClass}\``],
     );
 
     return {

--- a/packages/codegen/src/khronos/select.ts
+++ b/packages/codegen/src/khronos/select.ts
@@ -1,3 +1,4 @@
+import { sortStringsBy } from "@gtkx/utils";
 import type { GlEnum, GlFeature, GlInterfaceBlock, GlRegistry } from "./model.js";
 
 type GlProfile = "core";
@@ -8,60 +9,94 @@ type GlSelection = {
     profile: GlProfile;
 };
 
+type GlSymbolKind = "command" | "enum";
+
+type GlRemoval = {
+    feature: string;
+    comment?: string;
+};
+
+type GlSymbolProvenance = {
+    feature: string;
+    requireComment?: string;
+    removals: GlRemoval[];
+};
+
+type GlRemovedSymbol = {
+    name: string;
+    kind: GlSymbolKind;
+    feature: string;
+    comment?: string;
+};
+
 type GlSubset = {
-    commands: Map<string, string>;
-    enums: Map<string, string>;
+    commands: Map<string, GlSymbolProvenance>;
+    enums: Map<string, GlSymbolProvenance>;
+    removed: GlRemovedSymbol[];
+};
+
+type SelectionState = GlSubset & {
+    history: Map<string, GlRemoval[]>;
+};
+
+type MemberContext = {
+    feature: GlFeature;
+    block: GlInterfaceBlock;
+    kind: GlSymbolKind;
 };
 
 const isBlockApplicable = (block: GlInterfaceBlock, selection: GlSelection): boolean =>
-    block.profile === undefined || block.profile === selection.profile;
+    (block.profile === undefined || block.profile === selection.profile) &&
+    (block.api === undefined || block.api === selection.api);
 
-const addMissing = (target: Map<string, string>, names: string[], value: string): void => {
+const targetFor = (state: SelectionState, kind: GlSymbolKind): Map<string, GlSymbolProvenance> =>
+    kind === "command" ? state.commands : state.enums;
+
+const commentEntry = (comment: string | undefined): { comment?: string } =>
+    comment === undefined ? {} : { comment };
+
+const requireMember = (state: SelectionState, name: string, context: MemberContext): void => {
+    const target = targetFor(state, context.kind);
+
+    if (target.has(name)) {
+        return;
+    }
+
+    const { block, feature } = context;
+
+    target.set(name, {
+        feature: feature.name,
+        ...(block.comment !== undefined && { requireComment: block.comment }),
+        removals: [...(state.history.get(name) ?? [])],
+    });
+};
+
+const removeMember = (state: SelectionState, name: string, context: MemberContext): void => {
+    const { block, feature, kind } = context;
+    const removal: GlRemoval = { feature: feature.name, ...commentEntry(block.comment) };
+    targetFor(state, kind).delete(name);
+    state.history.set(name, [...(state.history.get(name) ?? []), removal]);
+    state.removed.push({ name, kind, ...removal });
+};
+
+const applyMembers = (state: SelectionState, names: string[], context: MemberContext): void => {
+    const apply = context.block.kind === "require" ? requireMember : removeMember;
+
     for (const name of names) {
-        if (!target.has(name)) {
-            target.set(name, value);
-        }
+        apply(state, name, context);
     }
 };
 
-const applyRequires = (
-    feature: GlFeature,
-    selection: GlSelection,
-    commands: Map<string, string>,
-    enums: Map<string, string>,
-): void => {
-    for (const block of feature.requires) {
-        if (!isBlockApplicable(block, selection)) {
-            continue;
-        }
-
-        addMissing(commands, block.commands, feature.name);
-        addMissing(enums, block.enums, feature.name);
-    }
+const applyBlock = (state: SelectionState, feature: GlFeature, block: GlInterfaceBlock): void => {
+    applyMembers(state, block.commands, { feature, block, kind: "command" });
+    applyMembers(state, block.enums, { feature, block, kind: "enum" });
 };
 
-const removeBlock = (block: GlInterfaceBlock, commands: Map<string, string>, enums: Map<string, string>): void => {
-    for (const name of block.commands) {
-        commands.delete(name);
-    }
-
-    for (const name of block.enums) {
-        enums.delete(name);
-    }
-};
-
-const applyRemoves = (
-    feature: GlFeature,
-    selection: GlSelection,
-    commands: Map<string, string>,
-    enums: Map<string, string>,
-): void => {
-    for (const block of feature.removes) {
-        if (!isBlockApplicable(block, selection)) {
-            continue;
+const applyFeature = (state: SelectionState, feature: GlFeature, selection: GlSelection): void => {
+    for (const block of feature.blocks) {
+        if (isBlockApplicable(block, selection)) {
+            applyBlock(state, feature, block);
         }
-
-        removeBlock(block, commands, enums);
     }
 };
 
@@ -70,22 +105,28 @@ const selectSubset = (registry: GlRegistry, selection: GlSelection): GlSubset =>
         .filter((feature) => feature.api === selection.api && feature.number <= selection.version)
         .toSorted((a, b) => a.number - b.number);
 
-    const commands: Map<string, string> = new Map();
-    const enums: Map<string, string> = new Map();
+    const state: SelectionState = {
+        commands: new Map(),
+        enums: new Map(),
+        removed: [],
+        history: new Map(),
+    };
 
     for (const feature of features) {
-        applyRequires(feature, selection, commands, enums);
+        applyFeature(state, feature, selection);
     }
 
-    for (const feature of features) {
-        applyRemoves(feature, selection, commands, enums);
-    }
-
-    return { commands, enums };
+    return {
+        commands: state.commands,
+        enums: state.enums,
+        removed: sortStringsBy(state.removed, (entry) => entry.name),
+    };
 };
 
-const resolveEnum = (registry: GlRegistry, name: string): GlEnum => {
-    const found = registry.enums.find((candidate) => candidate.name === name);
+const resolveEnum = (registry: GlRegistry, name: string, api: string): GlEnum => {
+    const found = registry.enums.find(
+        (candidate) => candidate.name === name && (candidate.api === undefined || candidate.api === api),
+    );
 
     if (found === undefined) {
         throw new Error(`Enum token ${name} has no definition in the registry`);
@@ -94,4 +135,4 @@ const resolveEnum = (registry: GlRegistry, name: string): GlEnum => {
     return found;
 };
 
-export { selectSubset, resolveEnum, type GlSelection };
+export { selectSubset, resolveEnum, type GlRemoval, type GlSelection, type GlSubset, type GlSymbolProvenance };

--- a/packages/codegen/tests/fingerprint.test.ts
+++ b/packages/codegen/tests/fingerprint.test.ts
@@ -10,6 +10,9 @@ const jsxInput = (overrides: Partial<JsxFingerprintInput> = {}): JsxFingerprintI
     ...overrides,
 });
 
+const jsxFingerprint = (overrides: Partial<JsxFingerprintInput> = {}, intrinsicElementCount = 0): string =>
+    computeJsxFingerprint(jsxInput(overrides), intrinsicElementCount).value;
+
 describe("computeGiFingerprint", () => {
     it("changes when the libraries change", () => {
         expect(computeGiFingerprint([], ["Gtk-4.0"], []).value).not.toBe(computeGiFingerprint([], ["Adw-1"], []).value);
@@ -23,62 +26,48 @@ describe("computeGiFingerprint", () => {
 
 describe("computeJsxFingerprint", () => {
     it("changes when component overrides change", () => {
-        const base = computeJsxFingerprint(jsxInput(), 0).value;
+        const withComponent = jsxFingerprint({
+            components: { GtkButton: { module: "@example/wrappers", export: "withButton" } },
+        });
 
-        const withComponent = computeJsxFingerprint(
-            jsxInput({ components: { GtkButton: { module: "@example/wrappers", export: "withButton" } } }),
-            0,
-        ).value;
-
-        expect(withComponent).not.toBe(base);
+        expect(withComponent).not.toBe(jsxFingerprint());
     });
 
     it("changes when the lazy element set changes", () => {
-        const base = computeJsxFingerprint(jsxInput(), 0).value;
-        expect(computeJsxFingerprint(jsxInput({ lazyElements: ["GtkStackPage"] }), 0).value).not.toBe(base);
+        expect(jsxFingerprint({ lazyElements: ["GtkStackPage"] })).not.toBe(jsxFingerprint());
     });
 
     it("changes when the base props change", () => {
-        const base = computeJsxFingerprint(jsxInput(), 0).value;
+        const withProps = jsxFingerprint({
+            props: { GtkButton: { module: "@gtkx/react/internal", export: "ChildrenProps" } },
+        });
 
-        const withProps = computeJsxFingerprint(
-            jsxInput({ props: { GtkButton: { module: "@gtkx/react/internal", export: "ChildrenProps" } } }),
-            0,
-        ).value;
-
-        expect(withProps).not.toBe(base);
+        expect(withProps).not.toBe(jsxFingerprint());
     });
 
     it("changes when the omitted props change", () => {
-        const base = computeJsxFingerprint(jsxInput(), 0).value;
-        expect(computeJsxFingerprint(jsxInput({ omittedProps: { AdwBin: ["child"] } }), 0).value).not.toBe(base);
+        expect(jsxFingerprint({ omittedProps: { AdwBin: ["child"] } })).not.toBe(jsxFingerprint());
     });
 
     it("is stable regardless of omitted prop order", () => {
-        const a = computeJsxFingerprint(jsxInput({ omittedProps: { AdwFlap: ["content", "flap"] } }), 0).value;
-        const b = computeJsxFingerprint(jsxInput({ omittedProps: { AdwFlap: ["flap", "content"] } }), 0).value;
+        const a = jsxFingerprint({ omittedProps: { AdwBottomSheet: ["content", "sheet"] } });
+        const b = jsxFingerprint({ omittedProps: { AdwBottomSheet: ["sheet", "content"] } });
         expect(a).toBe(b);
     });
 
     it("is stable regardless of component key order", () => {
-        const a = computeJsxFingerprint(
-            jsxInput({
-                components: { GtkButton: { module: "m", export: "a" }, GtkLabel: { module: "n", export: "b" } },
-            }),
-            0,
-        ).value;
+        const a = jsxFingerprint({
+            components: { GtkButton: { module: "m", export: "a" }, GtkLabel: { module: "n", export: "b" } },
+        });
 
-        const b = computeJsxFingerprint(
-            jsxInput({
-                components: { GtkLabel: { module: "n", export: "b" }, GtkButton: { module: "m", export: "a" } },
-            }),
-            0,
-        ).value;
+        const b = jsxFingerprint({
+            components: { GtkLabel: { module: "n", export: "b" }, GtkButton: { module: "m", export: "a" } },
+        });
 
         expect(a).toBe(b);
     });
 
     it("does not depend on the intrinsic element count", () => {
-        expect(computeJsxFingerprint(jsxInput(), 5).value).toBe(computeJsxFingerprint(jsxInput(), 10).value);
+        expect(jsxFingerprint({}, 5)).toBe(jsxFingerprint({}, 10));
     });
 });

--- a/packages/codegen/tests/helpers/khronos.ts
+++ b/packages/codegen/tests/helpers/khronos.ts
@@ -1,0 +1,22 @@
+import type { GlDocContext } from "../../src/khronos/doc-context.js";
+import type { GlSymbolProvenance } from "../../src/khronos/select.js";
+
+const docContext = (overrides: Partial<GlDocContext> = {}): GlDocContext => ({
+    kinds: new Map(),
+    types: new Map(),
+    aliasTargets: new Map(),
+    extensionCommands: new Map(),
+    extensionEnums: new Map(),
+    bitmaskGroups: new Set(),
+    emittedCommands: new Set(),
+    groupMembers: new Map(),
+    ...overrides,
+});
+
+const glProvenance = (overrides: Partial<GlSymbolProvenance> = {}): GlSymbolProvenance => ({
+    feature: "GL_VERSION_1_0",
+    removals: [],
+    ...overrides,
+});
+
+export { docContext, glProvenance };

--- a/packages/codegen/tests/integration/api-reference.test.ts
+++ b/packages/codegen/tests/integration/api-reference.test.ts
@@ -76,6 +76,46 @@ const registerClassPageTests = (): void => {
     });
 };
 
+const registerClassDocTests = (): void => {
+    it("documents method parameters and return values", () => {
+        const page = pageFor("Gtk.Button");
+        expect(page).toContain("**Parameters**");
+        expect(page).toContain("- `label`: a string");
+        expect(page).toContain("**Returns** the child widget of `button`");
+    });
+
+    it("keeps the signature fence free of the generated JSDoc", () => {
+        const page = pageFor("Gtk.Button");
+        expect(page).not.toContain("```ts\n/**");
+        expect(page).not.toContain("@param");
+    });
+
+    it("marks a deprecated class and its deprecated properties", () => {
+        const page = pageFor("Gtk.Assistant");
+        expect(page).toContain("> **Deprecated since 4.10.** This widget will be removed in GTK 5");
+        const properties = page.slice(page.indexOf("### `useHeaderBar`"));
+        expect(properties).toContain("deprecated since 4.10");
+    });
+
+    it("documents the virtual methods a subclass overrides", () => {
+        const page = pageFor("Gtk.Widget");
+        expect(page).toContain("## Implementing");
+        expect(page).toContain("call `super.<slot>(...)`");
+        expect(page).toContain("### `vfuncMeasure`");
+
+        expect(page).toContain(
+            "vfuncMeasure(orientation: Gtk.Orientation, forSize: number): [number, number, number, number]",
+        );
+    });
+
+    it("takes a slot description from the virtual method when the vtable field has none", () => {
+        const page = pageFor("Gtk.Accessible");
+        const slot = page.slice(page.indexOf("### `vfuncGetAccessibleParent`"));
+        expect(slot).toContain("vfuncGetAccessibleParent(): Gtk.Accessible | null");
+        expect(slot).toContain("accessible parent");
+    });
+};
+
 const registerPromisifiedPageTests = (): void => {
     it("renders promisified static async members on class pages", () => {
         const page = pageFor("Gio.DBusConnection");
@@ -95,7 +135,7 @@ const registerPromisifiedPageTests = (): void => {
     });
 };
 
-const registerSymbolPageTests = (): void => {
+const registerInterfacePageTests = (): void => {
     it("renders an interface page with prerequisites", () => {
         const page = pageFor("Gtk.Orientable");
         expect(page).toContain("# Gtk.Orientable");
@@ -103,6 +143,34 @@ const registerSymbolPageTests = (): void => {
         expect(page).toContain("### `orientation`");
     });
 
+    it("documents the vtable slots an implementer of an interface fills", () => {
+        const page = pageFor("Gio.ListModel");
+        expect(page).toContain("## Implementing");
+        expect(page).toContain("declare `implements Gio.ListModelImpl`");
+        expect(page).toContain("pass `Gio.ListModel` in the `implements` option of `registerClass`");
+        expect(page).toContain("### `vfuncGetItem`");
+        expect(page).toContain("vfuncGetItem(position: number): GObject.Object | null");
+        expect(page).toContain("### `vfuncGetNItems`");
+    });
+
+    it("says on the interface page that a slot may be left to the interface", () => {
+        expect(pageFor("Gio.ListModel")).toContain(
+            "Every slot is optional, and one the class leaves out keeps whatever the interface installs by default.",
+        );
+    });
+
+    it("leaves the implementing section off an interface without vtable slots", () => {
+        expect(pageFor("Gtk.Orientable")).not.toContain("## Implementing");
+    });
+
+    it("words the implementing intro for the kind of symbol the page documents", () => {
+        expect(pageFor("Gio.ListModel")).toContain("declare `implements Gio.ListModelImpl`");
+        expect(pageFor("Gtk.Button")).toContain("A subclass declared with `registerClass`");
+        expect(pageFor("Gtk.Button")).not.toContain("declare `implements Gtk.ButtonImpl`");
+    });
+};
+
+const registerSymbolPageTests = (): void => {
     it("renders an element page for JSX element names", () => {
         const page = pageFor("GtkButton");
         expect(page).toContain("# GtkButton");
@@ -118,6 +186,17 @@ const registerSymbolPageTests = (): void => {
         expect(page).toContain("| Member | Value | Description |");
         expect(page).toContain("| `HORIZONTAL` | `0` |");
         expect(page).toContain("Members are accessed as `Gtk.Orientation.<member>`.");
+    });
+
+    it("keeps enum member descriptions whole and unmangled", () => {
+        expect(pageFor("Gtk.InputPurpose")).toContain(
+            "| `PASSWORD` | `8` | Like GTK_INPUT_PURPOSE_FREE_FORM, but characters are hidden |",
+        );
+
+        expect(pageFor("Gtk.AccessibleProperty")).toContain(
+            "| `SORT` | `14` | Indicates if items in a table or grid are sorted in ascending or descending " +
+            "order. Value type: AccessibleSort |",
+        );
     });
 
     it("renders a record page with constructors, fields, and methods", () => {
@@ -223,7 +302,9 @@ describe("ApiReference — namespaces", () => {
 
 describe("ApiReference — lookup", () => {
     registerClassPageTests();
+    registerClassDocTests();
     registerPromisifiedPageTests();
+    registerInterfacePageTests();
     registerSymbolPageTests();
     registerLookupResolutionTests();
 });

--- a/packages/codegen/tests/integration/docs.test.ts
+++ b/packages/codegen/tests/integration/docs.test.ts
@@ -3,9 +3,13 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
 import { writeDocs } from "../../src/internal.js";
+import { readBuiltinElements } from "../../src/react/element-config.js";
 
 const GIR_PATH = ["/usr/share/gir-1.0"];
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const GI_STORE_DIR = join(REPO_ROOT, "node_modules", ".gtkx", "gi");
+const REACT_SUBEXPORTS = ["config", "adw", "adw/config", "internal"];
+const REACT_SURFACE = await readBuiltinElements(REACT_SUBEXPORTS, GI_STORE_DIR);
 const workDir = mkdtempSync(join(REPO_ROOT, "node_modules", ".gtkx-docs-test-"));
 const defaultOutDir = join(workDir, "default");
 const defaultResult = writeDocs({ libraries: ["Gtk-4.0"], girPath: GIR_PATH, outDir: defaultOutDir });
@@ -99,13 +103,6 @@ const registerSignalAndMethodTests = (): void => {
         );
     });
 
-    it("demotes upstream doc headings and strips media markup", () => {
-        const button = page(defaultOutDir, join("gtk", "button.md"));
-        expect(button).toContain("## CSS nodes");
-        expect(button).not.toContain("<picture");
-        expect(button).not.toContain("<img");
-    });
-
     it("skips regeneration while fresh and honors force", () => {
         const fresh = writeDocs({ libraries: ["Gtk-4.0"], girPath: GIR_PATH, outDir: defaultOutDir });
         expect(fresh.isRegenerated).toBe(false);
@@ -113,6 +110,44 @@ const registerSignalAndMethodTests = (): void => {
         const forced = writeDocs({ libraries: ["Gtk-4.0"], girPath: GIR_PATH, outDir: defaultOutDir, isForced: true });
         expect(forced.isRegenerated).toBe(true);
         expect(forced.namespaces).toEqual(defaultResult.namespaces);
+    });
+};
+
+const registerElementDocTests = (): void => {
+    it("documents signal handler parameters and return values", () => {
+        const label = page(defaultOutDir, join("gtk", "label.md"));
+        const handler = label.slice(label.indexOf("### `onActivateLink`"));
+        expect(handler).toContain("**Parameters**");
+        expect(handler).toContain("- `uri`: the URI that is activated");
+        expect(handler).toContain("- `self`: The instance the signal was emitted on.");
+        expect(handler).toContain("**Returns**");
+        expect(handler).toContain("the link has been activated");
+    });
+
+    it("marks a deprecated element and its deprecated props", () => {
+        const assistant = page(defaultOutDir, join("gtk", "assistant.md"));
+        expect(assistant).toContain("> **Deprecated since 4.10.** This widget will be removed in GTK 5");
+        const useHeaderBar = assistant.slice(assistant.indexOf("### `useHeaderBar`"));
+        expect(useHeaderBar).toContain("deprecated since 4.10");
+        const apply = assistant.slice(assistant.indexOf("### `onApply`"));
+        expect(apply.slice(0, apply.indexOf("### `on", 1))).toContain("**Deprecated since 4.10.**");
+    });
+
+    it("demotes upstream doc headings and strips media markup", () => {
+        const button = page(defaultOutDir, join("gtk", "button.md"));
+        expect(button).toContain("## CSS nodes");
+        expect(button).not.toContain("<picture");
+        expect(button).not.toContain("<img");
+    });
+
+    it("keeps DocBook and media markup off every page", () => {
+        for (const element of ["button", "window", "label", "picture", "text-view"]) {
+            const rendered = page(defaultOutDir, join("gtk", `${element}.md`));
+            expect(rendered).not.toContain("<picture");
+            expect(rendered).not.toContain("<video");
+            expect(rendered).not.toContain("<itemizedlist");
+            expect(rendered).not.toContain("<listitem");
+        }
     });
 };
 
@@ -124,23 +159,79 @@ describe("writeDocs", () => {
     registerNamespaceIndexTests();
     registerElementPageTests();
     registerSignalAndMethodTests();
+    registerElementDocTests();
 });
 
-describe("writeDocs with omitted props", () => {
+describe("writeDocs with element props", () => {
     const outDir = join(workDir, "omitted");
 
-    it("leaves the omitted props out of the element page", () => {
-        writeDocs({
-            libraries: ["Gtk-4.0"],
-            girPath: GIR_PATH,
-            outDir,
-            omittedProps: { GtkButton: ["child"] },
-        });
+    const result = writeDocs({
+        libraries: ["Gtk-4.0"],
+        girPath: GIR_PATH,
+        outDir,
+        omittedProps: { GtkButton: ["child"] },
+        props: {
+            GtkWidget: { module: "@gtkx/react/internal", export: "GtkWidgetProps" },
+            GtkHeaderBar: { module: "@gtkx/react/internal", export: "GtkHeaderBarProps" },
+        },
+    });
 
+    it("leaves the omitted props out of the element page", () => {
+        expect(result.isRegenerated).toBe(true);
         const button = page(outDir, join("gtk", "button.md"));
         expect(button).not.toContain("### `child`");
         expect(button).toContain("### `label`");
         expect(page(outDir, join("gtk", "frame.md"))).toContain("### `child`");
+    });
+
+    it("documents the element props GTKX adds alongside the GObject properties", () => {
+        const widget = page(outDir, join("gtk", "widget.md"));
+        expect(widget).toContain("### `children`");
+        expect(widget).toContain("Elements attached to the element's default child slot");
+        expect(widget).toContain("### `controllers`");
+        expect(widget).toContain("`Gtk.EventController` elements added to the widget.");
+        expect(widget).toContain("### `actionGroups`");
+        const headerBar = page(outDir, join("gtk", "header-bar.md"));
+        expect(headerBar).toContain("### `start`");
+        expect(headerBar).toContain("Widgets packed at the start of the bar.");
+        expect(headerBar).toContain("### `end`");
+        expect(headerBar).toContain("Widgets packed at the end of the bar.");
+    });
+});
+
+describe("writeDocs with the built-in Adwaita element config", () => {
+    const outDir = join(workDir, "adw");
+
+    const result = writeDocs({
+        libraries: ["Gtk-4.0", "Adw-1"],
+        girPath: GIR_PATH,
+        outDir,
+        props: REACT_SURFACE.props,
+        omittedProps: REACT_SURFACE.omittedProps,
+    });
+
+    it("documents the slots declared in @gtkx/react/adw", () => {
+        expect(result.isRegenerated).toBe(true);
+        const toolbarView = page(outDir, join("adw", "toolbar-view.md"));
+        expect(toolbarView).toContain("### `topBar`");
+        expect(toolbarView).toContain("Widgets stacked above the content.");
+        expect(toolbarView).toContain("### `bottomBar`");
+        expect(toolbarView).toContain("Widgets stacked below the content.");
+        expect(toolbarView).toContain("### `children`");
+        expect(toolbarView).toContain("`ReactNode | null`");
+        const alertDialog = page(outDir, join("adw", "alert-dialog.md"));
+        expect(alertDialog).toContain("### `responses`");
+        expect(alertDialog).toContain("`AlertDialogResponse[] | null`");
+        expect(alertDialog).toContain("Buttons the dialog offers, added and removed as the list changes.");
+    });
+
+    it("documents the props reached through an intersected props type", () => {
+        const expanderRow = page(outDir, join("adw", "expander-row.md"));
+        expect(expanderRow).toContain("### `rows`");
+        expect(expanderRow).toContain("Widgets added to the area the row reveals when it expands.");
+        expect(expanderRow).toContain("### `prefix`");
+        expect(expanderRow).toContain("Widgets added at the start of the row, before its title.");
+        expect(expanderRow).toContain("### `suffix`");
     });
 });
 

--- a/packages/codegen/tests/integration/jsx-docs.test.ts
+++ b/packages/codegen/tests/integration/jsx-docs.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { generateJsxFiles } from "../../src/store/jsx/pipeline.js";
+import { library } from "../helpers/library.js";
+
+const BUTTON_DOC = "Calls a callback function when the button is clicked.";
+const files = generateJsxFiles(library, { lazyElements: ["GtkStackPage"] });
+const gtk = files.namespaces.find((entry) => entry.directory === "gtk")?.source ?? "";
+
+const docBefore = (source: string, declaration: string): string => {
+    const index = source.indexOf(declaration);
+
+    if (index === -1) {
+        throw new Error(`Missing declaration ${declaration}`);
+    }
+
+    const before = source.slice(0, index);
+    const start = before.lastIndexOf("/**");
+    const end = before.lastIndexOf("*/");
+
+    if (start === -1 || end < start || before.slice(end + 2).trim().length > 0) {
+        return "";
+    }
+
+    return before.slice(start, end + 2);
+};
+
+describe("jsx store documentation", () => {
+    it("documents the props interface and the component export with the class doc", () => {
+        expect(docBefore(gtk, "export interface GtkButtonProps<")).toContain(BUTTON_DOC);
+        expect(docBefore(gtk, "export const GtkButton: (props: GtkButtonProps)")).toContain(BUTTON_DOC);
+
+        expect(docBefore(gtk, "export const GtkWidget = \"GtkWidget\" as const;")).toContain(
+            "The base class for all widgets.",
+        );
+    });
+
+    it("carries the class deprecation onto the props interface", () => {
+        expect(docBefore(gtk, "export interface GtkAssistantProps<")).toContain(
+            "@deprecated Since 4.10. This widget will be removed in GTK 5",
+        );
+    });
+
+    it("documents each property prop and its notify handler", () => {
+        expect(docBefore(gtk, "label?: string | null | undefined;")).toContain("Text of the label inside the button");
+
+        expect(docBefore(gtk, "onNotifyLabel?: ((value: string | null, self: Self) => void)")).toContain(
+            "Called with the new value when `label` changes.",
+        );
+    });
+
+    it("marks a deprecated property prop", () => {
+        expect(docBefore(gtk, "useHeaderBar?: number | null | undefined;")).toContain(
+            "@deprecated Since 4.10. This widget will be removed in GTK 5",
+        );
+    });
+
+    it("documents signal handler props with their parameters and return value", () => {
+        const doc = docBefore(gtk, "onActivateLink?: ((uri: string, self: Self)");
+        expect(doc).toContain("Emitted every time a URL is activated.");
+        expect(doc).toContain("@param uri the URI that is activated");
+        expect(doc).toContain("@param self The instance the signal was emitted on.");
+        expect(doc).toContain("@returns");
+    });
+
+    it("documents both declarations of a lazy element", () => {
+        const auxiliary = "An auxiliary class used by `GtkStack`.";
+        expect(docBefore(gtk, "export type GtkStackPageElementProps = ")).toContain(auxiliary);
+        expect(docBefore(gtk, "export const GtkStackPage: (props: GtkStackPageElementProps)")).toContain(auxiliary);
+    });
+});

--- a/packages/codegen/tests/integration/khronos/pipeline.test.ts
+++ b/packages/codegen/tests/integration/khronos/pipeline.test.ts
@@ -20,15 +20,26 @@ const result: GlGenerationResult = generateGlModules({
     overrideExports: OVERRIDE_EXPORTS,
 });
 
+const COMMANDS_SOURCE = result.files.get("commands.ts") ?? "";
+const ENUMS_SOURCE = result.files.get("enums.ts") ?? "";
+const TYPES_SOURCE = result.files.get("types.ts") ?? "";
+
 const DRAW_ELEMENTS_SIGNATURE =
     /drawElements\(\s*mode: PrimitiveType,\s*count: GLsizei,\s*type: DrawElementsType,\s*indices: GLintptr,?\s*\)/;
+
+const getDocBlock = (source: string, declaration: string): string => {
+    const declarationIndex = source.indexOf(declaration);
+    expect(declarationIndex).toBeGreaterThan(-1);
+
+    return source.slice(source.lastIndexOf("/**", declarationIndex), declarationIndex);
+};
 
 describe("khronos selection over the vendored registry", () => {
     it("resolves the gl 4.6 core subset to the pinned counts", () => {
         const registry = loadGlRegistry(REGISTRY_PATH);
         const subset = selectSubset(registry, { api: "gl", version: 4.6, profile: "core" });
-        expect(subset.commands.size).toBe(656);
-        expect(subset.enums.size).toBe(1363);
+        expect(subset.commands.size).toBe(657);
+        expect(subset.enums.size).toBe(1367);
     });
 
     it("declares the gl feature range from 1.0 to 4.6", () => {
@@ -41,14 +52,27 @@ describe("khronos selection over the vendored registry", () => {
 
 describe("khronos generation counts", () => {
     it("emits the pinned command and enum counts", () => {
-        expect(result.report.selectedCommands).toBe(656);
+        expect(result.report.selectedCommands).toBe(657);
         expect(result.report.emittedCommands).toBe(612);
         expect(result.report.derivedSingulars).toBe(27);
-        expect(result.report.exclusions).toHaveLength(44);
+        expect(result.report.exclusions).toHaveLength(45);
     });
 
     it("skips the unsafe-integer timeout token", () => {
         expect(result.files.get("enums.ts")).not.toContain("TIMEOUT_IGNORED");
+    });
+
+    it("reports the skipped enum token instead of dropping it silently", () => {
+        expect(result.report.enumExclusions).toContain("GL_TIMEOUT_IGNORED");
+        expect(ENUMS_SOURCE).not.toContain("TIMEOUT_IGNORED");
+    });
+
+    it("records the symbols the core profile removed", () => {
+        expect(result.report.coreRemovals.length).toBeGreaterThan(0);
+
+        expect(result.report.coreRemovals).toContainEqual(
+            expect.objectContaining({ name: "glBegin", kind: "command" }),
+        );
     });
 
     it("excludes the debug callback and override-owned commands", () => {
@@ -56,48 +80,57 @@ describe("khronos generation counts", () => {
         expect(byName.get("glDebugMessageCallback")).toBe("callback-parameter");
         expect(byName.get("glGetShaderInfoLog")).toBe("override-owned");
         expect(byName.get("glGetIntegerv")).toBe("compsize-output");
+        expect(byName.get("glGetPointerv")).toBe("unsupported-shape");
     });
 });
 
 describe("khronos generation surface", () => {
     it("emits prefix-stripped typed wrappers", () => {
-        const commands = result.files.get("commands.ts") ?? "";
-
-        expect(commands).toContain(
+        expect(COMMANDS_SOURCE).toContain(
             "export function clearColor(red: GLfloat, green: GLfloat, blue: GLfloat, alpha: GLfloat): void",
         );
 
-        expect(commands).toContain("export function createShader(type: ShaderType): GLuint");
-        expect(commands).toContain("return glCreateShader(type) as GLuint;");
+        expect(COMMANDS_SOURCE).toContain("export function createShader(type: ShaderType): GLuint");
+        expect(COMMANDS_SOURCE).toContain("return glCreateShader(type) as GLuint;");
     });
 
     it("types curated byte-offset parameters as numbers, never views", () => {
-        const commands = result.files.get("commands.ts") ?? "";
-        expect(commands).toContain("pointer: GLintptr");
-        expect(commands).toMatch(DRAW_ELEMENTS_SIGNATURE);
+        expect(COMMANDS_SOURCE).toContain("pointer: GLintptr");
+        expect(COMMANDS_SOURCE).toMatch(DRAW_ELEMENTS_SIGNATURE);
     });
 
     it("passes data parameters as buffers accepting views, offsets, and null", () => {
-        const commands = result.files.get("commands.ts") ?? "";
-        expect(commands).toContain("data: ArrayBufferView | GLintptr | null");
+        expect(COMMANDS_SOURCE).toContain("data: ArrayBufferView | GLintptr | null");
     });
 
     it("returns out-parameters instead of taking cells", () => {
-        const commands = result.files.get("commands.ts") ?? "";
-        expect(commands).toContain("export function genBuffers(n: GLsizei): GLuint[]");
-        expect(commands).toContain("const out0 = { value: new Array<number>(n).fill(0) };");
-        expect(commands).toContain("export function getShaderiv(shader: GLuint, pname: ShaderParameterName): GLint");
+        expect(COMMANDS_SOURCE).toContain("export function genBuffers(n: GLsizei): GLuint[]");
+        expect(COMMANDS_SOURCE).toContain("const out0 = { value: new Array<number>(n).fill(0) };");
 
-        expect(commands).toContain(
+        expect(COMMANDS_SOURCE).toContain(
+            "export function getShaderiv(shader: GLuint, pname: ShaderParameterName): GLint",
+        );
+
+        expect(COMMANDS_SOURCE).toContain(
             "export function getShaderSource(shader: GLuint, bufSize: GLsizei): [GLsizei, string]",
         );
     });
 
+    it("keeps tokens the core profile removed and a later feature restored", () => {
+        expect(ENUMS_SOURCE).toContain("export const STACK_OVERFLOW = 0x0503;");
+        expect(ENUMS_SOURCE).toContain("export const STACK_UNDERFLOW = 0x0504;");
+        expect(ENUMS_SOURCE).toContain("export const QUADS = 0x0007;");
+        expect(ENUMS_SOURCE).toContain("export const VERTEX_ARRAY = 0x8074;");
+    });
+
+    it("omits the commands whose pointer shape cannot be marshalled", () => {
+        expect(COMMANDS_SOURCE).not.toContain("export function getPointerv");
+    });
+
     it("derives singular forms from the gen/create/delete families", () => {
-        const commands = result.files.get("commands.ts") ?? "";
-        expect(commands).toContain("export function genBuffer(): GLuint");
-        expect(commands).toContain("export function createQuery(target: QueryTarget): GLuint");
-        expect(commands).toContain("export function deleteVertexArray(name: GLuint): void");
+        expect(COMMANDS_SOURCE).toContain("export function genBuffer(): GLuint");
+        expect(COMMANDS_SOURCE).toContain("export function createQuery(target: QueryTarget): GLuint");
+        expect(COMMANDS_SOURCE).toContain("export function deleteVertexArray(name: GLuint): void");
     });
 });
 
@@ -115,5 +148,114 @@ describe("khronos generation guarantees", () => {
         expect(() =>
             generateGlModules({ registryPath: REGISTRY_PATH, overrideExports: new Set(["clearColor"]) }),
         ).toThrow(/Override module exports collide/);
+    });
+});
+
+describe("khronos generated documentation", () => {
+    it("documents parameters with their registry kind and description", () => {
+        const block = getDocBlock(COMMANDS_SOURCE, "export function clearColor(");
+
+        expect(block).toContain(
+            " * @param red - `GLfloat`, kind `Color`. This parameter represents part of or a complete color.",
+        );
+    });
+
+    it("documents return values with the emitted type, group and object class", () => {
+        expect(getDocBlock(COMMANDS_SOURCE, "export function getError(")).toContain(" * @returns `ErrorCode`");
+
+        expect(getDocBlock(COMMANDS_SOURCE, "export function createProgram(")).toContain(
+            " * @returns `GLuint`, object class `program`",
+        );
+
+        expect(getDocBlock(COMMANDS_SOURCE, "export function isBuffer(")).toContain(" * @returns `boolean`");
+        expect(getDocBlock(COMMANDS_SOURCE, "export function getString(")).toContain(" * @returns `string`");
+        expect(getDocBlock(COMMANDS_SOURCE, "export function mapBuffer(")).toContain(" * @returns `GLpointer`");
+    });
+
+    it("documents a collapsed single-valued query as the scalar it returns", () => {
+        const block = getDocBlock(COMMANDS_SOURCE, "export function getShaderiv(");
+        expect(block).toContain(" * @returns `params` (`GLint`)");
+        expect(block).not.toContain("COMPSIZE");
+    });
+
+    it("documents a byte-offset parameter as an offset into the bound buffer", () => {
+        const block = getDocBlock(COMMANDS_SOURCE, "export function drawElements(");
+        expect(block).toContain(" * @param indices - `GLintptr`, byte offset into the bound buffer");
+        expect(block).not.toContain("COMPSIZE");
+    });
+
+    it("documents aliases, vector forms, and GLX opcodes", () => {
+        const activeTexture = getDocBlock(COMMANDS_SOURCE, "export function activeTexture(");
+        expect(activeTexture).toContain(" * Also known as `glActiveTextureARB`.");
+        expect(activeTexture).toContain(" * GLX render opcode 197.");
+
+        expect(getDocBlock(COMMANDS_SOURCE, "export function vertexAttrib1d(")).toContain(
+            " * Vector form: `vertexAttrib1dv`.",
+        );
+    });
+});
+
+describe("khronos generated provenance", () => {
+    it("documents the command's own GLX opcode, not the one of a named protocol variant", () => {
+        expect(getDocBlock(COMMANDS_SOURCE, "export function texImage2D(")).toContain(" * GLX render opcode 110.");
+        expect(getDocBlock(COMMANDS_SOURCE, "export function readPixels(")).toContain(" * GLX single opcode 111.");
+    });
+
+    it("keeps the notes of the parent command off a derived singular", () => {
+        const block = getDocBlock(COMMANDS_SOURCE, "export function genBuffer(");
+        expect(block).toContain(" * Provided by `GL_VERSION_1_5`.");
+        expect(block).not.toContain("Also known as");
+        expect(block).not.toContain("GLX ");
+    });
+
+    it("quotes the registry comment of a providing extension and of its require block", () => {
+        expect(getDocBlock(COMMANDS_SOURCE, "export function blendColor(")).toContain(
+            " * `GL_ARB_imaging` note: Now treating ARB_imaging as an extension, not a GL API version.",
+        );
+
+        expect(getDocBlock(COMMANDS_SOURCE, "export function createTextures(")).toContain(
+            " * `GL_ARB_direct_state_access` note: Texture object functions.",
+        );
+    });
+
+    it("documents the registry alone, without linking out to the refpages", () => {
+        expect(COMMANDS_SOURCE).not.toContain("@see");
+        expect(COMMANDS_SOURCE).not.toContain("OpenGL-Refpages");
+    });
+
+    it("closes the block after the prose when a command has no tags", () => {
+        expect(getDocBlock(COMMANDS_SOURCE, "export function finish(")).not.toContain(" *\n */");
+    });
+});
+
+describe("khronos generated enum documentation", () => {
+    it("documents the removal history of a restored token", () => {
+        expect(getDocBlock(ENUMS_SOURCE, "export const STACK_OVERFLOW")).toContain(
+            " * Removed from the core profile by `GL_VERSION_3_2` " +
+            "(Compatibility-only GL 1.1 features removed from GL 3.2), then restored by `GL_VERSION_4_3`.",
+        );
+    });
+
+    it("documents group members and bitmask combination", () => {
+        const clearBufferMask = getDocBlock(TYPES_SOURCE, "export type ClearBufferMask");
+        expect(clearBufferMask).toContain(" * Members: `COLOR_BUFFER_BIT`,");
+        expect(clearBufferMask).toContain("combined with `|`");
+        expect(getDocBlock(TYPES_SOURCE, "export type SyncBehaviorFlags")).not.toContain("combined with `|`");
+    });
+
+    it("documents scalar aliases with their C typedef", () => {
+        expect(getDocBlock(TYPES_SOURCE, "export type GLenum")).toContain("typedef unsigned int GLenum;");
+    });
+
+    it("documents the shared library constant", () => {
+        expect(COMMANDS_SOURCE).toContain(
+            "/** The shared library the generated OpenGL bindings are loaded from. */\nexport const LIB",
+        );
+    });
+
+    it("carries the registry license header in every module", () => {
+        expect(COMMANDS_SOURCE).toContain("SPDX-License-Identifier: Apache-2.0");
+        expect(ENUMS_SOURCE).toContain("SPDX-License-Identifier: Apache-2.0");
+        expect(TYPES_SOURCE).toContain("SPDX-License-Identifier: Apache-2.0");
     });
 });

--- a/packages/codegen/tests/integration/runner.test.ts
+++ b/packages/codegen/tests/integration/runner.test.ts
@@ -3,27 +3,17 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
 import { runCodegen } from "../../src/index.js";
+import { storeUnit } from "../helpers/store-unit.js";
 
 const GIR_PATH = ["/usr/share/gir-1.0"];
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const workDir = mkdtempSync(join(REPO_ROOT, "node_modules", ".gtkx-test-"));
 
-const giOptions = (name: string) => {
-    const root = join(workDir, name);
-
-    return {
-        root,
-        gi: {
-            storeDir: join(root, "node_modules", ".gtkx", "gi"),
-            linkDir: join(root, "node_modules", "@gtkx", "gi"),
-            version: "0.0.0",
-        },
-    };
-};
+const projectModules = (name: string): string => join(workDir, name, "node_modules");
 
 const registerStoreWriteTests = (): void => {
     it("writes the gi store with raw modules, barrels, a package.json and the visible alias", async () => {
-        const { gi } = giOptions("gi-only");
+        const gi = storeUnit(projectModules("gi-only"), "gi");
 
         const result = await runCodegen({
             libraries: ["GObject-2.0"],
@@ -43,13 +33,9 @@ const registerStoreWriteTests = (): void => {
     });
 
     it("writes the jsx unit when jsx options are given", async () => {
-        const { root, gi } = giOptions("with-jsx");
-
-        const jsx = {
-            storeDir: join(root, "node_modules", ".gtkx", "jsx"),
-            linkDir: join(root, "node_modules", "@gtkx", "jsx"),
-            version: "0.0.0",
-        };
+        const nodeModules = projectModules("with-jsx");
+        const gi = storeUnit(nodeModules, "gi");
+        const jsx = storeUnit(nodeModules, "jsx");
 
         const result = await runCodegen({
             libraries: ["Gtk-4.0"],
@@ -68,7 +54,7 @@ const registerStoreWriteTests = (): void => {
 
 const registerFreshnessTests = (): void => {
     it("skips regeneration when the store fingerprint is still fresh", async () => {
-        const { gi } = giOptions("rerun");
+        const gi = storeUnit(projectModules("rerun"), "gi");
         const options = { libraries: ["GLib-2.0"], girPath: GIR_PATH, gi };
         const first = await runCodegen(options);
         expect(first.isRegenerated).toBe(true);
@@ -78,7 +64,7 @@ const registerFreshnessTests = (): void => {
     });
 
     it("regenerates when forced", async () => {
-        const { gi } = giOptions("forced");
+        const gi = storeUnit(projectModules("forced"), "gi");
         const options = { libraries: ["GLib-2.0"], girPath: GIR_PATH, gi };
         await runCodegen(options);
         const result = await runCodegen({ ...options, isForced: true });
@@ -88,7 +74,7 @@ const registerFreshnessTests = (): void => {
     });
 
     it("regenerates when the fingerprint no longer matches", async () => {
-        const { gi } = giOptions("stale-fp");
+        const gi = storeUnit(projectModules("stale-fp"), "gi");
         const options = { libraries: ["GLib-2.0"], girPath: GIR_PATH, gi };
         await runCodegen(options);
 

--- a/packages/codegen/tests/unit/compile.test.ts
+++ b/packages/codegen/tests/unit/compile.test.ts
@@ -7,35 +7,40 @@ import { checkModules, compileProject, type SourceModule } from "../../src/compi
 import { compileStore } from "../../src/store/compile-store.js";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const tempDirs: string[] = [];
+
+const createTempDir = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "gtkx-compile-"));
+    tempDirs.push(dir);
+
+    return dir;
+};
+
+const compileStoreFrom = (files: SourceModule[]): string => {
+    const storeDir = createTempDir();
+
+    for (const file of files) {
+        const filePath = join(storeDir, file.fileName);
+        mkdirSync(dirname(filePath), { recursive: true });
+        writeFileSync(filePath, file.source);
+    }
+
+    compileStore({ storeDir, files, packageName: "@gtkx/gi" });
+
+    return storeDir;
+};
+
+afterEach(() => {
+    for (const dir of tempDirs) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+
+    tempDirs.length = 0;
+});
 
 describe("compileStore", () => {
-    let dir: string | undefined;
-
-    afterEach(() => {
-        if (dir !== undefined) {
-            rmSync(dir, { recursive: true, force: true });
-        }
-
-        dir = undefined;
-    });
-
-    const run = (files: SourceModule[]): string => {
-        const storeDir = mkdtempSync(join(tmpdir(), "gtkx-compile-"));
-        dir = storeDir;
-
-        for (const file of files) {
-            const filePath = join(storeDir, file.fileName);
-            mkdirSync(dirname(filePath), { recursive: true });
-            writeFileSync(filePath, file.source);
-        }
-
-        compileStore({ storeDir, files, packageName: "@gtkx/gi" });
-
-        return storeDir;
-    };
-
     it("emits JS and declarations for modules that import each other through relative paths", () => {
-        const storeDir = run([
+        const storeDir = compileStoreFrom([
             { fileName: "foo/foo.ts", source: "export const answer: number = 42;\n" },
             {
                 fileName: "bar/bar.ts",
@@ -51,7 +56,7 @@ describe("compileStore", () => {
 
     it("throws with a positioned message when a generated module has a type error", () => {
         expect(() =>
-            run([
+            compileStoreFrom([
                 { fileName: "foo/foo.ts", source: "export const answer: number = 42;\n" },
                 {
                     fileName: "bar/bar.ts",
@@ -87,19 +92,8 @@ describe("checkModules", () => {
 });
 
 describe("compileProject", () => {
-    let dir: string | undefined;
-
-    afterEach(() => {
-        if (dir !== undefined) {
-            rmSync(dir, { recursive: true, force: true });
-        }
-
-        dir = undefined;
-    });
-
     it("throws when tsc fails without a file-positioned diagnostic", () => {
-        const projectDir = mkdtempSync(join(tmpdir(), "gtkx-compile-"));
-        dir = projectDir;
+        const projectDir = createTempDir();
         writeFileSync(join(projectDir, "ok.ts"), "export const answer: number = 42;\n");
 
         expect(() => {

--- a/packages/codegen/tests/unit/doc.test.ts
+++ b/packages/codegen/tests/unit/doc.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { renderJsDoc } from "../../src/writer/doc.js";
+
+const ESCAPED_TERMINATOR = String.raw`*\/`;
+const MEDIA_DOC = "Cap styles.\n\n<picture>\n  <img alt='Caps' src='caps.png'>\n</picture>";
+
+const deprecatedBlock = (deprecated: { since: string | undefined; doc: string | undefined }): string =>
+    renderJsDoc(undefined, undefined, { deprecated });
+
+describe("renderJsDoc description and note", () => {
+    it("renders nothing without a doc, a note or a spec", () => {
+        expect(renderJsDoc(undefined)).toBe("");
+        expect(renderJsDoc("")).toBe("");
+        expect(renderJsDoc(undefined, undefined, {})).toBe("");
+    });
+
+    it("collapses a single-line description into one line", () => {
+        expect(renderJsDoc("A widget.")).toBe("/** A widget. */\n");
+    });
+
+    it("separates the trailing note from the description with a blank line", () => {
+        expect(renderJsDoc("A widget.", "Read-only.")).toBe("/**\n * A widget.\n *\n * Read-only.\n */\n");
+    });
+
+    it("uses the note alone when there is no description", () => {
+        expect(renderJsDoc(undefined, "Read-only.")).toBe("/** Read-only. */\n");
+    });
+
+    it("strips media blocks from the description", () => {
+        const rendered = renderJsDoc(MEDIA_DOC);
+        expect(rendered).not.toContain("<picture");
+        expect(rendered).not.toContain("<img");
+        expect(rendered).toContain("Cap styles.");
+    });
+
+    it("passes the identifier map through to the description conversion", () => {
+        const spec = { identifiers: new Map([["keyboard_mode", "keyboardMode"]]) };
+        expect(renderJsDoc("Set @keyboard_mode.", undefined, spec)).toBe("/** Set `keyboardMode`. */\n");
+    });
+});
+
+describe("renderJsDoc tags", () => {
+    it("emits param tags in the given order after a blank line", () => {
+        const spec = {
+            params: [
+                { name: "keyboardMode", doc: "whether the tooltip\nwas keyboard triggered" },
+                { name: "tooltip", doc: "the tooltip" },
+            ],
+        };
+
+        const expected = [
+            "/**",
+            " * Emitted on hover.",
+            " *",
+            " * @param keyboardMode whether the tooltip was keyboard triggered",
+            " * @param tooltip the tooltip",
+            " */",
+            "",
+        ].join("\n");
+
+        expect(renderJsDoc("Emitted on hover.", undefined, spec)).toBe(expected);
+    });
+
+    it("drops params without prose", () => {
+        expect(renderJsDoc(undefined, undefined, { params: [{ name: "a", doc: " " }] })).toBe("");
+    });
+
+    it("renders the returns, throws and since tags", () => {
+        expect(renderJsDoc(undefined, undefined, { returns: "the child" })).toBe("/**\n * @returns the child\n */\n");
+
+        expect(renderJsDoc(undefined, undefined, { throws: "GLib.Error on failure" })).toBe(
+            "/**\n * @throws GLib.Error on failure\n */\n",
+        );
+
+        expect(renderJsDoc(undefined, undefined, { since: "4.10" })).toBe("/**\n * @since 4.10\n */\n");
+    });
+
+    it("keeps a multi-line returns tag on several lines", () => {
+        expect(renderJsDoc(undefined, undefined, { returns: "a tuple of\n- the value\n- the offset" })).toBe(
+            "/**\n * @returns a tuple of\n * - the value\n * - the offset\n */\n",
+        );
+    });
+});
+
+describe("renderJsDoc deprecation and escaping", () => {
+    it("renders every deprecation shape", () => {
+        expect(deprecatedBlock({ since: "4.10", doc: "Use [method@Gtk.Widget.set_child] instead." })).toBe(
+            "/**\n * @deprecated Since 4.10. Use `Gtk.Widget.setChild()` instead.\n */\n",
+        );
+
+        expect(deprecatedBlock({ since: "4.10", doc: undefined })).toBe("/**\n * @deprecated Since 4.10.\n */\n");
+
+        expect(deprecatedBlock({ since: undefined, doc: "Use something else." })).toBe(
+            "/**\n * @deprecated Use something else.\n */\n",
+        );
+
+        expect(deprecatedBlock({ since: undefined, doc: undefined })).toBe("/**\n * @deprecated\n */\n");
+    });
+
+    it("orders the tag channel as params, returns, throws, deprecated and since", () => {
+        const spec = {
+            params: [{ name: "child", doc: "the child" }],
+            returns: "nothing",
+            throws: "GLib.Error",
+            deprecated: { since: "4.10", doc: undefined },
+            since: "4.0",
+        };
+
+        const expected = [
+            "/**",
+            " * @param child the child",
+            " * @returns nothing",
+            " * @throws GLib.Error",
+            " * @deprecated Since 4.10.",
+            " * @since 4.0",
+            " */",
+            "",
+        ].join("\n");
+
+        expect(renderJsDoc(undefined, undefined, spec)).toBe(expected);
+    });
+
+    it("escapes comment terminators in the description and in tag prose", () => {
+        expect(renderJsDoc("ends */ here")).toBe(`/** ends ${ESCAPED_TERMINATOR} here */\n`);
+
+        expect(renderJsDoc(undefined, undefined, { params: [{ name: "a", doc: "ends */ here" }] })).toBe(
+            `/**\n * @param a ends ${ESCAPED_TERMINATOR} here\n */\n`,
+        );
+    });
+});

--- a/packages/codegen/tests/unit/docs-render.test.ts
+++ b/packages/codegen/tests/unit/docs-render.test.ts
@@ -58,6 +58,12 @@ describe("firstSentence", () => {
         expect(firstSentence("no terminal punctuation here")).toBe("no terminal punctuation here");
     });
 
+    it("keeps underscored identifiers intact", () => {
+        expect(firstSentence("Like %GTK_INPUT_PURPOSE_FREE_FORM, but characters are hidden.")).toBe(
+            "Like GTK_INPUT_PURPOSE_FREE_FORM, but characters are hidden.",
+        );
+    });
+
     it("truncates very long sentences", () => {
         const sentence = `${"word ".repeat(60)}end.`;
         const result = firstSentence(sentence);

--- a/packages/codegen/tests/unit/gir-annotations.test.ts
+++ b/packages/codegen/tests/unit/gir-annotations.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import type { GirClass, GirVirtualMethod } from "../../src/gir/class.js";
+import type { GirField } from "../../src/gir/field.js";
+import type { GirFunction } from "../../src/gir/function.js";
+import type { GirProperty } from "../../src/gir/property.js";
+import { Library } from "../../src/gir/library.js";
+
+const library = Library.load(["Gtk-4.0"], ["/usr/share/gir-1.0"]);
+
+const typeIn = (namespaceName: string, typeName: string): GirClass => {
+    const namespace = library.namespaces.get(namespaceName);
+
+    const found = [...(namespace?.classes ?? []), ...(namespace?.interfaces ?? [])].find(
+        (candidate) => candidate.name === typeName,
+    );
+
+    if (found === undefined) {
+        throw new Error(`No class or interface ${namespaceName}.${typeName}`);
+    }
+
+    return found;
+};
+
+const methodIn = (namespaceName: string, typeName: string, methodName: string): GirFunction => {
+    const found = typeIn(namespaceName, typeName).methods.find((method) => method.name === methodName);
+
+    if (found === undefined) {
+        throw new Error(`No method ${namespaceName}.${typeName}.${methodName}`);
+    }
+
+    return found;
+};
+
+const propertyIn = (namespaceName: string, typeName: string, propertyName: string): GirProperty => {
+    const found = typeIn(namespaceName, typeName).properties.find((property) => property.name === propertyName);
+
+    if (found === undefined) {
+        throw new Error(`No property ${namespaceName}.${typeName}:${propertyName}`);
+    }
+
+    return found;
+};
+
+const vfuncIn = (namespaceName: string, typeName: string, vfuncName: string): GirVirtualMethod => {
+    const found = typeIn(namespaceName, typeName).vfuncs.find((vfunc) => vfunc.name === vfuncName);
+
+    if (found === undefined) {
+        throw new Error(`No virtual method ${namespaceName}.${typeName}.${vfuncName}`);
+    }
+
+    return found;
+};
+
+const vtableFieldIn = (namespaceName: string, recordName: string, fieldName: string): GirField => {
+    const record = library.namespaces.get(namespaceName)?.records.find((candidate) => candidate.name === recordName);
+    const found = record?.fields.find((field) => field.name === fieldName);
+
+    if (found === undefined) {
+        throw new Error(`No field ${namespaceName}.${recordName}.${fieldName}`);
+    }
+
+    return found;
+};
+
+const parameterDocs = (fn: GirFunction): Map<string, string | undefined> =>
+    new Map(fn.parameters.map((parameter) => [parameter.name, parameter.doc]));
+
+describe("deprecation annotations", () => {
+    it("reads the deprecation flag, version, and prose off a method", () => {
+        const { annotations } = methodIn("Gtk", "Widget", "show");
+        expect(annotations.isDeprecated).toBe(true);
+        expect(annotations.deprecatedSince).toBe("4.10");
+        expect(annotations.deprecationDoc).toContain("Use [method@Gtk.Widget.set_visible] instead");
+    });
+
+    it("reads deprecation off a property", () => {
+        const { annotations } = propertyIn("Gtk", "Application", "register-session");
+        expect(annotations.isDeprecated).toBe(true);
+        expect(annotations.deprecationDoc).toBeDefined();
+        expect(annotations.deprecationDoc).not.toBe("");
+    });
+
+    it("reads deprecation off a class", () => {
+        const { annotations } = typeIn("Gtk", "Assistant");
+        expect(annotations.isDeprecated).toBe(true);
+        expect(annotations.deprecatedSince).toBe("4.10");
+    });
+});
+
+describe("version annotations", () => {
+    it("reads the introducing release off a method", () => {
+        const launchFinish = methodIn("Gtk", "FileLauncher", "launch_finish");
+        expect(launchFinish.annotations.since).toBe("4.10");
+        expect(launchFinish.throws).toBe(true);
+    });
+});
+
+describe("parameter and return documentation", () => {
+    it("carries a doc on every parameter of a measured signature", () => {
+        const measure = methodIn("Gtk", "Widget", "measure");
+        const docs = parameterDocs(measure);
+        const names = ["orientation", "for_size", "minimum", "natural", "minimum_baseline", "natural_baseline"];
+
+        for (const name of names) {
+            expect(docs.get(name)).toBeTypeOf("string");
+        }
+
+        expect(measure.instance?.doc).toBe("A `GtkWidget` instance");
+    });
+
+    it("carries a doc on the return value and the instance parameter", () => {
+        const firstChild = methodIn("Gtk", "Widget", "get_first_child");
+        expect(firstChild.returnValue.doc).toContain("first child");
+        expect(firstChild.instance?.doc).toBe("a widget");
+    });
+});
+
+describe("virtual methods", () => {
+    it("keeps the interface vfunc documentation, which is richer than the vtable field's", () => {
+        const vfunc = vfuncIn("Gio", "ListModel", "get_n_items");
+        const field = vtableFieldIn("Gio", "ListModelInterface", "get_n_items");
+        expect(vfunc.invoker).toBe("get_n_items");
+        expect(vfunc.doc?.startsWith("Gets the number of items")).toBe(true);
+        expect(field.doc).toBe("the virtual function pointer for g_list_model_get_n_items()");
+    });
+
+    it("keeps a class vfunc documentation the vtable field lacks entirely", () => {
+        const vfunc = vfuncIn("Gtk", "Window", "close_request");
+        const field = vtableFieldIn("Gtk", "WindowClass", "close_request");
+        expect(vfunc.doc).toBe("Class handler for the [signal@Window::close-request] signal.");
+        expect(field.doc).toBeUndefined();
+    });
+});

--- a/packages/codegen/tests/unit/gtk-doc.test.ts
+++ b/packages/codegen/tests/unit/gtk-doc.test.ts
@@ -50,3 +50,64 @@ describe("gtkDocToMarkdown", () => {
         expect(gtkDocToMarkdown("Reach a@b for 100% coverage of a#tag.")).toBe("Reach a@b for 100% coverage of a#tag.");
     });
 });
+
+describe("gtkDocToMarkdown reference fixes", () => {
+    it("renames parameter references to the identifier the signature declares", () => {
+        expect(gtkDocToMarkdown("Pass @keyboard_mode.", new Map([["keyboard_mode", "keyboardMode"]]))).toBe(
+            "Pass `keyboardMode`.",
+        );
+    });
+
+    it("leaves a parameter reference the map does not cover as written", () => {
+        expect(gtkDocToMarkdown("its @user_destroy will be called", new Map([["sort_func", "sortFunc"]]))).toBe(
+            "its `user_destroy` will be called",
+        );
+    });
+
+    it("resolves old-style signal and property references to member paths", () => {
+        expect(gtkDocToMarkdown("See the #GSocketClient::event signal.")).toBe(
+            "See the `GSocketClient.event` signal.",
+        );
+
+        expect(gtkDocToMarkdown("set the #GApplication:resource-base-path property")).toBe(
+            "set the `GApplication.resourceBasePath` property",
+        );
+    });
+
+    it("unescapes a backslash-escaped percent instead of reading it as a constant", () => {
+        expect(gtkDocToMarkdown(String.raw`modifiers: \%f and \%u`)).toBe("modifiers: %f and %u");
+    });
+
+    it("drops HTML comment separators without merging them into the reference", () => {
+        expect(gtkDocToMarkdown("by providing #GCallback<!-- -->s")).toBe("by providing `GCallback`s");
+    });
+
+    it("camel-cases identifier links and appends parentheses", () => {
+        expect(gtkDocToMarkdown("use [id@webkit_feature_get_status]")).toBe("use `webkitFeatureGetStatus()`");
+    });
+});
+
+describe("gtkDocToMarkdown DocBook conversion", () => {
+    it("converts DocBook lists to Markdown bullets", () => {
+        const input =
+            "<itemizedlist><listitem><para>one</para></listitem><listitem><para>two</para></listitem></itemizedlist>";
+
+        expect(gtkDocToMarkdown(input)).toBe("- one\n- two");
+    });
+
+    it("converts DocBook literals and links", () => {
+        expect(gtkDocToMarkdown('<link linkend="GdkPixbufLoader-area-prepared">area_prepared</link>')).toBe(
+            "area_prepared",
+        );
+
+        expect(gtkDocToMarkdown("<para>Use <literal>none</literal> to disable.</para>")).toBe(
+            "Use `none` to disable.",
+        );
+    });
+
+    it("converts DocBook informal examples to fenced blocks", () => {
+        expect(gtkDocToMarkdown("<informalexample><programlisting>a = 1;</programlisting></informalexample>")).toBe(
+            "```\na = 1;\n```",
+        );
+    });
+});

--- a/packages/codegen/tests/unit/khronos-command-jsdoc.test.ts
+++ b/packages/codegen/tests/unit/khronos-command-jsdoc.test.ts
@@ -1,0 +1,439 @@
+import { describe, expect, it } from "vitest";
+import type { InArg, OutArg } from "../../src/khronos/args.js";
+import type { GlDocContext } from "../../src/khronos/doc-context.js";
+import type { GlExtensionAttribution } from "../../src/khronos/extensions.js";
+import type { GlCommand, GlParam } from "../../src/khronos/model.js";
+import type { CommandPlan, GlScalar, ParamPlan, ReturnPlan } from "../../src/khronos/plan.js";
+import type { GlSymbolProvenance } from "../../src/khronos/select.js";
+import { commandJsDoc, derivedJsDoc, inParamDocLine } from "../../src/khronos/jsdoc.js";
+import { docContext, glProvenance } from "../helpers/khronos.js";
+
+type OkPlan = CommandPlan & { isOk: true };
+
+const GLENUM: GlScalar = { descriptor: "t.uint32", tsAlias: "GLenum", isGroupBearing: true };
+const GLINT: GlScalar = { descriptor: "t.int32", tsAlias: "GLint", viewType: "Int32Array" };
+const GLUINT: GlScalar = { descriptor: "t.uint32", tsAlias: "GLuint", viewType: "Uint32Array" };
+const GLFLOAT: GlScalar = { descriptor: "t.float32", tsAlias: "GLfloat", viewType: "Float32Array" };
+const GLSIZEI: GlScalar = { descriptor: "t.int32", tsAlias: "GLsizei", viewType: "Int32Array" };
+const SCALAR_RETURN: ReturnPlan = { kind: "scalar", scalar: GLENUM };
+const VOID_RETURN: ReturnPlan = { kind: "void" };
+
+const KIND_TABLE: Map<string, string> = new Map([
+    ["Color", "This parameter represents part of or a complete color."],
+    ["Matrix4x4", "This parameter represents a 4x4 matrix."],
+    ["Clamped[0; 1]", "This parameter will get clamped to the 0 to 1 range."],
+]);
+
+const glCommand = (overrides: Partial<GlCommand> & { name: string }): GlCommand => ({
+    returnCType: "void",
+    returnKinds: [],
+    params: [],
+    ...overrides,
+});
+
+const glParam = (overrides: Partial<GlParam> & { name: string; cType: string }): GlParam => ({
+    kinds: [],
+    ...overrides,
+});
+
+const extension = (name: string, notes: string[] = []): GlExtensionAttribution => ({ name, notes });
+
+const okPlan = (command: GlCommand, params: ParamPlan[], returnPlan: ReturnPlan = VOID_RETURN): OkPlan => ({
+    isOk: true,
+    command,
+    params,
+    returnPlan,
+});
+
+const inArg = (name: string, tsType: string): InArg => ({ isOut: false, name, tsType, descriptor: "t.float32" });
+
+const outArg = (paramIndex: number, tsType: string): OutArg => ({
+    isOut: true,
+    cellName: `out${String(paramIndex)}`,
+    seed: "",
+    tsType,
+    descriptor: "t.ref(t.int32)",
+    paramIndex,
+});
+
+const lineStartingWith = (doc: string, prefix: string): string[] =>
+    doc.split("\n").filter((line) => line.startsWith(prefix));
+
+const noteDoc = (command: GlCommand, provenance: GlSymbolProvenance, docs: GlDocContext): string =>
+    commandJsDoc({ plan: okPlan(command, []), provenance, ins: [], outs: [], docs });
+
+const notedCommand = (): GlCommand =>
+    glCommand({
+        name: "glVertexAttrib1d",
+        comment: "Kept for the tessellation shaders",
+        vecEquiv: "glVertexAttrib1dv",
+        glx: { type: "render", opcode: "197", comment: "PBO protocol" },
+    });
+
+describe("khronos command jsdoc", () => {
+    it("separates the prose block from the tag block on a parameterless command", () => {
+        const doc = commandJsDoc({
+            plan: okPlan(
+                glCommand({ name: "glGetError", returnCType: "GLenum", returnGroup: "ErrorCode" }),
+                [],
+                SCALAR_RETURN,
+            ),
+            provenance: glProvenance(),
+            ins: [],
+            outs: [],
+            docs: docContext(),
+        });
+
+        expect(doc).toBe(
+            [
+                "/**",
+                " * `GLenum glGetError()`",
+                " *",
+                " * Provided by `GL_VERSION_1_0`.",
+                " *",
+                " * @returns `ErrorCode`",
+                " */",
+            ].join("\n"),
+        );
+    });
+});
+
+describe("khronos derived singular jsdoc", () => {
+    it("separates the prose block from the tag block on a derived singular", () => {
+        const doc = derivedJsDoc({
+            command: glCommand({ name: "glGenBuffers" }),
+            provenance: glProvenance({ feature: "GL_VERSION_1_5" }),
+            summary: "Returns one buffer object name via `glGenBuffers(1, ...)`.",
+            body: [" * @returns `GLuint`, object class `buffer`"],
+            docs: docContext(),
+        });
+
+        expect(doc).toBe(
+            [
+                "/**",
+                " * Returns one buffer object name via `glGenBuffers(1, ...)`.",
+                " *",
+                " * Provided by `GL_VERSION_1_5`.",
+                " *",
+                " * @returns `GLuint`, object class `buffer`",
+                " */",
+            ].join("\n"),
+        );
+    });
+
+    it("keeps the notes of the parent command off a derived singular", () => {
+        const doc = derivedJsDoc({
+            command: notedCommand(),
+            provenance: glProvenance(),
+            summary: "Deletes one buffer object name via `glVertexAttrib1d(1, ...)`.",
+            body: [],
+            docs: docContext({
+                aliasTargets: new Map([["glVertexAttrib1d", ["glVertexAttrib1dARB"]]]),
+                emittedCommands: new Set(["glVertexAttrib1dv"]),
+            }),
+        });
+
+        expect(doc).not.toContain("Also known as");
+        expect(doc).not.toContain("GLX render opcode");
+        expect(doc).not.toContain("Vector form");
+    });
+});
+
+describe("khronos parameter metadata", () => {
+    const command = glCommand({
+        name: "glParams",
+        params: [
+            glParam({ name: "red", cType: "GLfloat", kinds: ["Color"] }),
+            glParam({ name: "value", cType: "const GLfloat *", len: "count*16", kinds: ["Matrix4x4"] }),
+            glParam({ name: "path", cType: "GLuint", kinds: ["Path"] }),
+            glParam({ name: "depth", cType: "GLdouble", kinds: ["Clamped[0; 1]", "Color"] }),
+        ],
+    });
+
+    const plan = okPlan(command, [
+        { kind: "scalar", scalar: GLFLOAT },
+        { kind: "array-in", scalar: GLFLOAT },
+        { kind: "scalar", scalar: GLUINT },
+        { kind: "scalar", scalar: GLFLOAT },
+    ]);
+
+    const doc = commandJsDoc({
+        plan,
+        provenance: glProvenance(),
+        ins: [
+            inArg("red", "GLfloat"),
+            inArg("value", "GLfloat[] | Float32Array"),
+            inArg("path", "GLuint"),
+            inArg("depth", "GLdouble"),
+        ],
+        outs: [],
+        docs: docContext({ kinds: KIND_TABLE }),
+    });
+
+    it("appends the description of a kind the registry table knows", () => {
+        expect(lineStartingWith(doc, " * @param red")).toEqual([
+            " * @param red - `GLfloat`, kind `Color`. This parameter represents part of or a complete color.",
+        ]);
+
+        expect(lineStartingWith(doc, " * @param value")).toEqual([
+            " * @param value - `GLfloat[] | Float32Array`, length `count*16`, kind `Matrix4x4`. " +
+            "This parameter represents a 4x4 matrix.",
+        ]);
+    });
+
+    it("omits the sentence for a kind the registry table lacks", () => {
+        expect(lineStartingWith(doc, " * @param path")).toEqual([" * @param path - `GLuint`, kind `Path`"]);
+    });
+
+    it("lists a comma-joined kind as one entry per kind", () => {
+        expect(lineStartingWith(doc, " * @param depth")).toEqual([
+            " * @param depth - `GLdouble`, kind `Clamped[0; 1]`, kind `Color`. " +
+            "This parameter will get clamped to the 0 to 1 range. " +
+            "This parameter represents part of or a complete color.",
+        ]);
+    });
+});
+
+describe("khronos parameter shapes", () => {
+    it("documents a byte-offset parameter as an offset, without its C pointer length", () => {
+        const command = glCommand({
+            name: "glDrawElements",
+            params: [glParam({ name: "indices", cType: "const void *", len: "COMPSIZE(count,type)" })],
+        });
+
+        const plan = okPlan(command, [{ kind: "byte-offset" }]);
+        const arg = inArg("indices", "GLintptr");
+
+        expect(inParamDocLine(plan, arg, docContext())).toBe(
+            " * @param indices - `GLintptr`, byte offset into the bound buffer",
+        );
+    });
+
+    it("drops the group once the emitted type already names it", () => {
+        const command = glCommand({
+            name: "glTexImage2D",
+            params: [
+                glParam({ name: "target", cType: "GLenum", group: "TextureTarget" }),
+                glParam({ name: "internalformat", cType: "GLint", group: "InternalFormat" }),
+            ],
+        });
+
+        const plan = okPlan(command, [
+            { kind: "scalar", scalar: GLENUM },
+            { kind: "scalar", scalar: GLINT },
+        ]);
+
+        expect(inParamDocLine(plan, inArg("target", "TextureTarget"), docContext())).toBe(
+            " * @param target - `TextureTarget`",
+        );
+
+        expect(inParamDocLine(plan, inArg("internalformat", "GLint"), docContext())).toBe(
+            " * @param internalformat - `GLint`, group `InternalFormat`",
+        );
+    });
+});
+
+describe("khronos return metadata", () => {
+    it("reports the emitted type of a pointer return, with its registry metadata", () => {
+        const doc = commandJsDoc({
+            plan: okPlan(
+                glCommand({
+                    name: "glGetString",
+                    returnCType: "const GLubyte *",
+                    returnObjectClass: "program",
+                    returnKinds: ["String"],
+                }),
+                [],
+                { kind: "string" },
+            ),
+            provenance: glProvenance(),
+            ins: [],
+            outs: [],
+            docs: docContext(),
+        });
+
+        expect(lineStartingWith(doc, " * @returns")).toEqual([
+            " * @returns `string`, object class `program`, kind `String`",
+        ]);
+    });
+
+    it("reports a GLboolean return as the emitted boolean", () => {
+        const doc = commandJsDoc({
+            plan: okPlan(glCommand({ name: "glIsBuffer", returnCType: "GLboolean" }), [], { kind: "boolean" }),
+            provenance: glProvenance(),
+            ins: [],
+            outs: [],
+            docs: docContext(),
+        });
+
+        expect(lineStartingWith(doc, " * @returns")).toEqual([" * @returns `boolean`"]);
+    });
+});
+
+describe("khronos out parameter metadata", () => {
+    it("reports a collapsed single-valued query as the scalar it returns", () => {
+        const command = glCommand({
+            name: "glGetShaderiv",
+            params: [
+                glParam({ name: "shader", cType: "GLuint", objectClass: "shader" }),
+                glParam({ name: "pname", cType: "GLenum", group: "ShaderParameterName" }),
+                glParam({ name: "params", cType: "GLint *", len: "COMPSIZE(pname)" }),
+            ],
+        });
+
+        const doc = commandJsDoc({
+            plan: okPlan(command, [
+                { kind: "scalar", scalar: GLUINT },
+                { kind: "scalar", scalar: GLENUM },
+                { kind: "ref-out", scalar: GLINT },
+            ]),
+            provenance: glProvenance(),
+            ins: [inArg("shader", "GLuint"), inArg("pname", "ShaderParameterName")],
+            outs: [outArg(2, "GLint")],
+            docs: docContext(),
+        });
+
+        expect(lineStartingWith(doc, " * @returns")).toEqual([" * @returns `params` (`GLint`)"]);
+    });
+
+    it("keeps the length of an out parameter the caller still sizes", () => {
+        const command = glCommand({
+            name: "glGenBuffers",
+            params: [
+                glParam({ name: "n", cType: "GLsizei" }),
+                glParam({ name: "buffers", cType: "GLuint *", len: "n", objectClass: "buffer" }),
+            ],
+        });
+
+        const doc = commandJsDoc({
+            plan: okPlan(command, [
+                { kind: "scalar", scalar: GLSIZEI },
+                { kind: "ref-array-out", scalar: GLUINT, lenParamName: "n" },
+            ]),
+            provenance: glProvenance(),
+            ins: [inArg("n", "GLsizei")],
+            outs: [outArg(1, "GLuint[]")],
+            docs: docContext(),
+        });
+
+        expect(lineStartingWith(doc, " * @returns")).toEqual([
+            " * @returns `buffers` (`GLuint[]`, length `n`, object class `buffer`)",
+        ]);
+    });
+});
+
+describe("khronos tuple returns", () => {
+    it("prints every out member of a tuple return", () => {
+        const command = glCommand({
+            name: "glGetError",
+            params: [
+                glParam({ name: "length", cType: "GLsizei *", len: "1" }),
+                glParam({ name: "type", cType: "GLenum *", group: "AttributeType", len: "1" }),
+            ],
+        });
+
+        const doc = commandJsDoc({
+            plan: okPlan(command, [
+                { kind: "ref-out", scalar: GLSIZEI },
+                { kind: "ref-out", scalar: GLENUM },
+            ]),
+            provenance: glProvenance(),
+            ins: [],
+            outs: [outArg(0, "GLsizei"), outArg(1, "AttributeType")],
+            docs: docContext(),
+        });
+
+        expect(lineStartingWith(doc, " * @returns")).toEqual([
+            " * @returns Tuple of `length` (`GLsizei`), `type` (`AttributeType`)",
+        ]);
+    });
+});
+
+describe("khronos registry provenance notes", () => {
+    const provenance = glProvenance({
+        feature: "GL_VERSION_4_3",
+        requireComment: "Reuse tokens from KHR_debug",
+        removals: [
+            { feature: "GL_VERSION_3_2", comment: "Compatibility-only GL 1.1 features removed from GL 3.2" },
+            { feature: "GL_VERSION_4_0" },
+        ],
+    });
+
+    const docs = docContext({
+        aliasTargets: new Map([["glVertexAttrib1d", ["glVertexAttrib1dARB", "glVertexAttrib1dNV"]]]),
+
+        extensionCommands: new Map([
+            ["glVertexAttrib1d", [extension("GL_ARB_vertex_program"), extension("GL_NV_vertex_program")]],
+        ]),
+
+        emittedCommands: new Set(["glVertexAttrib1dv"]),
+    });
+
+    it("emits every note once, in the documented order", () => {
+        const doc = noteDoc(notedCommand(), provenance, docs);
+
+        expect(doc.split("\n").slice(3, 11)).toEqual([
+            " * Provided by `GL_VERSION_4_3`.",
+            " * Removed from the core profile by `GL_VERSION_3_2` " +
+            "(Compatibility-only GL 1.1 features removed from GL 3.2), `GL_VERSION_4_0`, " +
+            "then restored by `GL_VERSION_4_3`.",
+            " * Registry note: Reuse tokens from KHR_debug",
+            " * Also provided by the `GL_ARB_vertex_program`, `GL_NV_vertex_program` extensions.",
+            " * Registry note: Kept for the tessellation shaders",
+            " * Also known as `glVertexAttrib1dARB`, `glVertexAttrib1dNV`.",
+            " * Vector form: `vertexAttrib1dv`.",
+            " * GLX render opcode 197. PBO protocol.",
+        ]);
+
+        expect(lineStartingWith(doc, " * Registry note:")).toEqual([
+            " * Registry note: Reuse tokens from KHR_debug",
+            " * Registry note: Kept for the tessellation shaders",
+        ]);
+    });
+});
+
+describe("khronos extension notes", () => {
+    it("quotes the note each providing extension carries", () => {
+        const withNotes = docContext({
+            extensionCommands: new Map([
+                [
+                    "glActiveTexture",
+                    [
+                        extension("GL_ARB_imaging", ["Now treating ARB_imaging as an extension, not a GL API version"]),
+                        extension("GL_ARB_multitexture", ["Texture object functions"]),
+                    ],
+                ],
+            ]),
+        });
+
+        const doc = noteDoc(glCommand({ name: "glActiveTexture" }), glProvenance(), withNotes);
+
+        expect(lineStartingWith(doc, " * `GL_ARB")).toEqual([
+            " * `GL_ARB_imaging` note: Now treating ARB_imaging as an extension, not a GL API version.",
+            " * `GL_ARB_multitexture` note: Texture object functions.",
+        ]);
+    });
+});
+
+describe("khronos registry note omission", () => {
+    it("omits every note the registry does not carry, and the empty tag block with them", () => {
+        const doc = noteDoc(glCommand({ name: "glVertexAttrib1d" }), glProvenance(), docContext());
+        expect(doc.split("\n").slice(3)).toEqual([" * Provided by `GL_VERSION_1_0`.", " */"]);
+    });
+
+    it("names a single extension in the singular", () => {
+        const extensions = new Map([["glActiveTexture", [extension("GL_ARB_multitexture")]]]);
+        const docs = docContext({ extensionCommands: extensions });
+        const doc = noteDoc(glCommand({ name: "glActiveTexture" }), glProvenance(), docs);
+
+        expect(lineStartingWith(doc, " * Also provided by")).toEqual([
+            " * Also provided by the `GL_ARB_multitexture` extension.",
+        ]);
+    });
+
+    it("drops the vector form when its target is not emitted", () => {
+        const docs = docContext({ emittedCommands: new Set(["glVertexAttrib1d"]) });
+        const doc = noteDoc(notedCommand(), glProvenance(), docs);
+        expect(lineStartingWith(doc, " * Vector form:")).toEqual([]);
+    });
+});

--- a/packages/codegen/tests/unit/khronos-model.test.ts
+++ b/packages/codegen/tests/unit/khronos-model.test.ts
@@ -1,0 +1,129 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { type GlEnum, type GlFeature, loadGlRegistry } from "../../src/khronos/model.js";
+
+const REGISTRY_PATH = fileURLToPath(new URL("../../src/khronos/registry/gl.xml", import.meta.url));
+const registry = loadGlRegistry(REGISTRY_PATH);
+
+const enumNamed = (name: string): GlEnum => {
+    const found = registry.enums.find((candidate) => candidate.name === name);
+
+    if (found === undefined) {
+        throw new Error(`No enum named ${name} in the registry`);
+    }
+
+    return found;
+};
+
+const featureNamed = (name: string): GlFeature => {
+    const found = registry.features.find((candidate) => candidate.name === name);
+
+    if (found === undefined) {
+        throw new Error(`No feature named ${name} in the registry`);
+    }
+
+    return found;
+};
+
+describe("khronos registry kinds", () => {
+    it("retains every declared parameter kind description", () => {
+        expect(registry.kinds.size).toBe(29);
+        expect(registry.kinds.get("WinCoord")).toBe("This parameter represents a window coordinate.");
+    });
+});
+
+describe("khronos registry types", () => {
+    it("keeps the declaration text with the type name inline", () => {
+        expect(registry.types.get("GLenum")?.declaration).toBe("typedef unsigned int GLenum;");
+    });
+
+    it("keeps the requires and comment attributes", () => {
+        expect(registry.types.get("GLbyte")?.requires).toBe("khrplatform");
+        expect(registry.types.get("GLvoid")?.comment).toBe("Not an actual GL type, though used in headers in the past");
+    });
+
+    it("retains every declared type", () => {
+        expect(registry.types.size).toBe(43);
+    });
+});
+
+describe("khronos registry commands", () => {
+    it("splits parameter kinds", () => {
+        expect(registry.commands.get("glClearColor")?.params[0]?.kinds).toEqual(["Color"]);
+    });
+
+    it("keeps the return object class and kinds", () => {
+        expect(registry.commands.get("glCreateProgram")?.returnObjectClass).toBe("program");
+        expect(registry.commands.get("glGetString")?.returnKinds).toEqual(["String"]);
+    });
+
+    it("keeps the vector equivalent and glx protocol information", () => {
+        expect(registry.commands.get("glVertexAttrib1d")?.vecEquiv).toBe("glVertexAttrib1dv");
+        expect(registry.commands.get("glActiveTexture")?.glx).toEqual({ type: "render", opcode: "197" });
+    });
+
+    it("keeps the command's own glx entry, not the named protocol variant", () => {
+        expect(registry.commands.get("glTexImage2D")?.glx).toEqual({ type: "render", opcode: "110" });
+        expect(registry.commands.get("glReadPixels")?.glx).toEqual({ type: "single", opcode: "111" });
+    });
+
+    it("inverts the alias relation onto the aliased command", () => {
+        expect(registry.commands.get("glActiveTextureARB")?.aliasTarget).toBe("glActiveTexture");
+        expect(registry.aliasTargets.get("glActiveTexture")).toContain("glActiveTextureARB");
+    });
+});
+
+describe("khronos registry enums", () => {
+    it("records bitmask groups only where the block declares them", () => {
+        expect(registry.bitmaskGroups.has("ClearBufferMask")).toBe(true);
+        expect(registry.bitmaskGroups.has("SyncBehaviorFlags")).toBe(false);
+    });
+
+    it("keeps the value type, comment, and enclosing vendor", () => {
+        const token = enumNamed("GL_INVALID_INDEX");
+        expect(token.valueType).toBe("u");
+        expect(token.comment).toBe("Tagged as uint");
+        expect(token.vendor).toBe("ARB");
+    });
+
+    it("keeps enum aliases and deprecation comments", () => {
+        expect(enumNamed("GL_CLIP_DISTANCE0").alias).toBe("GL_CLIP_PLANE0");
+        expect(enumNamed("GL_AUTO_GENERATE_MIPMAP").comment).toBe("Should be deprecated");
+    });
+
+    it("inherits the bitmask flag from the enclosing block", () => {
+        expect(enumNamed("GL_COLOR_BUFFER_BIT").isBitmask).toBe(true);
+    });
+});
+
+describe("khronos registry extensions", () => {
+    it("retains every extension and splits its supported apis", () => {
+        expect(registry.extensions).toHaveLength(863);
+        const multitexture = registry.extensions.find((extension) => extension.name === "GL_ARB_multitexture");
+        expect(multitexture?.supported).toContain("gl");
+    });
+});
+
+describe("khronos registry comment", () => {
+    it("keeps the license header", () => {
+        expect(registry.comment).toContain("SPDX-License-Identifier: Apache-2.0");
+    });
+});
+
+describe("khronos registry features", () => {
+    it("keeps require and remove blocks interleaved in document order", () => {
+        const comments = featureNamed("GL_VERSION_4_3")
+            .blocks.filter((block) => block.kind === "require")
+            .map((block) => block.comment);
+
+        expect(comments).toContain(
+            "Restore functionality removed in GL 3.2 core to GL 4.3. Needed for debug interface.",
+        );
+
+        const removals = featureNamed("GL_VERSION_3_2")
+            .blocks.filter((block) => block.kind === "remove")
+            .map((block) => block.comment);
+
+        expect(removals).toContain("Compatibility-only GL 1.1 features removed from GL 3.2");
+    });
+});

--- a/packages/codegen/tests/unit/khronos-modules.test.ts
+++ b/packages/codegen/tests/unit/khronos-modules.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import type { GlEnum, GlType } from "../../src/khronos/model.js";
+import type { GlSymbolProvenance } from "../../src/khronos/select.js";
+import { type EnumRow, renderCommandsModule, renderEnumsModule, renderTypesModule } from "../../src/khronos/modules.js";
+import { docContext, glProvenance } from "../helpers/khronos.js";
+
+const REGISTRY_COMMENT = "Copyright 2013-2026 The Khronos Group Inc.\nSPDX-License-Identifier: Apache-2.0";
+
+const glEnum = (overrides: Partial<GlEnum> & { name: string }): GlEnum => ({
+    value: "0x8295",
+    groups: [],
+    isBitmask: false,
+    ...overrides,
+});
+
+const enumRow = (token: GlEnum, provenance: GlSymbolProvenance = glProvenance()): EnumRow => ({
+    token,
+    exportName: token.name.slice(3),
+    literal: token.value,
+    provenance,
+});
+
+const glType = (name: string, declaration: string, overrides: Partial<GlType> = {}): GlType => ({
+    name,
+    declaration,
+    ...overrides,
+});
+
+const blockFor = (source: string, exported: string): string[] => {
+    const lines = source.split("\n");
+    const end = lines.indexOf(exported);
+    const start = lines.lastIndexOf("/**", end);
+
+    return lines.slice(start, end + 1);
+};
+
+const documentedToken = (): GlEnum =>
+    glEnum({
+        name: "GL_AUTO_GENERATE_MIPMAP",
+        groups: ["InternalFormatPName"],
+        comment: "Should be deprecated",
+        alias: "GL_CLIP_PLANE0",
+        valueType: "u",
+        vendor: "ARB",
+        blockComment: "Tokens whose numeric value is intrinsically meaningful",
+    });
+
+const documentedProvenance = (): GlSymbolProvenance =>
+    glProvenance({
+        feature: "GL_VERSION_4_3",
+        requireComment: "Reuse tokens from ARB_internalformat_query2",
+        removals: [{ feature: "GL_VERSION_3_2", comment: "Compatibility-only GL 1.1 features removed" }],
+    });
+
+describe("khronos enum jsdoc", () => {
+    it("emits every registry fact in the documented order", () => {
+        const docs = docContext({
+            registryComment: REGISTRY_COMMENT,
+            extensionEnums: new Map([
+                ["GL_AUTO_GENERATE_MIPMAP", [{ name: "GL_ARB_internalformat_query2", notes: ["Extends the query"] }]],
+            ]),
+        });
+
+        const source = renderEnumsModule([enumRow(documentedToken(), documentedProvenance())], docs);
+
+        expect(blockFor(source, "export const AUTO_GENERATE_MIPMAP = 0x8295;")).toEqual([
+            "/**",
+            " * `GL_AUTO_GENERATE_MIPMAP`.",
+            " *",
+            " * Provided by `GL_VERSION_4_3`.",
+            " * Removed from the core profile by `GL_VERSION_3_2` (Compatibility-only GL 1.1 features removed), " +
+            "then restored by `GL_VERSION_4_3`.",
+            " * Registry note: Reuse tokens from ARB_internalformat_query2",
+            " * Also provided by the `GL_ARB_internalformat_query2` extension.",
+            " * `GL_ARB_internalformat_query2` note: Extends the query.",
+            " * Groups: `InternalFormatPName`.",
+            " * Token note: Should be deprecated.",
+            " * Also known as `GL_CLIP_PLANE0`.",
+            " * Tagged `u` in the registry.",
+            " * Allocated from the `ARB` enumerant range: Tokens whose numeric value is intrinsically meaningful.",
+            " */",
+            "export const AUTO_GENERATE_MIPMAP = 0x8295;",
+        ]);
+    });
+
+    it("emits only the summary and the provided-by line for a bare token", () => {
+        const source = renderEnumsModule([enumRow(glEnum({ name: "GL_ONE", value: "1" }))], docContext());
+
+        expect(blockFor(source, "export const ONE = 1;")).toEqual([
+            "/**",
+            " * `GL_ONE`.",
+            " *",
+            " * Provided by `GL_VERSION_1_0`.",
+            " */",
+            "export const ONE = 1;",
+        ]);
+    });
+
+    it("names the enclosing block when it carries a comment but no vendor", () => {
+        const token = glEnum({ name: "GL_DYNAMIC_STORAGE_BIT", value: "0x0100", blockComment: "Reserved bits" });
+        const source = renderEnumsModule([enumRow(token)], docContext());
+
+        expect(blockFor(source, "export const DYNAMIC_STORAGE_BIT = 0x0100;")).toContain(
+            " * Registry enumerant block: Reserved bits.",
+        );
+    });
+});
+
+describe("khronos enum group aliases", () => {
+    const docs = docContext({
+        bitmaskGroups: new Set(["ClearBufferMask"]),
+        groupMembers: new Map([
+            ["ClearBufferMask", ["COLOR_BUFFER_BIT", "DEPTH_BUFFER_BIT"]],
+            ["SyncBehaviorFlags", ["NONE"]],
+        ]),
+    });
+
+    const source = renderTypesModule(
+        new Map([
+            ["ClearBufferMask", "GLbitfield"],
+            ["SyncBehaviorFlags", "GLbitfield"],
+        ]),
+        docs,
+    );
+
+    it("declares a registry bitmask group as combinable and lists its members", () => {
+        expect(blockFor(source, "export type ClearBufferMask = GLbitfield;")).toEqual([
+            "/**",
+            " * Registry enum group `ClearBufferMask`, declared as a bitmask: members are combined with `|`.",
+            " *",
+            " * Open and documentation-only; any `GLbitfield` value is accepted.",
+            " *",
+            " * Members: `COLOR_BUFFER_BIT`, `DEPTH_BUFFER_BIT`.",
+            " */",
+            "export type ClearBufferMask = GLbitfield;",
+        ]);
+    });
+
+    it("keeps the plain wording for a GLbitfield group the registry does not declare a bitmask", () => {
+        expect(blockFor(source, "export type SyncBehaviorFlags = GLbitfield;")).toEqual([
+            "/**",
+            " * Registry enum group `SyncBehaviorFlags`.",
+            " *",
+            " * Open and documentation-only; any `GLbitfield` value is accepted.",
+            " *",
+            " * Members: `NONE`.",
+            " */",
+            "export type SyncBehaviorFlags = GLbitfield;",
+        ]);
+    });
+});
+
+describe("khronos type aliases", () => {
+    const docs = docContext({
+        registryComment: REGISTRY_COMMENT,
+        types: new Map([
+            ["GLenum", glType("GLenum", "typedef unsigned int GLenum;")],
+            ["GLbyte", glType("GLbyte", "typedef khronos_int8_t GLbyte;", { requires: "khrplatform" })],
+            ["GLsync", glType("GLsync", "typedef struct __GLsync *GLsync;")],
+        ]),
+    });
+
+    const source = renderTypesModule(new Map(), docs);
+
+    it("prints the registry typedef of a scalar the registry declares", () => {
+        expect(source).toContain("/** The C `GLenum` scalar: `typedef unsigned int GLenum;`. */");
+    });
+
+    it("names the header a scalar requires", () => {
+        expect(source).toContain(
+            "/** The C `GLbyte` scalar: `typedef khronos_int8_t GLbyte;`. Requires the `khrplatform` header. */",
+        );
+    });
+
+    it("falls back to the bare wording for a scalar the registry does not declare", () => {
+        expect(source).toContain("/** The C `GLfloat` scalar. */");
+    });
+
+    it("prints the registry typedef of the opaque sync handle", () => {
+        expect(source).toContain("/** An opaque `GLsync` fence handle: `typedef struct __GLsync *GLsync;`. */");
+    });
+
+    it("attributes the generated file to the Khronos registry", () => {
+        expect(source.split("\n").slice(0, 8)).toEqual([
+            "/**",
+            " * GENERATED FILE: do not edit.",
+            " *",
+            " * Derived from the Khronos OpenGL registry (gl.xml).",
+            " *",
+            " * Copyright 2013-2026 The Khronos Group Inc.",
+            " * SPDX-License-Identifier: Apache-2.0",
+            " */",
+        ]);
+    });
+});
+
+describe("khronos commands module", () => {
+    it("documents the shared library constant", () => {
+        const source = renderCommandsModule([], [], new Set(), docContext());
+
+        expect(source).toContain(
+            "/** The shared library the generated OpenGL bindings are loaded from. */\n" +
+            "export const LIB = \"libGL.so.1\";",
+        );
+    });
+});

--- a/packages/codegen/tests/unit/khronos-select.test.ts
+++ b/packages/codegen/tests/unit/khronos-select.test.ts
@@ -1,0 +1,99 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildExtensionIndex } from "../../src/khronos/extensions.js";
+import { loadGlRegistry } from "../../src/khronos/model.js";
+import { type GlSelection, type GlSymbolProvenance, resolveEnum, selectSubset } from "../../src/khronos/select.js";
+
+const REGISTRY_PATH = fileURLToPath(new URL("../../src/khronos/registry/gl.xml", import.meta.url));
+const SELECTION: GlSelection = { api: "gl", version: 4.6, profile: "core" };
+const registry = loadGlRegistry(REGISTRY_PATH);
+const subset = selectSubset(registry, SELECTION);
+
+const provenanceFor = (source: Map<string, GlSymbolProvenance>, name: string): GlSymbolProvenance => {
+    const found = source.get(name);
+
+    if (found === undefined) {
+        throw new Error(`No provenance for ${name}`);
+    }
+
+    return found;
+};
+
+describe("khronos core selection", () => {
+    it("restores symbols a later feature re-requires after a core removal", () => {
+        const overflow = provenanceFor(subset.enums, "GL_STACK_OVERFLOW");
+        expect(overflow.feature).toBe("GL_VERSION_4_3");
+
+        expect(overflow.requireComment).toBe(
+            "Restore functionality removed in GL 3.2 core to GL 4.3. Needed for debug interface.",
+        );
+
+        expect(overflow.removals).toEqual([
+            { feature: "GL_VERSION_3_2", comment: "Compatibility-only GL 1.1 features removed from GL 3.2" },
+        ]);
+
+        const quads = provenanceFor(subset.enums, "GL_QUADS");
+        expect(quads.feature).toBe("GL_VERSION_4_0");
+        expect(quads.requireComment).toBe("Reuse ARB_tessellation_shader");
+        const vertexArray = provenanceFor(subset.enums, "GL_VERTEX_ARRAY");
+        expect(vertexArray.feature).toBe("GL_VERSION_4_3");
+        expect(vertexArray.requireComment).toBe("Reuse tokens from KHR_debug");
+        expect(provenanceFor(subset.commands, "glGetPointerv").feature).toBe("GL_VERSION_4_3");
+    });
+
+    it("attributes a command to the feature that introduced it", () => {
+        const activeTexture = provenanceFor(subset.commands, "glActiveTexture");
+        expect(activeTexture.feature).toBe("GL_VERSION_1_3");
+        expect(activeTexture.requireComment).toBeUndefined();
+        expect(activeTexture.removals).toEqual([]);
+    });
+
+    it("records the symbols the core profile drops", () => {
+        const begin = subset.removed.find((entry) => entry.name === "glBegin");
+        expect(begin?.kind).toBe("command");
+        expect(begin?.feature).toBe("GL_VERSION_3_2");
+    });
+});
+
+describe("khronos extension index", () => {
+    it("credits the extensions that also provide a selected symbol", () => {
+        const index = buildExtensionIndex(registry, SELECTION);
+
+        expect(index.commands.get("glDebugMessageControl")).toContainEqual(
+            expect.objectContaining({ name: "GL_KHR_debug" }),
+        );
+
+        expect(index.enums.get("GL_AUTO_GENERATE_MIPMAP")).toContainEqual(
+            expect.objectContaining({ name: "GL_ARB_internalformat_query2" }),
+        );
+    });
+
+    it("sorts every credited extension list", () => {
+        const index = buildExtensionIndex(registry, SELECTION);
+
+        expect(index.commands.get("glProgramParameteri")?.map((attribution) => attribution.name)).toEqual([
+            "GL_ARB_get_program_binary",
+            "GL_ARB_separate_shader_objects",
+        ]);
+    });
+
+    it("keeps the comment of the extension and of the block that requires the symbol", () => {
+        const index = buildExtensionIndex(registry, SELECTION);
+
+        expect(index.commands.get("glBlendColor")).toContainEqual({
+            name: "GL_ARB_imaging",
+            notes: ["Now treating ARB_imaging as an extension, not a GL API version"],
+        });
+
+        expect(index.commands.get("glCreateTextures")).toContainEqual({
+            name: "GL_ARB_direct_state_access",
+            notes: ["Texture object functions"],
+        });
+    });
+});
+
+describe("khronos enum resolution", () => {
+    it("disambiguates a duplicated token by api", () => {
+        expect(resolveEnum(registry, "GL_ACTIVE_PROGRAM_EXT", "gl").value).toBe("0x8B8D");
+    });
+});

--- a/packages/codegen/tests/unit/libraries.test.ts
+++ b/packages/codegen/tests/unit/libraries.test.ts
@@ -4,6 +4,22 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveLibraries } from "../../src/gir/libraries.js";
 
+const writeEmptyFiles = (dir: string, names: string[]): void => {
+    for (const name of names) {
+        writeFileSync(join(dir, name), "");
+    }
+};
+
+const withTempDir = (prefix: string, run: (dir: string) => void): void => {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+
+    try {
+        run(dir);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+};
+
 describe("resolveLibraries", () => {
     it("returns the GTK-only default when libraries is omitted", () => {
         expect(resolveLibraries(undefined, [])).toEqual(["Gtk-4.0"]);
@@ -18,15 +34,10 @@ describe("resolveLibraries", () => {
     });
 
     it('expands "*" to the namespaces discovered on the search path', () => {
-        const dir = mkdtempSync(join(tmpdir(), "gir-resolve-"));
-
-        try {
-            writeFileSync(join(dir, "Gtk-4.0.gir"), "");
-            writeFileSync(join(dir, "Adw-1.gir"), "");
+        withTempDir("gir-resolve-", (dir) => {
+            writeEmptyFiles(dir, ["Gtk-4.0.gir", "Adw-1.gir"]);
             expect(resolveLibraries("*", [dir])).toEqual(["Adw-1", "Gtk-4.0"]);
-        } finally {
-            rmSync(dir, { recursive: true, force: true });
-        }
+        });
     });
 
     it('throws when "*" matches no .gir files', () => {
@@ -46,37 +57,26 @@ describe('resolveLibraries — "*" GIR discovery', () => {
     });
 
     it("returns sorted namespace identifiers for matching .gir files", () => {
-        writeFileSync(join(dir, "Gtk-4.0.gir"), "");
-        writeFileSync(join(dir, "Adw-1.gir"), "");
+        writeEmptyFiles(dir, ["Gtk-4.0.gir", "Adw-1.gir"]);
         expect(resolveLibraries("*", [dir])).toEqual(["Adw-1", "Gtk-4.0"]);
     });
 
     it("skips files that are not .gir or not Name-Version shaped", () => {
-        writeFileSync(join(dir, "Gtk-4.0.gir"), "");
-        writeFileSync(join(dir, "notes.txt"), "");
-        writeFileSync(join(dir, "weird name.gir"), "");
-        writeFileSync(join(dir, "NoVersion.gir"), "");
+        writeEmptyFiles(dir, ["Gtk-4.0.gir", "notes.txt", "weird name.gir", "NoVersion.gir"]);
         expect(resolveLibraries("*", [dir])).toEqual(["Gtk-4.0"]);
     });
 
     it("keeps only the highest version when a namespace appears multiple times", () => {
-        writeFileSync(join(dir, "Gtk-3.0.gir"), "");
-        writeFileSync(join(dir, "Gtk-4.0.gir"), "");
-        writeFileSync(join(dir, "Soup-2.4.gir"), "");
-        writeFileSync(join(dir, "Soup-3.0.gir"), "");
+        writeEmptyFiles(dir, ["Gtk-3.0.gir", "Gtk-4.0.gir", "Soup-2.4.gir", "Soup-3.0.gir"]);
         expect(resolveLibraries("*", [dir])).toEqual(["Gtk-4.0", "Soup-3.0"]);
     });
 
     it("deduplicates a namespace found across multiple search directories", () => {
-        const other = mkdtempSync(join(tmpdir(), "gir-discover-b-"));
-
-        try {
-            writeFileSync(join(dir, "Gtk-4.0.gir"), "");
-            writeFileSync(join(other, "Gtk-4.0.gir"), "");
+        withTempDir("gir-discover-b-", (other) => {
+            writeEmptyFiles(dir, ["Gtk-4.0.gir"]);
+            writeEmptyFiles(other, ["Gtk-4.0.gir"]);
             expect(resolveLibraries("*", [dir, other])).toEqual(["Gtk-4.0"]);
-        } finally {
-            rmSync(other, { recursive: true, force: true });
-        }
+        });
     });
 
     it("skips directories that cannot be read rather than crashing", () => {

--- a/packages/codegen/tests/unit/plan.test.ts
+++ b/packages/codegen/tests/unit/plan.test.ts
@@ -7,15 +7,21 @@ const NO_POLICY: GlPlanPolicy = { byteOffsetParams: new Set(), singleValuedQueri
 const command = (name: string, returnCType: string, params: GlParam[]): GlCommand => ({
     name,
     returnCType,
+    returnKinds: [],
     params,
 });
 
-const param = (name: string, cType: string, extra?: Partial<GlParam>): GlParam => ({ name, cType, ...extra });
+const param = (name: string, cType: string, extra?: Partial<GlParam>): GlParam => ({
+    name,
+    cType,
+    kinds: [],
+    ...extra,
+});
 
-const okPlan = (input: GlCommand, policy: GlPlanPolicy = NO_POLICY): CommandPlan & { ok: true } => {
+const okPlan = (input: GlCommand, policy: GlPlanPolicy = NO_POLICY): CommandPlan & { isOk: true } => {
     const plan = planCommand(input, policy);
 
-    if (!plan.ok) {
+    if (!plan.isOk) {
         throw new Error(`Expected ${input.name} to plan, got exclusion: ${plan.reason}`);
     }
 
@@ -106,9 +112,9 @@ describe("planCommand outputs", () => {
         ]);
 
         const excluded = planCommand(query, NO_POLICY);
-        expect(excluded.ok).toBe(false);
+        expect(excluded.isOk).toBe(false);
 
-        if (excluded.ok) {
+        if (excluded.isOk) {
             return;
         }
 
@@ -156,9 +162,9 @@ describe("planCommand exclusions", () => {
             NO_POLICY,
         );
 
-        expect(computed.ok).toBe(false);
+        expect(computed.isOk).toBe(false);
 
-        if (computed.ok) {
+        if (computed.isOk) {
             return;
         }
 
@@ -172,9 +178,9 @@ describe("planCommand exclusions", () => {
             NO_POLICY,
         );
 
-        expect(callback.ok).toBe(false);
+        expect(callback.isOk).toBe(false);
 
-        if (callback.ok) {
+        if (callback.isOk) {
             return;
         }
 

--- a/packages/codegen/typedoc.json
+++ b/packages/codegen/typedoc.json
@@ -1,5 +1,0 @@
-{
-    "intentionallyNotExported": [
-        "GiSymbolEntry"
-    ]
-}

--- a/packages/e2e/tests/elements/container-slot.test.tsx
+++ b/packages/e2e/tests/elements/container-slot.test.tsx
@@ -276,7 +276,7 @@ describe("render - ContainerProp (6)", () => {
 });
 
 describe("render - ContainerProp (7)", () => {
-    describe("AdwExpanderRow (rows/actions) (1)", () => {
+    describe("AdwExpanderRow (rows/suffix) (1)", () => {
         it("creates ExpanderRow widget", async () => {
             const ref = createRef<Adw.ExpanderRow>();
             await render(<AdwExpanderRow ref={ref} title="Test" />);
@@ -313,17 +313,22 @@ describe("render - ContainerProp (7)", () => {
 });
 
 describe("render - ContainerProp (8)", () => {
-    describe("AdwExpanderRow (rows/actions) (2)", () => {
+    describe("AdwExpanderRow (rows/suffix) (2)", () => {
         it("adds nested rows to ExpanderRow", async () => {
             const rowRef = createRef<Adw.ActionRow>();
-            await render(<AdwExpanderRow title="Settings" rows={<AdwActionRow ref={rowRef} title="Option 1" />} />);
+
+            await render(
+                <AdwExpanderRow expanded title="Settings" rows={<AdwActionRow ref={rowRef} title="Option 1" />} />,
+            );
+
             expect(rowRef.current).not.toBeNull();
-            expect(screen.getByText("Option 1")).toBeDefined();
+            expect(await screen.findByText("Option 1")).toBeDefined();
         });
 
         it("adds multiple rows", async () => {
             await render(
                 <AdwExpanderRow
+                    expanded
                     title="Settings"
                     rows={(
                         <>
@@ -334,14 +339,14 @@ describe("render - ContainerProp (8)", () => {
                 />,
             );
 
-            expect(screen.getByText("Option 1")).toBeDefined();
-            expect(screen.getByText("Option 2")).toBeDefined();
+            expect(await screen.findByText("Option 1")).toBeDefined();
+            expect(await screen.findByText("Option 2")).toBeDefined();
         });
     });
 });
 
 describe("render - ContainerProp (9)", () => {
-    describe("AdwExpanderRow (rows/actions) (3)", () => {
+    describe("AdwExpanderRow (rows/suffix) (3)", () => {
         it("removes nested rows when unmounted", async () => {
             const expanderRef = createRef<Adw.ExpanderRow>();
 
@@ -367,19 +372,19 @@ describe("render - ContainerProp (9)", () => {
         });
 
         it("adds action widgets to ExpanderRow", async () => {
-            await render(<AdwExpanderRow title="Group" actions={<GtkButton label="Action" />} />);
+            await render(<AdwExpanderRow title="Group" suffix={<GtkButton label="Action" />} />);
             expect(screen.getByText("Action")).toBeDefined();
         });
     });
 });
 
 describe("render - ContainerProp (10)", () => {
-    describe("AdwExpanderRow (rows/actions) (4)", () => {
+    describe("AdwExpanderRow (rows/suffix) (4)", () => {
         it("adds multiple action widgets", async () => {
             await render(
                 <AdwExpanderRow
                     title="Group"
-                    actions={(
+                    suffix={(
                         <>
                             <GtkButton label="Action 1" />
                             <GtkButton label="Action 2" />
@@ -392,14 +397,14 @@ describe("render - ContainerProp (10)", () => {
             expect(screen.getByText("Action 2")).toBeDefined();
         });
 
-        it("handles multiple rows and actions together", async () => {
+        it("handles multiple rows and suffixes together", async () => {
             const ref = createRef<Adw.ExpanderRow>();
 
             await render(
                 <AdwExpanderRow
                     ref={ref}
                     title="Complex"
-                    actions={(
+                    suffix={(
                         <>
                             <GtkButton label="Action 1" />
                             <GtkButton label="Action 2" />

--- a/packages/gl/scripts/codegen.ts
+++ b/packages/gl/scripts/codegen.ts
@@ -19,24 +19,42 @@ const registryPath = join(
 
 const glSrcDir = join(scriptDir, "..", "src");
 const outputDir = join(glSrcDir, "generated");
-const EXPORT_PATTERN = /^export (?:async )?(?:function|const|type|interface|class) ([A-Za-z_$][\w$]*)/gm;
+const EXPORT_BLOCK_PATTERN = /^export \{([^}]*)\}/gm;
 const overrideExports = overrideExportNames(join(glSrcDir, "overrides.ts"));
 const report = runGlCodegen({ registryPath, overrideExports, outputDir, resolveFrom: join(scriptDir, "..") });
 const exclusionCounts: Map<string, number> = new Map();
+
+function exportSpecifierNames(specifiers: string): string[] {
+    return specifiers
+        .split(",")
+        .map((specifier) => specifier.trim().split(/\s+/).at(-1) ?? "")
+        .filter((name) => name.length > 0);
+}
 
 function overrideExportNames(path: string): Set<string> {
     const source = readFileSync(path, "utf8");
     const names: Set<string> = new Set();
 
-    for (const match of source.matchAll(EXPORT_PATTERN)) {
-        const name = match[1];
+    for (const match of source.matchAll(EXPORT_BLOCK_PATTERN)) {
+        const specifiers = exportSpecifierNames(match[1] ?? "");
 
-        if (name !== undefined) {
+        for (const name of specifiers) {
             names.add(name);
         }
     }
 
     return names;
+}
+
+function summarizeCounts(counts: Map<string, number>): string {
+    return [...counts]
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(([reason, count]) => `${reason} ${String(count)}`)
+        .join(", ");
+}
+
+function summarizeEnumExclusions(tokens: string[]): string {
+    return tokens.map((token) => `${token}: unrepresentable`).join(", ");
 }
 
 for (const exclusion of report.exclusions) {
@@ -50,5 +68,13 @@ log.info(
 
 log.info(
     `commands: ${String(report.selectedCommands)} selected, ${String(report.emittedCommands)} emitted, ` +
-    `${String(report.derivedSingulars)} derived singulars, ${String(report.exclusions.length)} excluded`,
+    `${String(report.derivedSingulars)} derived singulars, ${String(report.exclusions.length)} excluded ` +
+    `(${summarizeCounts(exclusionCounts)})`,
 );
+
+log.info(
+    `enums: ${String(report.enumExclusions.length)} skipped ` +
+    `(${summarizeEnumExclusions(report.enumExclusions)})`,
+);
+
+log.info(`core profile: ${String(report.coreRemovals.length)} symbols removed`);

--- a/packages/gl/tests/gl.test.ts
+++ b/packages/gl/tests/gl.test.ts
@@ -49,16 +49,33 @@ const compileShaderPair = (vertSrc: string, fragSrc: string): number => {
     return program;
 };
 
+const createFilledBuffer = (target: number, data: ArrayBufferView): number => {
+    const buffer = gl.genBuffer();
+    gl.bindBuffer(target, buffer);
+    gl.bufferData(target, data.byteLength, data, gl.STATIC_DRAW);
+
+    return buffer;
+};
+
 const setUpTriangleAttribArray = (): { vao: number; vbo: number } => {
     const vao = gl.genVertexArray();
     gl.bindVertexArray(vao);
-    const vbo = gl.genBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
-    gl.bufferData(gl.ARRAY_BUFFER, TRIANGLE_POSITIONS.byteLength, TRIANGLE_POSITIONS, gl.STATIC_DRAW);
+    const vbo = createFilledBuffer(gl.ARRAY_BUFFER, TRIANGLE_POSITIONS);
     gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
     gl.enableVertexAttribArray(0);
 
     return { vao, vbo };
+};
+
+const installUniformProgram = (): { program: number } => {
+    const fixture = { program: 0 };
+
+    beforeAll(() => {
+        fixture.program = compileShaderPair(UNIFORM_VERT, BASIC_FRAG);
+        gl.useProgram(fixture.program);
+    });
+
+    return fixture;
 };
 
 beforeAll(async () => {
@@ -167,71 +184,61 @@ describe("program operations", () => {
 });
 
 describe("uniform operations — lookup and scalars", () => {
-    let program: number;
-
-    beforeAll(() => {
-        program = compileShaderPair(UNIFORM_VERT, BASIC_FRAG);
-        gl.useProgram(program);
-    });
+    const fixture = installUniformProgram();
 
     it("gets a uniform location", () => {
-        const loc = gl.getUniformLocation(program, "uFloat");
+        const loc = gl.getUniformLocation(fixture.program, "uFloat");
         expect(loc).toBeGreaterThanOrEqual(0);
     });
 
     it("returns -1 for nonexistent uniform", () => {
-        const loc = gl.getUniformLocation(program, "nonexistent");
+        const loc = gl.getUniformLocation(fixture.program, "nonexistent");
         expect(loc).toBe(-1);
     });
 
     it("sets a float uniform", () => {
-        const loc = gl.getUniformLocation(program, "uFloat");
+        const loc = gl.getUniformLocation(fixture.program, "uFloat");
         gl.uniform1f(loc, 1.5);
         expect(gl.getError()).toBe(gl.NO_ERROR);
     });
 
     it("sets an int uniform", () => {
-        const loc = gl.getUniformLocation(program, "uInt");
+        const loc = gl.getUniformLocation(fixture.program, "uInt");
         gl.uniform1i(loc, 42);
         expect(gl.getError()).toBe(gl.NO_ERROR);
     });
 });
 
 describe("uniform operations — vectors and matrices", () => {
-    let program: number;
-
-    beforeAll(() => {
-        program = compileShaderPair(UNIFORM_VERT, BASIC_FRAG);
-        gl.useProgram(program);
-    });
+    const fixture = installUniformProgram();
 
     it("sets a vec2 uniform", () => {
-        const loc = gl.getUniformLocation(program, "uVec2");
+        const loc = gl.getUniformLocation(fixture.program, "uVec2");
         gl.uniform2f(loc, 1, 2);
         expect(gl.getError()).toBe(gl.NO_ERROR);
     });
 
     it("sets a vec3 uniform", () => {
-        const loc = gl.getUniformLocation(program, "uVec3");
+        const loc = gl.getUniformLocation(fixture.program, "uVec3");
         gl.uniform3f(loc, 1, 2, 3);
         expect(gl.getError()).toBe(gl.NO_ERROR);
     });
 
     it("sets a vec4 uniform", () => {
-        const loc = gl.getUniformLocation(program, "uVec4");
+        const loc = gl.getUniformLocation(fixture.program, "uVec4");
         gl.uniform4f(loc, 1, 2, 3, 4);
         expect(gl.getError()).toBe(gl.NO_ERROR);
     });
 
     it("sets a mat4 uniform", () => {
-        const loc = gl.getUniformLocation(program, "uMat4");
+        const loc = gl.getUniformLocation(fixture.program, "uMat4");
         const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
         gl.uniformMatrix4fv(loc, 1, false, identity);
         expect(gl.getError()).toBe(gl.NO_ERROR);
     });
 
     it("sets a mat4 uniform from a Float32Array", () => {
-        const loc = gl.getUniformLocation(program, "uMat4");
+        const loc = gl.getUniformLocation(fixture.program, "uMat4");
         const identity = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
         gl.uniformMatrix4fv(loc, 1, false, identity);
         expect(gl.getError()).toBe(gl.NO_ERROR);
@@ -271,20 +278,14 @@ describe("buffer operations", () => {
     });
 
     it("binds and fills a buffer with float data", () => {
-        const buffer = gl.genBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-        const data = new Float32Array([-1, -1, 0, 1, -1, 0, 0, 1, 0]);
-        gl.bufferData(gl.ARRAY_BUFFER, data.byteLength, data, gl.STATIC_DRAW);
+        const buffer = createFilledBuffer(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 0, 1, -1, 0, 0, 1, 0]));
         expect(gl.getError()).toBe(gl.NO_ERROR);
         gl.bindBuffer(gl.ARRAY_BUFFER, 0);
         gl.deleteBuffer(buffer);
     });
 
     it("binds and fills a buffer with unsigned short data", () => {
-        const buffer = gl.genBuffer();
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffer);
-        const indices = new Uint16Array([0, 1, 2]);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices.byteLength, indices, gl.STATIC_DRAW);
+        const buffer = createFilledBuffer(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array([0, 1, 2]));
         expect(gl.getError()).toBe(gl.NO_ERROR);
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, 0);
         gl.deleteBuffer(buffer);
@@ -293,10 +294,7 @@ describe("buffer operations", () => {
 
 describe("buffer data transfer", () => {
     it("reads buffer contents back through getBufferSubData", () => {
-        const buffer = gl.genBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-        const data = new Float32Array([1.5, -2.5, 3.25, 0]);
-        gl.bufferData(gl.ARRAY_BUFFER, data.byteLength, data, gl.STATIC_DRAW);
+        const buffer = createFilledBuffer(gl.ARRAY_BUFFER, new Float32Array([1.5, -2.5, 3.25, 0]));
         const readBack = new Float32Array(4);
         gl.getBufferSubData(gl.ARRAY_BUFFER, 0, readBack.byteLength, readBack);
         expect([...readBack]).toEqual([1.5, -2.5, 3.25, 0]);
@@ -385,10 +383,7 @@ describe("drawing operations — draw calls", () => {
 
     it("draws elements", () => {
         const { vao, vbo } = setUpTriangleAttribArray();
-        const ebo = gl.genBuffer();
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ebo);
-        const indices = new Uint16Array([0, 1, 2]);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices.byteLength, indices, gl.STATIC_DRAW);
+        const ebo = createFilledBuffer(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array([0, 1, 2]));
         gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0);
         expect(gl.getError()).toBe(gl.NO_ERROR);
         gl.bindVertexArray(0);

--- a/packages/react/src/adw/prop-types.ts
+++ b/packages/react/src/adw/prop-types.ts
@@ -2,35 +2,62 @@ import type * as Adw from "@gtkx/gi/adw";
 import type { ReactNode } from "react";
 import type { ChildrenProps } from "../prop-types.js";
 
+/** One button in an `Adw.AlertDialog`'s `responses` prop. */
 type AlertDialogResponse = {
+    /** Name the dialog reports on `onResponse` when this button is chosen. */
     id: string;
+    /** Text shown on the button. */
     label: string;
+    /** Styling the button is given, such as suggested or destructive; defaults to the plain appearance. */
     appearance?: Adw.ResponseAppearance;
+    /** Whether the button can be activated; defaults to true. */
     isEnabled?: boolean;
 };
 
+/** Props of an `Adw.AlertDialog` element. */
 type AdwAlertDialogProps = {
+    /** Buttons the dialog offers, added and removed as the list changes. */
     responses?: AlertDialogResponse[] | null | undefined;
 } & ChildrenProps;
 
+/** Props of an `Adw.PreferencesRow` element. */
 type AdwPreferencesRowProps = {
+    /** Widgets added at the start of the row, before its title. */
     prefix?: ReactNode | null | undefined;
+    /** Widgets added at the end of the row. */
     suffix?: ReactNode | null | undefined;
 };
 
+/** Props of an `Adw.ExpanderRow` element. */
 type AdwExpanderRowProps = {
+    /** Widgets added to the area the row reveals when it expands. */
     rows?: ReactNode | null | undefined;
-    actions?: ReactNode | null | undefined;
 } & AdwPreferencesRowProps;
 
+/** Props of an `Adw.ToolbarView` element, whose `children` is the content the bars surround. */
 type AdwToolbarViewProps = {
+    /** Widgets stacked above the content. */
     topBar?: ReactNode | null | undefined;
+    /** Widgets stacked below the content. */
     bottomBar?: ReactNode | null | undefined;
 } & ChildrenProps;
 
+/** Props of an element that hosts breakpoints, such as `Adw.Window` or `Adw.BreakpointBin`. */
 type AdwBreakpointsProps = {
+    /** `Adw.Breakpoint` elements added to the element, each applying while its condition holds. */
     breakpoints?: ReactNode | null | undefined;
 } & ChildrenProps;
+
+/** Props of an `Adw.MultiLayoutView` element. */
+type AdwMultiLayoutViewProps = {
+    /** `Adw.Layout` elements added to the view, each holding the content it lays out. */
+    layouts?: ReactNode | null | undefined;
+    /**
+     * Widget the view places in the `Adw.LayoutSlot` whose `id` is the prop name without its `Slot`
+     * suffix, so `sidebarSlot` fills the slot with id `sidebar` in whichever layout is current.
+     */
+    [slot: `${string}Slot`]: ReactNode | null | undefined;
+};
 
 export {
     type AlertDialogResponse,
@@ -39,4 +66,5 @@ export {
     type AdwExpanderRowProps,
     type AdwToolbarViewProps,
     type AdwBreakpointsProps,
+    type AdwMultiLayoutViewProps,
 };


### PR DESCRIPTION
Emits every piece of documentation the GIR and Khronos inputs carry, and renders the API reference from it.

- **GIR**: parameter, return-value, property, field, enum-member and error-domain documentation reaches the generated declarations, alongside `@since` and `@deprecated`.
- **Khronos**: the OpenGL bindings carry their registry documentation, with per-command notes and parameter pairing.
- **Reference pages**: `packages/codegen/src/docs/` renders the symbol and element pages the website publishes.

Generated bindings started carrying `@deprecated` in part 4, where the doc model landed with the store rework. The call sites this PR migrates drop their targeted `@typescript-eslint/no-deprecated` disables; the rest are removed by parts 8, 10, 12 and 13.

Review notes addressed:

- The excluded-enum summary no longer claims `unsafe-integer` for every exclusion. `enumLiteral` also rejects values that are not BigInt literals at all, so the reason now reads `unrepresentable`, which is true of both.

`docs.test.ts` reads the `gi` store at module scope, and every `test` target in `nx.json` declares `gtkx:codegen` in `dependsOn`, so the store is generated and linked before any test file loads.

Part 7 of 15 in the v1.0.0 release stack. Merge in order.

### Areas touched

- `packages/codegen` (40)
- `packages/gl` (2)
