### PR TITLE
Portal unparentable elements and refresh Adwaita set

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -14,9 +14,6 @@
         "^@gtkx/jsx(/.*)?$"
     ],
     "ignoreIssues": {
-        "packages/react/src/reconciler/behaviors.ts": [
-            "exports"
-        ],
         "packages/utils/src/process/index.ts": [
             "exports"
         ],

--- a/packages/codegen/tests/integration/docs.test.ts
+++ b/packages/codegen/tests/integration/docs.test.ts
@@ -233,6 +233,14 @@ describe("writeDocs with the built-in Adwaita element config", () => {
         expect(expanderRow).toContain("Widgets added at the start of the row, before its title.");
         expect(expanderRow).toContain("### `suffix`");
     });
+
+    it("documents the multi-layout view's slot index signature", () => {
+        const multiLayoutView = page(outDir, join("adw", "multi-layout-view.md"));
+        expect(multiLayoutView).toContain("### `layouts`");
+        expect(multiLayoutView).toContain("`Adw.Layout` elements added to the view");
+        expect(multiLayoutView).toContain("### `${string}Slot`");
+        expect(multiLayoutView).toContain("so `sidebarSlot` fills the slot with id `sidebar`");
+    });
 });
 
 describe("writeDocs with a custom base path", () => {

--- a/packages/e2e/tests/elements/about-dialog.test.tsx
+++ b/packages/e2e/tests/elements/about-dialog.test.tsx
@@ -1,54 +1,111 @@
-import type * as Gtk from "@gtkx/gi/gtk";
+import type { CreditSection } from "@gtkx/react/internal";
+import * as Gtk from "@gtkx/gi/gtk";
 import { GtkAboutDialog } from "@gtkx/jsx/gtk";
 import { rootElement } from "@gtkx/react";
-import { render } from "@gtkx/testing";
-import { createRef } from "react";
+import { render, userEvent, within } from "@gtkx/testing";
+import { createRef, type ReactNode, type RefObject } from "react";
 import { describe, expect, it } from "vitest";
-
-type CreditSection = { sectionName: string; people: string[] };
 
 const SECTIONS: CreditSection[] = [
     { sectionName: "Design", people: ["Ada Lovelace"] },
     { sectionName: "Testing", people: ["Grace Hopper", "Margaret Hamilton"] },
 ];
 
-describe("render - AboutDialog credit sections", () => {
-    it("creates AboutDialog with credit sections", async () => {
-        const ref = createRef<Gtk.AboutDialog>();
+const TRANSLATIONS: CreditSection[] = [{ sectionName: "Translation", people: ["Alan Turing"] }];
 
-        await render(<GtkAboutDialog ref={ref} programName="GTKX" creditSections={SECTIONS} />, {
-            container: rootElement,
-        });
+const CreditedDialog = ({
+    dialogRef,
+    sections,
+}: {
+    dialogRef: RefObject<Gtk.AboutDialog | null>;
+    sections?: CreditSection[] | undefined;
+}): ReactNode => <GtkAboutDialog ref={dialogRef} programName="GTKX" creditSections={sections} visible />;
 
-        expect(ref.current).toHaveObjectProperty("programName", "GTKX");
+const renderDialog = async (
+    dialogRef: RefObject<Gtk.AboutDialog | null>,
+    sections?: CreditSection[],
+): Promise<(node: ReactNode) => Promise<void>> => {
+    const { rerender } = await render(<CreditedDialog dialogRef={dialogRef} sections={sections} />, {
+        container: rootElement,
     });
 
-    it("rejects sections changed after they are applied", async () => {
+    return rerender;
+};
+
+const getDialog = (dialogRef: RefObject<Gtk.AboutDialog | null>): Gtk.AboutDialog => {
+    if (!dialogRef.current) {
+        throw new Error("Expected an AboutDialog instance");
+    }
+
+    return dialogRef.current;
+};
+
+const showCredits = async (dialog: Gtk.AboutDialog): Promise<void> => {
+    await userEvent.click(within(dialog).getByRole(Gtk.AccessibleRole.TAB, { name: "Credits" }));
+};
+
+const getCreditCount = (dialog: Gtk.AboutDialog, text: string): number =>
+    within(dialog).queryAllByText(text, { exact: false }).length;
+
+const expectRejectedSections = async (sections?: CreditSection[]): Promise<void> => {
+    const ref = createRef<Gtk.AboutDialog>();
+    const rerender = await renderDialog(ref, SECTIONS);
+
+    await expect(rerender(<CreditedDialog dialogRef={ref} sections={sections} />)).rejects.toThrow(
+        /Cannot change the construct-only prop 'creditSections' of <GtkAboutDialog>/,
+    );
+};
+
+const expectSectionsOnce = (dialog: Gtk.AboutDialog): void => {
+    expect(getCreditCount(dialog, "Design")).toBe(1);
+    expect(getCreditCount(dialog, "Ada Lovelace")).toBe(1);
+    expect(getCreditCount(dialog, "Testing")).toBe(1);
+    expect(getCreditCount(dialog, "Grace Hopper")).toBe(1);
+    expect(getCreditCount(dialog, "Margaret Hamilton")).toBe(1);
+};
+
+describe("render - AboutDialog credit sections", () => {
+    it("lists every section and person on the credits page", async () => {
         const ref = createRef<Gtk.AboutDialog>();
+        await renderDialog(ref, SECTIONS);
+        const dialog = getDialog(ref);
+        await showCredits(dialog);
+        expectSectionsOnce(dialog);
+    });
 
-        const { rerender } = await render(<GtkAboutDialog ref={ref} programName="GTKX" creditSections={SECTIONS} />, {
-            container: rootElement,
-        });
+    it("throws when the sections change after they are applied", async () => {
+        await expectRejectedSections(TRANSLATIONS);
+    });
 
-        await expect(
-            rerender(
-                <GtkAboutDialog
-                    ref={ref}
-                    programName="GTKX"
-                    creditSections={[{ sectionName: "Translation", people: ["Alan Turing"] }]}
-                />,
-            ),
-        ).rejects.toThrow(/Cannot change the construct-only prop 'creditSections' of <GtkAboutDialog>/);
+    it("throws when the sections are taken away", async () => {
+        await expectRejectedSections();
+    });
+
+    it("accepts an equal array built again on the next render", async () => {
+        const ref = createRef<Gtk.AboutDialog>();
+        const rerender = await renderDialog(ref, SECTIONS);
+
+        await rerender(
+            <CreditedDialog
+                dialogRef={ref}
+                sections={[
+                    { sectionName: "Design", people: ["Ada Lovelace"] },
+                    { sectionName: "Testing", people: ["Grace Hopper", "Margaret Hamilton"] },
+                ]}
+            />,
+        );
+
+        const dialog = getDialog(ref);
+        await showCredits(dialog);
+        expectSectionsOnce(dialog);
     });
 
     it("applies sections provided after mount only once", async () => {
         const ref = createRef<Gtk.AboutDialog>();
-
-        const { rerender } = await render(<GtkAboutDialog ref={ref} programName="GTKX" />, {
-            container: rootElement,
-        });
-
-        await rerender(<GtkAboutDialog ref={ref} programName="GTKX" creditSections={SECTIONS} />);
-        expect(ref.current).toHaveObjectProperty("programName", "GTKX");
+        const rerender = await renderDialog(ref);
+        await rerender(<CreditedDialog dialogRef={ref} sections={SECTIONS} />);
+        const dialog = getDialog(ref);
+        await showCredits(dialog);
+        expectSectionsOnce(dialog);
     });
 });

--- a/packages/e2e/tests/elements/adw-behavior-registration.test.tsx
+++ b/packages/e2e/tests/elements/adw-behavior-registration.test.tsx
@@ -14,7 +14,7 @@ describe("adwaita behavior registration", () => {
         expect(behaviorsFor("AdwNavigationSplitView").length).toBeGreaterThan(0);
         expect(behaviorsFor("AdwPreferencesPage").length).toBeGreaterThan(0);
         expect(behaviorsFor("AdwTabView").length).toBeGreaterThan(0);
-        expect(behaviorsFor("AdwLeaflet").length).toBeGreaterThan(0);
+        expect(behaviorsFor("AdwWrapBox").length).toBeGreaterThan(0);
     });
 
     it("gives every registered behavior at least one property", () => {

--- a/packages/e2e/tests/elements/layout-manager.test.tsx
+++ b/packages/e2e/tests/elements/layout-manager.test.tsx
@@ -1,7 +1,7 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkBox, GtkBoxLayout, GtkFixedLayout, GtkGridLayout } from "@gtkx/jsx/gtk";
 import { render } from "@gtkx/testing";
-import { createRef, type Ref } from "react";
+import { createRef, type ReactElement, type Ref } from "react";
 import { describe, expect, it } from "vitest";
 
 type BoxRef = { boxRef: Ref<Gtk.Box | null> };
@@ -18,36 +18,30 @@ const SwitchableLayoutBox = ({ boxRef, shouldUseGrid }: BoxRef & { shouldUseGrid
     <GtkBox ref={boxRef} layoutManager={shouldUseGrid ? <GtkGridLayout /> : <GtkBoxLayout spacing={4} />} />
 );
 
+const renderLayoutManager = async (layoutManager: ReactElement): Promise<Gtk.LayoutManager | null> => {
+    const boxRef = createRef<Gtk.Box>();
+    await render(<GtkBox ref={boxRef} layoutManager={layoutManager} />);
+
+    return boxRef.current?.getLayoutManager() ?? null;
+};
+
 describe("render - layoutManager prop wiring", () => {
     it("attaches a GtkBoxLayout to the host widget", async () => {
-        const boxRef = createRef<Gtk.Box>();
-
-        await render(
-            <GtkBox
-                ref={boxRef}
-                layoutManager={<GtkBoxLayout orientation={Gtk.Orientation.VERTICAL} spacing={12} />}
-            />,
-        );
-
-        const layout = boxRef.current?.getLayoutManager();
+        const layout = await renderLayoutManager(<GtkBoxLayout orientation={Gtk.Orientation.VERTICAL} spacing={12} />);
         expect(layout).toBeInstanceOf(Gtk.BoxLayout);
         expect(layout).toHaveObjectProperty("orientation", Gtk.Orientation.VERTICAL);
         expect(layout).toHaveObjectProperty("spacing", 12);
     });
 
     it("attaches a GtkGridLayout to the host widget", async () => {
-        const boxRef = createRef<Gtk.Box>();
-        await render(<GtkBox ref={boxRef} layoutManager={<GtkGridLayout columnSpacing={6} rowSpacing={4} />} />);
-        const layout = boxRef.current?.getLayoutManager();
+        const layout = await renderLayoutManager(<GtkGridLayout columnSpacing={6} rowSpacing={4} />);
         expect(layout).toBeInstanceOf(Gtk.GridLayout);
         expect(layout).toHaveObjectProperty("columnSpacing", 6);
         expect(layout).toHaveObjectProperty("rowSpacing", 4);
     });
 
     it("attaches a GtkFixedLayout to the host widget", async () => {
-        const boxRef = createRef<Gtk.Box>();
-        await render(<GtkBox ref={boxRef} layoutManager={<GtkFixedLayout />} />);
-        expect(boxRef.current?.getLayoutManager()).toBeInstanceOf(Gtk.FixedLayout);
+        expect(await renderLayoutManager(<GtkFixedLayout />)).toBeInstanceOf(Gtk.FixedLayout);
     });
 });
 

--- a/packages/e2e/tests/elements/multi-layout-view.test.tsx
+++ b/packages/e2e/tests/elements/multi-layout-view.test.tsx
@@ -1,0 +1,96 @@
+import type * as Adw from "@gtkx/gi/adw";
+import * as Gtk from "@gtkx/gi/gtk";
+import { AdwLayout, AdwLayoutSlot, AdwMultiLayoutView } from "@gtkx/jsx/adw";
+import { GtkBox, GtkLabel } from "@gtkx/jsx/gtk";
+import { render, screen } from "@gtkx/testing";
+import { createRef, type ReactElement, type RefObject } from "react";
+import { describe, expect, it } from "vitest";
+
+type RenderedView = { view: Adw.MultiLayoutView; rerender: (layoutName: string) => Promise<void> };
+
+const LAYOUTS = (
+    <>
+        <AdwLayout name="wide">
+            <GtkBox orientation={Gtk.Orientation.HORIZONTAL}>
+                <AdwLayoutSlot id="sidebar" />
+                <AdwLayoutSlot id="content" />
+            </GtkBox>
+        </AdwLayout>
+        <AdwLayout name="narrow">
+            <GtkBox orientation={Gtk.Orientation.VERTICAL}>
+                <AdwLayoutSlot id="sidebar" />
+                <AdwLayoutSlot id="content" />
+            </GtkBox>
+        </AdwLayout>
+    </>
+);
+
+const buildView = (ref: RefObject<Adw.MultiLayoutView | null>, layoutName: string): ReactElement => (
+    <AdwMultiLayoutView
+        ref={ref}
+        layoutName={layoutName}
+        layouts={LAYOUTS}
+        sidebarSlot={<GtkLabel>Side</GtkLabel>}
+        contentSlot={<GtkLabel>Main</GtkLabel>}
+    />
+);
+
+const renderView = async (layoutName: string): Promise<RenderedView> => {
+    const ref = createRef<Adw.MultiLayoutView>();
+    const { rerender } = await render(buildView(ref, layoutName));
+    const { current } = ref;
+
+    if (!current) {
+        throw new TypeError("Expected a MultiLayoutView instance");
+    }
+
+    return { view: current, rerender: (next) => rerender(buildView(ref, next)) };
+};
+
+describe("render - AdwMultiLayoutView", () => {
+    it("adds every layout declared in the layouts slot", async () => {
+        const { view } = await renderView("wide");
+        expect(view.getLayoutByName("wide")).not.toBeNull();
+        expect(view.getLayoutByName("narrow")).not.toBeNull();
+    });
+
+    it("fills each AdwLayout with the content declared as its children", async () => {
+        const { view } = await renderView("wide");
+        expect(view.getLayoutByName("wide")?.getContent()).toBeInstanceOf(Gtk.Box);
+        expect(view.getLayoutByName("narrow")?.getContent()).toBeInstanceOf(Gtk.Box);
+    });
+
+    it("places named slot children through the view", async () => {
+        const { view } = await renderView("wide");
+        expect(view.getChild("sidebar")).toHaveObjectProperty("label", "Side");
+        expect(view.getChild("content")).toHaveObjectProperty("label", "Main");
+        expect(await screen.findByText("Side")).toBeDefined();
+        expect(await screen.findByText("Main")).toBeDefined();
+    });
+
+    it("applies layoutName once the named layout has attached", async () => {
+        const { view } = await renderView("narrow");
+        expect(view.getLayoutName()).toBe("narrow");
+        expect(view.getLayout()).toBe(view.getLayoutByName("narrow"));
+    });
+
+    it("switches layout when layoutName changes", async () => {
+        const { view, rerender } = await renderView("wide");
+        expect(view.getLayoutName()).toBe("wide");
+        await rerender("narrow");
+        expect(view.getLayoutName()).toBe("narrow");
+    });
+
+    it("takes a slot child back out of the view when its prop is dropped", async () => {
+        const ref = createRef<Adw.MultiLayoutView>();
+        const sidebar = <GtkLabel>Side</GtkLabel>;
+
+        const { rerender } = await render(
+            <AdwMultiLayoutView ref={ref} layoutName="wide" layouts={LAYOUTS} sidebarSlot={sidebar} />,
+        );
+
+        expect(await screen.findByText("Side")).toBeDefined();
+        await rerender(<AdwMultiLayoutView ref={ref} layoutName="wide" layouts={LAYOUTS} />);
+        expect(screen.queryByText("Side")).toBeNull();
+    });
+});

--- a/packages/e2e/tests/elements/scrolled-window.test.tsx
+++ b/packages/e2e/tests/elements/scrolled-window.test.tsx
@@ -1,11 +1,25 @@
 import * as Gtk from "@gtkx/gi/gtk";
-import { GtkBox, GtkLabel, GtkScrolledWindow } from "@gtkx/jsx/gtk";
+import { GtkBox, GtkLabel, GtkScrolledWindow, type GtkScrolledWindowProps } from "@gtkx/jsx/gtk";
 import { render, screen } from "@gtkx/testing";
 import { createRef } from "react";
 import { describe, expect, it } from "vitest";
 
-const getPolicy = (scrolledWindow: Gtk.ScrolledWindow): [Gtk.PolicyType, Gtk.PolicyType] => {
-    return scrolledWindow.getPolicy();
+const renderContentWindow = async (props: GtkScrolledWindowProps): Promise<Gtk.ScrolledWindow> => {
+    const ref = createRef<Gtk.ScrolledWindow>();
+
+    await render(
+        <GtkScrolledWindow ref={ref} {...props}>
+            <GtkLabel>Content</GtkLabel>
+        </GtkScrolledWindow>,
+    );
+
+    const scrolledWindow = ref.current;
+
+    if (scrolledWindow === null) {
+        throw new Error("expected the scrolled window ref to be assigned");
+    }
+
+    return scrolledWindow;
 };
 
 function App({ text }: { text: string }) {
@@ -18,74 +32,38 @@ function App({ text }: { text: string }) {
 
 describe("render - ScrolledWindow (1)", () => {
     it("creates ScrolledWindow widget", async () => {
-        const ref = createRef<Gtk.ScrolledWindow>();
-
-        await render(
-            <GtkScrolledWindow ref={ref}>
-                <GtkLabel>Content</GtkLabel>
-            </GtkScrolledWindow>,
-        );
-
-        expect(ref.current).not.toBeNull();
-        expect(ref.current).toBeInstanceOf(Gtk.ScrolledWindow);
+        const scrolledWindow = await renderContentWindow({});
+        expect(scrolledWindow).toBeInstanceOf(Gtk.ScrolledWindow);
     });
 
     it("sets AUTOMATIC scroll policy by default", async () => {
-        const ref = createRef<Gtk.ScrolledWindow>();
-
-        await render(
-            <GtkScrolledWindow ref={ref}>
-                <GtkLabel>Content</GtkLabel>
-            </GtkScrolledWindow>,
-        );
-
-        const [hPolicy, vPolicy] = getPolicy(ref.current as Gtk.ScrolledWindow);
+        const scrolledWindow = await renderContentWindow({});
+        const [hPolicy, vPolicy] = scrolledWindow.getPolicy();
         expect(hPolicy).toBe(Gtk.PolicyType.AUTOMATIC);
         expect(vPolicy).toBe(Gtk.PolicyType.AUTOMATIC);
     });
 
     it("sets horizontal scroll policy", async () => {
-        const ref = createRef<Gtk.ScrolledWindow>();
-
-        await render(
-            <GtkScrolledWindow ref={ref} hscrollbarPolicy={Gtk.PolicyType.NEVER}>
-                <GtkLabel>Content</GtkLabel>
-            </GtkScrolledWindow>,
-        );
-
-        const [hPolicy] = getPolicy(ref.current as Gtk.ScrolledWindow);
+        const scrolledWindow = await renderContentWindow({ hscrollbarPolicy: Gtk.PolicyType.NEVER });
+        const [hPolicy] = scrolledWindow.getPolicy();
         expect(hPolicy).toBe(Gtk.PolicyType.NEVER);
     });
 });
 
 describe("render - ScrolledWindow (2)", () => {
     it("sets vertical scroll policy", async () => {
-        const ref = createRef<Gtk.ScrolledWindow>();
-
-        await render(
-            <GtkScrolledWindow ref={ref} vscrollbarPolicy={Gtk.PolicyType.ALWAYS}>
-                <GtkLabel>Content</GtkLabel>
-            </GtkScrolledWindow>,
-        );
-
-        const [, vPolicy] = getPolicy(ref.current as Gtk.ScrolledWindow);
+        const scrolledWindow = await renderContentWindow({ vscrollbarPolicy: Gtk.PolicyType.ALWAYS });
+        const [, vPolicy] = scrolledWindow.getPolicy();
         expect(vPolicy).toBe(Gtk.PolicyType.ALWAYS);
     });
 
     it("sets both scroll policies", async () => {
-        const ref = createRef<Gtk.ScrolledWindow>();
+        const scrolledWindow = await renderContentWindow({
+            hscrollbarPolicy: Gtk.PolicyType.NEVER,
+            vscrollbarPolicy: Gtk.PolicyType.ALWAYS,
+        });
 
-        await render(
-            <GtkScrolledWindow
-                ref={ref}
-                hscrollbarPolicy={Gtk.PolicyType.NEVER}
-                vscrollbarPolicy={Gtk.PolicyType.ALWAYS}
-            >
-                <GtkLabel>Content</GtkLabel>
-            </GtkScrolledWindow>,
-        );
-
-        const [hPolicy, vPolicy] = getPolicy(ref.current as Gtk.ScrolledWindow);
+        const [hPolicy, vPolicy] = scrolledWindow.getPolicy();
         expect(hPolicy).toBe(Gtk.PolicyType.NEVER);
         expect(vPolicy).toBe(Gtk.PolicyType.ALWAYS);
     });
@@ -104,11 +82,11 @@ describe("render - ScrolledWindow (3)", () => {
         }
 
         await render(<App hPolicyProp={Gtk.PolicyType.AUTOMATIC} vPolicyProp={Gtk.PolicyType.AUTOMATIC} />);
-        let [hPolicy, vPolicy] = getPolicy(ref.current as Gtk.ScrolledWindow);
+        let [hPolicy, vPolicy] = ref.current?.getPolicy() ?? [];
         expect(hPolicy).toBe(Gtk.PolicyType.AUTOMATIC);
         expect(vPolicy).toBe(Gtk.PolicyType.AUTOMATIC);
         await render(<App hPolicyProp={Gtk.PolicyType.NEVER} vPolicyProp={Gtk.PolicyType.ALWAYS} />);
-        [hPolicy, vPolicy] = getPolicy(ref.current as Gtk.ScrolledWindow);
+        [hPolicy, vPolicy] = ref.current?.getPolicy() ?? [];
         expect(hPolicy).toBe(Gtk.PolicyType.NEVER);
         expect(vPolicy).toBe(Gtk.PolicyType.ALWAYS);
     });

--- a/packages/e2e/tests/elements/source-view.test.tsx
+++ b/packages/e2e/tests/elements/source-view.test.tsx
@@ -2,7 +2,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import * as GtkSource from "@gtkx/gi/gtksource";
 import { GtkSourceBuffer, type GtkSourceBufferProps, GtkSourceView } from "@gtkx/jsx/gtksource";
 import { render, screen, userEvent, waitFor } from "@gtkx/testing";
-import { createRef, type ReactNode, type RefObject } from "react";
+import { createRef, type ReactElement, type ReactNode, type RefObject } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { getSourceBuffer } from "../helpers/buffer-text.js";
 import { expectNoBufferChangedOnReconcile } from "../helpers/text-buffer-view-render.js";
@@ -14,6 +14,13 @@ const buildLanguageSourceView = (
     ref: RefObject<GtkSource.View | null>,
     language: GtkSource.Language | null,
 ): ReactNode => <GtkSourceView ref={ref} buffer={<GtkSourceBuffer language={language}>code</GtkSourceBuffer>} />;
+
+const renderSourceBuffer = async (buffer: ReactElement): Promise<GtkSource.Buffer> => {
+    const ref = createRef<GtkSource.View>();
+    await render(<GtkSourceView ref={ref} buffer={buffer} />);
+
+    return getSourceBuffer(ref);
+};
 
 const renderJsLanguageSourceView = async (ref: RefObject<GtkSource.View | null>) => {
     const { rerender } = await render(buildLanguageSourceView(ref, getLanguage("js")));
@@ -44,9 +51,7 @@ describe("render - SourceView (1)", () => {
         });
 
         it("sets initial text content via buffer children", async () => {
-            const ref = createRef<GtkSource.View>();
-            await render(<GtkSourceView ref={ref} buffer={<GtkSourceBuffer>Hello World</GtkSourceBuffer>} />);
-            const buffer = getSourceBuffer(ref);
+            const buffer = await renderSourceBuffer(<GtkSourceBuffer>Hello World</GtkSourceBuffer>);
             expect(buffer).not.toBeNull();
             expect(screen.getByDisplayValue("Hello World")).toBeDefined();
         });
@@ -80,13 +85,7 @@ describe("render - SourceView (2)", () => {
             ["sets enableUndo property", true],
             ["disables undo when enableUndo is false", false],
         ])("%s", async (_title, enableUndo) => {
-            const ref = createRef<GtkSource.View>();
-
-            await render(
-                <GtkSourceView ref={ref} buffer={<GtkSourceBuffer enableUndo={enableUndo}>Content</GtkSourceBuffer>} />,
-            );
-
-            const buffer = getSourceBuffer(ref);
+            const buffer = await renderSourceBuffer(<GtkSourceBuffer enableUndo={enableUndo}>Content</GtkSourceBuffer>);
             expect(buffer).toHaveObjectProperty("enableUndo", enableUndo);
         });
 
@@ -120,33 +119,19 @@ describe("render - SourceView (3)", () => {
 describe("render - SourceView (4)", () => {
     describe("syntax highlighting (1)", () => {
         it("sets language on the buffer", async () => {
-            const ref = createRef<GtkSource.View>();
-
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={<GtkSourceBuffer language={getLanguage("js")}>const x = 1;</GtkSourceBuffer>}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer language={getLanguage("js")}>const x = 1;</GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
-            const language = buffer.getLanguage();
-            expect(language?.getId()).toBe("js");
+            expect(buffer.getLanguage()?.getId()).toBe("js");
         });
 
         it("sets styleScheme on the buffer", async () => {
-            const ref = createRef<GtkSource.View>();
-
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={<GtkSourceBuffer styleScheme={getScheme("classic")}>text</GtkSourceBuffer>}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer styleScheme={getScheme("classic")}>text</GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
-            const scheme = buffer.getStyleScheme();
-            expect(scheme?.getId()).toBe("classic");
+            expect(buffer.getStyleScheme()?.getId()).toBe("classic");
         });
     });
 });
@@ -154,27 +139,17 @@ describe("render - SourceView (4)", () => {
 describe("render - SourceView (5)", () => {
     describe("syntax highlighting (2)", () => {
         it("sets highlightSyntax property", async () => {
-            const ref = createRef<GtkSource.View>();
-            await render(<GtkSourceView ref={ref} buffer={<GtkSourceBuffer highlightSyntax>text</GtkSourceBuffer>} />);
-            const buffer = getSourceBuffer(ref);
+            const buffer = await renderSourceBuffer(<GtkSourceBuffer highlightSyntax>text</GtkSourceBuffer>);
             expect(buffer).toHaveObjectProperty("highlightSyntax", true);
         });
 
         it("highlightSyntax can be explicitly disabled with language", async () => {
-            const ref = createRef<GtkSource.View>();
-
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={(
-                        <GtkSourceBuffer language={getLanguage("js")} highlightSyntax={false}>
-                            const x = 1;
-                        </GtkSourceBuffer>
-                    )}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer language={getLanguage("js")} highlightSyntax={false}>
+                    const x = 1;
+                </GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
             expect(buffer).toHaveObjectProperty("highlightSyntax", false);
         });
     });
@@ -183,51 +158,31 @@ describe("render - SourceView (5)", () => {
 describe("render - SourceView (7)", () => {
     describe("additional buffer props", () => {
         it("sets highlightMatchingBrackets property", async () => {
-            const ref = createRef<GtkSource.View>();
-
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={<GtkSourceBuffer highlightMatchingBrackets={false}>()</GtkSourceBuffer>}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer highlightMatchingBrackets={false}>()</GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
             expect(buffer).toHaveObjectProperty("highlightMatchingBrackets", false);
         });
 
         it("highlightMatchingBrackets defaults to true", async () => {
-            const ref = createRef<GtkSource.View>();
-            await render(<GtkSourceView ref={ref} buffer={<GtkSourceBuffer>()</GtkSourceBuffer>} />);
-            const buffer = getSourceBuffer(ref);
+            const buffer = await renderSourceBuffer(<GtkSourceBuffer>()</GtkSourceBuffer>);
             expect(buffer).toHaveObjectProperty("highlightMatchingBrackets", true);
         });
 
         it("sets implicitTrailingNewline property to false", async () => {
-            const ref = createRef<GtkSource.View>();
-
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={<GtkSourceBuffer implicitTrailingNewline={false}>no newline</GtkSourceBuffer>}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer implicitTrailingNewline={false}>no newline</GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
             expect(buffer).toHaveObjectProperty("implicitTrailingNewline", false);
         });
 
         it("sets implicitTrailingNewline property to true", async () => {
-            const ref = createRef<GtkSource.View>();
-
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={<GtkSourceBuffer implicitTrailingNewline>with newline</GtkSourceBuffer>}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer implicitTrailingNewline>with newline</GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
             expect(buffer).toHaveObjectProperty("implicitTrailingNewline", true);
         });
     });
@@ -236,10 +191,8 @@ describe("render - SourceView (7)", () => {
 describe("render - SourceView (8)", () => {
     describe("callbacks (1)", () => {
         it("calls onChanged when text changes programmatically", async () => {
-            const ref = createRef<GtkSource.View>();
             const onChanged = vi.fn();
-            await render(<GtkSourceView ref={ref} buffer={<GtkSourceBuffer onChanged={onChanged} />} />);
-            const buffer = getSourceBuffer(ref);
+            const buffer = await renderSourceBuffer(<GtkSourceBuffer onChanged={onChanged} />);
             buffer.setText("New text", -1);
 
             await waitFor(() => {
@@ -258,17 +211,12 @@ describe("render - SourceView (8)", () => {
 describe("render - SourceView (9)", () => {
     describe("callbacks (2)", () => {
         it("calls onCursorMoved when cursor position changes", async () => {
-            const ref = createRef<GtkSource.View>();
             const onCursorMoved = vi.fn();
 
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={<GtkSourceBuffer onCursorMoved={onCursorMoved}>Some text here</GtkSourceBuffer>}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer onCursorMoved={onCursorMoved}>Some text here</GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
             const iter = buffer.getIterAtOffset(5);
             buffer.placeCursor(iter);
 
@@ -278,21 +226,14 @@ describe("render - SourceView (9)", () => {
         });
 
         it("calls onHighlightUpdated when highlighting updates", async () => {
-            const ref = createRef<GtkSource.View>();
             const onHighlightUpdated = vi.fn();
 
-            await render(
-                <GtkSourceView
-                    ref={ref}
-                    buffer={(
-                        <GtkSourceBuffer language={getLanguage("js")} onHighlightUpdated={onHighlightUpdated}>
-                            const x = 1;
-                        </GtkSourceBuffer>
-                    )}
-                />,
+            const buffer = await renderSourceBuffer(
+                <GtkSourceBuffer language={getLanguage("js")} onHighlightUpdated={onHighlightUpdated}>
+                    const x = 1;
+                </GtkSourceBuffer>,
             );
 
-            const buffer = getSourceBuffer(ref);
             buffer.setText("function foo() { return 42; }", -1);
 
             await waitFor(() => {

--- a/packages/e2e/tests/elements/top-level-parenting.test.tsx
+++ b/packages/e2e/tests/elements/top-level-parenting.test.tsx
@@ -3,7 +3,7 @@ import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { AdwAlertDialog } from "@gtkx/jsx/adw";
 import { GtkApplication, GtkApplicationWindow, GtkWindow } from "@gtkx/jsx/gtk";
-import { createPortal, rootElement } from "@gtkx/react";
+import { rootElement } from "@gtkx/react";
 import { render } from "@gtkx/testing";
 import { createRef, type ReactNode, type RefObject, useState } from "react";
 import { describe, expect, it } from "vitest";
@@ -35,7 +35,7 @@ const ParentedTree = ({
     );
 };
 
-const PortaledChild = ({
+const NestedChild = ({
     parentRef,
     childRef,
     isParented,
@@ -45,45 +45,69 @@ const PortaledChild = ({
     isParented: boolean;
 }) => (
     <ParentedTree parentRef={parentRef}>
-        {(parent) =>
-            createPortal(
-                <GtkWindow
-                    ref={childRef}
-                    transientFor={isParented ? parent : null}
-                    defaultWidth={50}
-                    defaultHeight={50}
-                />,
-                rootElement,
-            )}
+        {(parent) => (
+            <GtkWindow
+                ref={childRef}
+                transientFor={isParented ? parent : null}
+                defaultWidth={50}
+                defaultHeight={50}
+            />
+        )}
     </ParentedTree>
 );
 
+const renderNestedChild = async (isParented: boolean) => {
+    const parentRef = createRef<Gtk.Window>();
+    const childRef = createRef<Gtk.Window>();
+
+    const { rerender } = await render(
+        <NestedChild parentRef={parentRef} childRef={childRef} isParented={isParented} />,
+        { container: rootElement },
+    );
+
+    const rerenderNestedChild = (isStillParented: boolean) =>
+        rerender(<NestedChild parentRef={parentRef} childRef={childRef} isParented={isStillParented} />);
+
+    return { parentRef, childRef, rerenderNestedChild };
+};
+
 describe("explicit top-level parenting", () => {
     it("sets transientFor on a window from the prop", async () => {
-        const parentRef = createRef<Gtk.Window>();
-        const childRef = createRef<Gtk.Window>();
-
-        await render(<PortaledChild parentRef={parentRef} childRef={childRef} isParented={true} />, {
-            container: rootElement,
-        });
-
+        const { parentRef, childRef } = await renderNestedChild(true);
         expect(parentRef.current).not.toBeNull();
         expect(childRef.current).toHaveObjectProperty("transientFor", parentRef.current);
         expect(childRef.current?.getParent()).toBeNull();
     });
 
+    it("keeps transientFor clear when the prop is an explicit null", async () => {
+        const { parentRef, childRef } = await renderNestedChild(false);
+        expect(parentRef.current).not.toBeNull();
+        expect(childRef.current?.getTransientFor()).toBeNull();
+    });
+
     it("clears transientFor when the prop becomes null", async () => {
+        const { parentRef, childRef, rerenderNestedChild } = await renderNestedChild(true);
+        expect(childRef.current).toHaveObjectProperty("transientFor", parentRef.current);
+        await rerenderNestedChild(false);
+        expect(childRef.current?.getTransientFor()).toBeNull();
+    });
+});
+
+describe("default top-level parenting", () => {
+    it("defaults transientFor to the nearest parent window when the prop is not passed", async () => {
         const parentRef = createRef<Gtk.Window>();
         const childRef = createRef<Gtk.Window>();
 
-        const { rerender } = await render(
-            <PortaledChild parentRef={parentRef} childRef={childRef} isParented={true} />,
+        await render(
+            <ParentedTree parentRef={parentRef}>
+                {() => <GtkWindow ref={childRef} defaultWidth={50} defaultHeight={50} />}
+            </ParentedTree>,
             { container: rootElement },
         );
 
+        expect(parentRef.current).not.toBeNull();
         expect(childRef.current).toHaveObjectProperty("transientFor", parentRef.current);
-        await rerender(<PortaledChild parentRef={parentRef} childRef={childRef} isParented={false} />);
-        expect(childRef.current?.getTransientFor()).toBeNull();
+        expect(childRef.current?.getParent()).toBeNull();
     });
 
     it("presents an Adw.Dialog against its enclosing window", async () => {

--- a/packages/e2e/tests/elements/widget.test.tsx
+++ b/packages/e2e/tests/elements/widget.test.tsx
@@ -1,11 +1,9 @@
 import type { ComponentProps, ReactNode } from "react";
 import * as Gdk from "@gtkx/gi/gdk";
-import * as Gio from "@gtkx/gi/gio";
 import * as GObject from "@gtkx/gi/gobject";
 import * as Gtk from "@gtkx/gi/gtk";
 import {
     GtkAboutDialog,
-    GtkApplication,
     GtkApplicationWindow,
     GtkBox,
     GtkButton,
@@ -20,13 +18,12 @@ import {
     GtkListBox,
     GtkSwitch,
 } from "@gtkx/jsx/gtk";
-import { createPortal, rootElement } from "@gtkx/react";
 import { render as baseRender, screen, userEvent, waitFor, within } from "@gtkx/testing";
 import { createRef, useState } from "react";
 import { describe, expect, it, type Mock, vi } from "vitest";
-import { createAppIdFactory } from "../helpers/unique-name.js";
+import { createApplicationRenderer } from "../helpers/application-render.js";
 
-const uniqueAppId = createAppIdFactory("org.gtkx.widgettest");
+const renderInApp = createApplicationRenderer("org.gtkx.widgettest");
 
 const render = (element: ReactNode) => baseRender(element);
 
@@ -63,6 +60,13 @@ const renderSwitchAndClick = async (props: ComponentProps<typeof GtkSwitch>): Pr
     await userEvent.click(switchWidget);
 
     return switchWidget;
+};
+
+const renderStateSetSwitchAndClick = async (): Promise<Mock> => {
+    const handleStateSet = vi.fn(() => Gdk.EVENT_PROPAGATE);
+    await renderSwitchAndClick({ onStateSet: handleStateSet });
+
+    return handleStateSet;
 };
 
 const labelItems = (items: string[]): ReactNode => items.map((item) => <GtkLabel key={item}>{item}</GtkLabel>);
@@ -117,13 +121,21 @@ function OptionalClickButton({ onClicked, isMounted }: { onClicked: () => void; 
     return isMounted ? <GtkButton onClicked={onClicked} label="Click" /> : null;
 }
 
-const renderInApp = (window: ReactNode) =>
-    baseRender(
-        <GtkApplication applicationId={uniqueAppId()} flags={Gio.ApplicationFlags.NON_UNIQUE}>
-            {window}
-        </GtkApplication>,
-        { container: rootElement },
-    );
+const renderDialogInWindow = (dialog: ReactNode) =>
+    renderInApp(<GtkApplicationWindow>{dialog}</GtkApplicationWindow>);
+
+const renderAboutDialog = async (props: ComponentProps<typeof GtkAboutDialog>) => {
+    const ref = createRef<Gtk.AboutDialog>();
+    const result = await renderDialogInWindow(<GtkAboutDialog ref={ref} {...props} />);
+
+    return { ref, ...result };
+};
+
+const renderKeyControllerAndType = async (controllers: ReactNode): Promise<void> => {
+    await render(<GtkButton label="Focus me" canFocus focusable controllers={controllers} />);
+    const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON);
+    await userEvent.keyboard(button, "a");
+};
 
 describe("widget - creation (1)", () => {
     describe("basic widgets", () => {
@@ -403,8 +415,7 @@ describe("widget - signals (1)", () => {
         });
 
         it("connects onStateSet handler to state-set signal", async () => {
-            const handleStateSet = vi.fn(() => Gdk.EVENT_PROPAGATE);
-            await renderSwitchAndClick({ onStateSet: handleStateSet });
+            const handleStateSet = await renderStateSetSwitchAndClick();
 
             await waitFor(() => {
                 expect(handleStateSet).toHaveBeenCalledTimes(1);
@@ -472,8 +483,7 @@ describe("widget - signals (3)", () => {
 describe("widget - signals (4)", () => {
     describe("signal arguments", () => {
         it("receives signal arguments in callback", async () => {
-            const handleStateSet = vi.fn(() => Gdk.EVENT_PROPAGATE);
-            await renderSwitchAndClick({ onStateSet: handleStateSet });
+            const handleStateSet = await renderStateSetSwitchAndClick();
 
             await waitFor(() => {
                 expect(handleStateSet).toHaveBeenCalledWith(true, expect.any(Gtk.Switch));
@@ -621,35 +631,13 @@ describe("widget - signals (9)", () => {
         describe("key controller (1)", () => {
             it("connects onKeyPressed handler", async () => {
                 const handleKeyPressed = vi.fn(() => Gdk.EVENT_PROPAGATE);
-
-                await render(
-                    <GtkButton
-                        label="Focus me"
-                        canFocus
-                        focusable
-                        controllers={<GtkEventControllerKey onKeyPressed={handleKeyPressed} />}
-                    />,
-                );
-
-                const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON);
-                await userEvent.keyboard(button, "a");
+                await renderKeyControllerAndType(<GtkEventControllerKey onKeyPressed={handleKeyPressed} />);
                 expect(handleKeyPressed).toHaveBeenCalled();
             });
 
             it("connects onKeyReleased handler", async () => {
                 const handleKeyReleased = vi.fn();
-
-                await render(
-                    <GtkButton
-                        label="Focus me"
-                        canFocus
-                        focusable
-                        controllers={<GtkEventControllerKey onKeyReleased={handleKeyReleased} />}
-                    />,
-                );
-
-                const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON);
-                await userEvent.keyboard(button, "a");
+                await renderKeyControllerAndType(<GtkEventControllerKey onKeyReleased={handleKeyReleased} />);
                 expect(handleKeyReleased).toHaveBeenCalled();
             });
         });
@@ -852,49 +840,18 @@ describe("widget - auto-wrapping (4)", () => {
 
 describe("widget - AboutDialog (1)", () => {
     describe("creditSections", () => {
-        it("applies credit sections on mount", async () => {
-            const ref = createRef<Gtk.AboutDialog>();
-
-            await renderInApp(
-                <GtkApplicationWindow>
-                    {createPortal(
-                        <GtkAboutDialog
-                            ref={ref}
-                            programName="Test App"
-                            creditSections={[
-                                { sectionName: "Contributors", people: ["Alice", "Bob"] },
-                                { sectionName: "Testers", people: ["Charlie"] },
-                            ]}
-                        />,
-                        rootElement,
-                    )}
-                </GtkApplicationWindow>,
-            );
-
-            expect(ref.current).not.toBeNull();
-        });
-
-        it("applies empty credit sections array", async () => {
-            const ref = createRef<Gtk.AboutDialog>();
-
-            await renderInApp(
-                <GtkApplicationWindow>
-                    {createPortal(<GtkAboutDialog ref={ref} programName="Test App" creditSections={[]} />, rootElement)}
-                </GtkApplicationWindow>,
-            );
-
-            expect(ref.current).not.toBeNull();
-        });
-
-        it("renders without creditSections prop", async () => {
-            const ref = createRef<Gtk.AboutDialog>();
-
-            await renderInApp(
-                <GtkApplicationWindow>
-                    {createPortal(<GtkAboutDialog ref={ref} programName="Test App" />, rootElement)}
-                </GtkApplicationWindow>,
-            );
-
+        it.each([
+            [
+                "applies credit sections on mount",
+                [
+                    { sectionName: "Contributors", people: ["Alice", "Bob"] },
+                    { sectionName: "Testers", people: ["Charlie"] },
+                ],
+            ],
+            ["applies empty credit sections array", []],
+            ["renders without creditSections prop", undefined],
+        ])("%s", async (_title, creditSections) => {
+            const { ref } = await renderAboutDialog({ programName: "Test App", creditSections });
             expect(ref.current).not.toBeNull();
         });
     });
@@ -903,35 +860,15 @@ describe("widget - AboutDialog (1)", () => {
 describe("widget - AboutDialog (2)", () => {
     describe("lifecycle", () => {
         it("presents dialog on mount", async () => {
-            await renderInApp(
-                <GtkApplicationWindow>
-                    {createPortal(<GtkAboutDialog programName="Lifecycle Test" />, rootElement)}
-                </GtkApplicationWindow>,
-            );
-
+            await renderDialogInWindow(<GtkAboutDialog programName="Lifecycle Test" />);
             expect(await screen.findByText(/Lifecycle Test/)).toBeDefined();
         });
 
         it("destroys dialog on unmount", async () => {
-            const ref = createRef<Gtk.AboutDialog>();
-            const appId = uniqueAppId();
-
-            function App({ shouldShow }: { shouldShow: boolean }) {
-                return (
-                    <GtkApplication applicationId={appId} flags={Gio.ApplicationFlags.NON_UNIQUE}>
-                        <GtkApplicationWindow>
-                            {shouldShow
-                                ? createPortal(<GtkAboutDialog ref={ref} programName="Unmount Test" />, rootElement)
-                                : null}
-                        </GtkApplicationWindow>
-                    </GtkApplication>
-                );
-            }
-
-            const { rerender } = await baseRender(<App shouldShow={true} />, { container: rootElement });
-            const handle = ref.current;
-            expect(handle).toBeDefined();
-            await rerender(<App shouldShow={false} />);
+            const { rerender } = await renderAboutDialog({ programName: "Unmount Test" });
+            expect(await screen.findByText(/Unmount Test/)).toBeDefined();
+            await rerender(<GtkApplicationWindow />);
+            expect(screen.queryByText(/Unmount Test/)).toBeNull();
         });
     });
 });

--- a/packages/e2e/tests/elements/window.test.tsx
+++ b/packages/e2e/tests/elements/window.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode, RefObject } from "react";
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
 import { AdwApplication, AdwApplicationWindow } from "@gtkx/jsx/adw";
-import { GtkApplication, GtkApplicationWindow, GtkLabel } from "@gtkx/jsx/gtk";
+import { GtkApplication, GtkApplicationWindow, GtkBox, GtkLabel } from "@gtkx/jsx/gtk";
 import { rootElement } from "@gtkx/react";
 import { render as baseRender, screen } from "@gtkx/testing";
 import { createRef } from "react";
@@ -71,6 +71,28 @@ describe("render - Window (1)", () => {
             await renderAdw(<AdwApplicationWindow ref={ref} />);
             expect(ref.current).not.toBeNull();
             expect(ref.current?.getApplication()).not.toBeNull();
+        });
+
+        it("creates Gtk.ApplicationWindow through intermediate elements", async () => {
+            const ref = createRef<Gtk.ApplicationWindow>();
+
+            await render(
+                <GtkApplicationWindow title="Outer">
+                    <GtkBox>
+                        <GtkApplicationWindow ref={ref} title="Nested App Window" />
+                    </GtkBox>
+                </GtkApplicationWindow>,
+            );
+
+            expect(ref.current).not.toBeNull();
+            expect(ref.current?.getApplication()).not.toBeNull();
+            expect(ref.current?.getParent()).toBeNull();
+        });
+
+        it("throws without a GtkApplication ancestor", async () => {
+            await expect(
+                baseRender(<GtkApplicationWindow title="Orphan" />, { container: rootElement }),
+            ).rejects.toThrow(/useApplication must be called within GtkApplication/);
         });
     });
 });

--- a/packages/e2e/tests/helpers/application-render.tsx
+++ b/packages/e2e/tests/helpers/application-render.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import * as Gio from "@gtkx/gi/gio";
+import { GtkApplication } from "@gtkx/jsx/gtk";
+import { rootElement } from "@gtkx/react";
+import { render } from "@gtkx/testing";
+import { createAppIdFactory } from "./unique-name.js";
+
+type ApplicationRenderResult = {
+    rerender: (element: ReactNode) => Promise<void>;
+};
+
+type ApplicationRenderer = (element: ReactNode) => Promise<ApplicationRenderResult>;
+
+const createApplicationRenderer = (prefix: string): ApplicationRenderer => {
+    const uniqueAppId = createAppIdFactory(prefix);
+
+    return async (element) => {
+        const appId = uniqueAppId();
+
+        const inApplication = (child: ReactNode): ReactNode => (
+            <GtkApplication applicationId={appId} flags={Gio.ApplicationFlags.NON_UNIQUE}>
+                {child}
+            </GtkApplication>
+        );
+
+        const { rerender } = await render(inApplication(element), { container: rootElement });
+
+        return {
+            rerender: async (next: ReactNode) => {
+                await rerender(inApplication(next));
+            },
+        };
+    };
+};
+
+export { createApplicationRenderer };

--- a/packages/e2e/tests/use-parent-window.test.tsx
+++ b/packages/e2e/tests/use-parent-window.test.tsx
@@ -1,17 +1,16 @@
 import type * as Gtk from "@gtkx/gi/gtk";
-import * as Gio from "@gtkx/gi/gio";
 import { GSimpleAction } from "@gtkx/jsx/gio";
-import { GtkApplication, GtkApplicationWindow, type GtkApplicationWindowProps, GtkBox } from "@gtkx/jsx/gtk";
-import { rootElement, useParentWindow } from "@gtkx/react";
+import { GtkApplicationWindow, type GtkApplicationWindowProps, GtkBox } from "@gtkx/jsx/gtk";
+import { useParentWindow } from "@gtkx/react";
 import { render } from "@gtkx/testing";
 import { useEffect } from "react";
 import { describe, expect, it } from "vitest";
-import { createAppIdFactory } from "./helpers/unique-name.js";
+import { createApplicationRenderer } from "./helpers/application-render.js";
 
 type ProbeProps = { slot: string };
 
 const captured: Record<string, Gtk.Window | null> = {};
-const uniqueAppId = createAppIdFactory("org.gtkx.useparentwindowtest");
+const renderApplication = createApplicationRenderer("org.gtkx.useparentwindowtest");
 
 const Probe = ({ slot }: ProbeProps) => {
     const parentWindow = useParentWindow();
@@ -26,25 +25,22 @@ const Probe = ({ slot }: ProbeProps) => {
 const renderProbedWindow = async (props: GtkApplicationWindowProps): Promise<Gtk.Window | null> => {
     let windowInstance: Gtk.Window | null = null;
 
-    await render(
-        <GtkApplication applicationId={uniqueAppId()} flags={Gio.ApplicationFlags.NON_UNIQUE}>
-            <GtkApplicationWindow
-                ref={(instance) => {
-                    windowInstance = instance;
-                }}
-                defaultWidth={100}
-                defaultHeight={100}
-                {...props}
-            />
-        </GtkApplication>,
-        { container: rootElement },
+    await renderApplication(
+        <GtkApplicationWindow
+            ref={(instance) => {
+                windowInstance = instance;
+            }}
+            defaultWidth={100}
+            defaultHeight={100}
+            {...props}
+        />,
     );
 
     return windowInstance;
 };
 
 describe("useParentWindow", () => {
-    it("returns the window provided by createWindowComponent", async () => {
+    it("returns the window provided by the enclosing window element", async () => {
         const windowInstance = await renderProbedWindow({ children: <Probe slot="children" /> });
         expect(windowInstance).not.toBeNull();
         expect(captured.children).toBe(windowInstance);
@@ -72,7 +68,7 @@ describe("useParentWindow", () => {
         expect(captured.actions).toBe(windowInstance);
     });
 
-    it("returns null when there is no createWindowComponent ancestor", async () => {
+    it("returns null when there is no window ancestor", async () => {
         await render(<Probe slot="orphan" />);
         expect(captured.orphan).toBeNull();
     });
@@ -86,13 +82,10 @@ describe("useParentWindow", () => {
             return null;
         };
 
-        await render(
-            <GtkApplication applicationId={uniqueAppId()} flags={Gio.ApplicationFlags.NON_UNIQUE}>
-                <GtkApplicationWindow defaultWidth={100} defaultHeight={100}>
-                    <RenderProbe />
-                </GtkApplicationWindow>
-            </GtkApplication>,
-            { container: rootElement },
+        await renderApplication(
+            <GtkApplicationWindow defaultWidth={100} defaultHeight={100}>
+                <RenderProbe />
+            </GtkApplicationWindow>,
         );
 
         expect(seen).toEqual(["null", "window"]);

--- a/packages/react/src/adw/dialog.tsx
+++ b/packages/react/src/adw/dialog.tsx
@@ -1,36 +1,33 @@
 import type * as Adw from "@gtkx/gi/adw";
-import { type ElementType, type ReactNode, type Ref, useLayoutEffect, useState } from "react";
-import { useMergedRef } from "../hooks/use-merged-refs.js";
+import { type ElementType, type ReactNode, useCallback } from "react";
+import { createPortaledComponent } from "../components/portaled.js";
 import { useParentWindow } from "../hooks/use-parent-window.js";
-import { rootElement } from "../reconciler/root-element.js";
-import { createPortal } from "../reconciler/root.js";
+import { createPresentedComponent, type PresentedProps } from "../hooks/use-presented-instance.js";
 
-type DialogComponentProps = {
-    ref?: Ref<Adw.Dialog | null> | undefined;
+type DialogComponentProps = PresentedProps<Adw.Dialog>;
+
+const closeDialog = (dialog: Adw.Dialog): void => {
+    dialog.forceClose();
 };
 
-const createDialogComponent = (Component: ElementType): ((props: DialogComponentProps) => ReactNode) => {
-    return ({ ref, ...rest }: DialogComponentProps): ReactNode => {
-        const parent = useParentWindow();
-        const [dialog, setDialog] = useState<Adw.Dialog | null>(null);
+const usePresentDialog = (): ((dialog: Adw.Dialog) => void) => {
+    const parent = useParentWindow();
 
-        useLayoutEffect(() => {
-            if (!dialog) {
-                return;
-            }
-
+    return useCallback(
+        (dialog: Adw.Dialog) => {
             dialog.present(parent);
-
-            return () => {
-                dialog.forceClose();
-            };
-        }, [dialog, parent]);
-
-        const mergedRef = useMergedRef(ref, setDialog);
-
-        return createPortal(<Component ref={mergedRef} {...rest} />, rootElement);
-    };
+        },
+        [parent],
+    );
 };
+
+const createDialogComponent = (Component: ElementType): ((props: DialogComponentProps) => ReactNode) =>
+    createPortaledComponent(
+        createPresentedComponent<Adw.Dialog>(Component, {
+            usePresent: usePresentDialog,
+            dismiss: closeDialog,
+        }),
+    );
 
 /** @internal */
 export { createDialogComponent };

--- a/packages/react/src/adw/element-behaviors.ts
+++ b/packages/react/src/adw/element-behaviors.ts
@@ -6,20 +6,21 @@ import {
     adoptedChildrenSlot,
     applicationCreator,
     boxSlot,
+    childMatcher,
     childSetterSlot,
     contentSetterSlot,
     deferred,
+    indexedSlot,
     list,
     slot,
 } from "../reconciler/behaviors.js";
-import { type ElementConfig, forTypes, registerElements } from "../reconciler/registry.js";
+import { type ElementBehavior, type ElementConfig, forTypes, registerElements } from "../reconciler/registry.js";
 import { BUILTIN_ELEMENTS, CHILD_SETTER_TYPES, CONTENT_SETTER_TYPES } from "./element-config.js";
 
 type AdwChildSetter =
     | Adw.Bin |
     Adw.BreakpointBin |
     Adw.Clamp |
-    Adw.ClampScrollable |
     Adw.Dialog |
     Adw.NavigationPage |
     Adw.SplitButton |
@@ -28,13 +29,11 @@ type AdwChildSetter =
     Adw.ToastOverlay |
     Adw.Toggle;
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-type AdwContentSetter = Adw.ApplicationWindow | Adw.BottomSheet | Adw.Flap | Adw.OverlaySplitView | Adw.Window;
+type AdwContentSetter = Adw.ApplicationWindow | Adw.BottomSheet | Adw.OverlaySplitView | Adw.Window;
 type BreakpointHost = Adw.ApplicationWindow | Adw.Window | Adw.Dialog;
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-type PageHost = Adw.PreferencesDialog | Adw.PreferencesWindow;
 type PrefixSuffixRow = Adw.ActionRow | Adw.EntryRow | Adw.ExpanderRow;
 
+const SLOT_SUFFIX = "Slot";
 const childSetter = childSetterSlot<AdwChildSetter>();
 const contentSetter = contentSetterSlot<AdwContentSetter>();
 
@@ -45,38 +44,113 @@ const breakpoints = slot<BreakpointHost, Adw.Breakpoint>("breakpoints", "AdwBrea
 });
 
 const prefixSuffix = [
-    slot<PrefixSuffixRow, Gtk.Widget>("prefix", "GtkWidget", {
-        attach: (row, child) => {
+    addRemoveSlot<Gtk.Widget, PrefixSuffixRow>(
+        "prefix",
+        "GtkWidget",
+        (row, child) => {
             row.addPrefix(child);
         },
-        detach: (row, child) => {
+        (row, child) => {
             row.remove(child);
         },
-    }),
-    slot<PrefixSuffixRow, Gtk.Widget>("suffix", "GtkWidget", {
-        attach: (row, child) => {
+    ),
+    addRemoveSlot<Gtk.Widget, PrefixSuffixRow>(
+        "suffix",
+        "GtkWidget",
+        (row, child) => {
             row.addSuffix(child);
         },
-        detach: (row, child) => {
+        (row, child) => {
             row.remove(child);
         },
-    }),
+    ),
 ];
 
-const pageHostChildren = addRemoveSlot<Adw.PreferencesPage, PageHost>(
+const preferencesDialogChildren = addRemoveSlot<Adw.PreferencesPage, Adw.PreferencesDialog>(
     "children",
     "AdwPreferencesPage",
-    (host, page) => {
-        host.add(page);
+    (dialog, page) => {
+        dialog.add(page);
     },
-    (host, page) => {
-        host.remove(page);
+    (dialog, page) => {
+        dialog.remove(page);
     },
 );
+
+const sidebarSections = indexedSlot<Adw.Sidebar, Adw.SidebarSection>("children", "AdwSidebarSection");
+const sidebarItems = indexedSlot<Adw.SidebarSection, Adw.SidebarItem>("children", "AdwSidebarItem");
+const isWidget = childMatcher("GtkWidget");
+
+const multiLayoutSlots: ElementBehavior<Adw.MultiLayoutView> = {
+    attach: (view, child, info) => {
+        const id = getSlotId(info.slot);
+
+        if (id === null || !isWidget(child)) {
+            return;
+        }
+
+        view.setChild(id, child as Gtk.Widget);
+
+        return true;
+    },
+    detach: (view, child, info) => {
+        const id = getSlotId(info.slot);
+
+        if (id === null || !isWidget(child)) {
+            return;
+        }
+
+        const widget = child as Gtk.Widget;
+
+        if (view.getChild(id) === widget) {
+            widget.unparent();
+        }
+    },
+};
+
+const multiLayoutLayouts = slot<Adw.MultiLayoutView, Gtk.Widget>("layouts", "GtkWidget", {
+    attach: (view, content) => {
+        const layout = new Adw.Layout({ content });
+        view.addLayout(layout);
+
+        return layout;
+    },
+    reorder: (_view, _content, info) => info.adopted,
+    detach: (view, _content, info) => {
+        if (info.adopted instanceof Adw.Layout) {
+            view.removeLayout(info.adopted);
+        }
+    },
+});
 
 const BUILTIN_BEHAVIORS: Record<string, ElementConfig<never>> = {
     AdwApplication: {
         behaviors: [applicationCreator(Adw.Application)],
+    },
+    AdwSidebar: {
+        behaviors: [sidebarSections],
+    },
+    AdwSidebarSection: {
+        behaviors: [sidebarItems],
+    },
+    AdwMultiLayoutView: {
+        behaviors: [
+            multiLayoutLayouts,
+            multiLayoutSlots,
+            deferred<Adw.MultiLayoutView, string>("layoutName", (view, name) => view.getLayoutByName(name) !== null),
+        ],
+    },
+    AdwClampScrollable: {
+        behaviors: [
+            slot<Adw.ClampScrollable, Gtk.Scrollable & Gtk.Widget>("children", "GtkScrollable", {
+                attach: (clamp, child) => {
+                    clamp.setChild(child);
+                },
+                detach: (clamp) => {
+                    clamp.setChild(null);
+                },
+            }),
+        ],
     },
     ...forTypes(CHILD_SETTER_TYPES, {
         behaviors: [childSetter],
@@ -127,29 +201,13 @@ const BUILTIN_BEHAVIORS: Record<string, ElementConfig<never>> = {
                     row.remove(child);
                 },
             ),
-            addRemoveSlot<Gtk.Widget, Adw.ExpanderRow>(
-                "actions",
-                "GtkWidget",
-                (row, child) => {
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    row.addAction(child);
-                },
-                (row, child) => {
-                    row.remove(child);
-                },
-            ),
         ],
     },
     AdwNavigationSplitView: {
         behaviors: [contentSetterSlot<Adw.NavigationSplitView, Adw.NavigationPage>("AdwNavigationPage")],
     },
-    AdwLeaflet: {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        behaviors: [boxSlot<Adw.Leaflet | Adw.WrapBox>()],
-    },
     AdwWrapBox: {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        behaviors: [boxSlot<Adw.Leaflet | Adw.WrapBox>()],
+        behaviors: [boxSlot<Adw.WrapBox>()],
     },
     AdwCarousel: {
         behaviors: [
@@ -179,10 +237,7 @@ const BUILTIN_BEHAVIORS: Record<string, ElementConfig<never>> = {
         ],
     },
     AdwPreferencesDialog: {
-        behaviors: [pageHostChildren],
-    },
-    AdwPreferencesWindow: {
-        behaviors: [pageHostChildren],
+        behaviors: [preferencesDialogChildren],
     },
     AdwPreferencesGroup: {
         behaviors: [
@@ -194,23 +249,6 @@ const BUILTIN_BEHAVIORS: Record<string, ElementConfig<never>> = {
                 },
                 (group, child) => {
                     group.remove(child);
-                },
-            ),
-        ],
-    },
-    AdwSqueezer: {
-        behaviors: [
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            addRemoveSlot<Gtk.Widget, Adw.Squeezer>(
-                "children",
-                "GtkWidget",
-                (squeezer, child) => {
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    squeezer.add(child);
-                },
-                (squeezer, child) => {
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    squeezer.remove(child);
                 },
             ),
         ],
@@ -262,22 +300,26 @@ const BUILTIN_BEHAVIORS: Record<string, ElementConfig<never>> = {
     AdwToolbarView: {
         behaviors: [
             contentSetterSlot<Adw.ToolbarView>(),
-            slot<Adw.ToolbarView, Gtk.Widget>("topBar", "GtkWidget", {
-                attach: (view, child) => {
+            addRemoveSlot<Gtk.Widget, Adw.ToolbarView>(
+                "topBar",
+                "GtkWidget",
+                (view, child) => {
                     view.addTopBar(child);
                 },
-                detach: (view, child) => {
+                (view, child) => {
                     view.remove(child);
                 },
-            }),
-            slot<Adw.ToolbarView, Gtk.Widget>("bottomBar", "GtkWidget", {
-                attach: (view, child) => {
+            ),
+            addRemoveSlot<Gtk.Widget, Adw.ToolbarView>(
+                "bottomBar",
+                "GtkWidget",
+                (view, child) => {
                     view.addBottomBar(child);
                 },
-                detach: (view, child) => {
+                (view, child) => {
                     view.remove(child);
                 },
-            }),
+            ),
         ],
     },
     AdwHeaderBar: {
@@ -355,6 +397,14 @@ const BUILTIN_BEHAVIORS: Record<string, ElementConfig<never>> = {
         ],
     },
 };
+
+function getSlotId(name: string): string | null {
+    if (name.length <= SLOT_SUFFIX.length || !name.endsWith(SLOT_SUFFIX)) {
+        return null;
+    }
+
+    return name.slice(0, -SLOT_SUFFIX.length);
+}
 
 registerElements(BUILTIN_ELEMENTS);
 registerElements(BUILTIN_BEHAVIORS);

--- a/packages/react/src/adw/element-config.ts
+++ b/packages/react/src/adw/element-config.ts
@@ -3,7 +3,6 @@ import { type ElementConfig, forTypes, internal, type ModuleExport } from "../re
 const CHILD_SETTER_TYPES: string[] = [
     "AdwBin",
     "AdwClamp",
-    "AdwClampScrollable",
     "AdwNavigationPage",
     "AdwSplitButton",
     "AdwStatusPage",
@@ -12,17 +11,11 @@ const CHILD_SETTER_TYPES: string[] = [
     "AdwToggle",
 ];
 
-const CONTENT_SETTER_TYPES: string[] = ["AdwBottomSheet", "AdwFlap", "AdwOverlaySplitView"];
+const CONTENT_SETTER_TYPES: string[] = ["AdwBottomSheet", "AdwOverlaySplitView"];
 const childrenProps = internal("ChildrenProps");
 const breakpointsProps = adw("AdwBreakpointsProps");
 const preferencesRowProps = adw("AdwPreferencesRowProps");
 
-/**
- * The framework's own element configuration for the Adwaita types it customizes: the base props interface each
- * generated element extends, the component that wraps it, the GObject properties left out of its generated
- * props, and whether its GObject is created by its parent. Carries no behaviors, so importing it never
- * reaches the GObject bindings.
- */
 const BUILTIN_ELEMENTS: Record<string, ElementConfig> = {
     ...forTypes(CHILD_SETTER_TYPES, {
         props: childrenProps,
@@ -32,11 +25,24 @@ const BUILTIN_ELEMENTS: Record<string, ElementConfig> = {
         props: childrenProps,
         omittedProps: ["content"],
     }),
+    AdwClampScrollable: {
+        props: childrenProps,
+        omittedProps: ["child"],
+    },
     AdwViewStackPage: {
         isLazy: true,
     },
     AdwTabPage: {
         isLazy: true,
+    },
+    AdwLayout: {
+        isLazy: true,
+    },
+    AdwSidebarSection: {
+        props: childrenProps,
+    },
+    AdwMultiLayoutView: {
+        props: adw("AdwMultiLayoutViewProps"),
     },
     AdwPreferencesRow: {
         props: preferencesRowProps,
@@ -71,9 +77,6 @@ const BUILTIN_ELEMENTS: Record<string, ElementConfig> = {
         props: childrenProps,
         omittedProps: ["content"],
     },
-    AdwLeaflet: {
-        props: childrenProps,
-    },
     AdwWrapBox: {
         props: childrenProps,
     },
@@ -86,13 +89,7 @@ const BUILTIN_ELEMENTS: Record<string, ElementConfig> = {
     AdwPreferencesDialog: {
         props: childrenProps,
     },
-    AdwPreferencesWindow: {
-        props: childrenProps,
-    },
     AdwPreferencesGroup: {
-        props: childrenProps,
-    },
-    AdwSqueezer: {
         props: childrenProps,
     },
     AdwTabView: {

--- a/packages/react/src/components/application-window.tsx
+++ b/packages/react/src/components/application-window.tsx
@@ -1,0 +1,10 @@
+import type { ElementType, ReactNode } from "react";
+import { useApplication } from "../hooks/use-application.js";
+import { createPortaledComponent } from "./portaled.js";
+import { createPresentedWindowComponent } from "./window.js";
+
+const createApplicationWindowComponent = (Component: ElementType): ((props: unknown) => ReactNode) =>
+    createPortaledComponent(createPresentedWindowComponent(Component), useApplication);
+
+/** @internal */
+export { createApplicationWindowComponent };

--- a/packages/react/src/components/window.tsx
+++ b/packages/react/src/components/window.tsx
@@ -1,11 +1,13 @@
 import type * as Gtk from "@gtkx/gi/gtk";
-import { type ElementType, type ReactNode, type Ref, useLayoutEffect, useState } from "react";
-import { useMergedRef } from "../hooks/use-merged-refs.js";
+import { type ElementType, type ReactElement, type ReactNode, use } from "react";
 import { ParentWindowContext } from "../hooks/use-parent-window.js";
+import { createPresentedComponent, type PresentedProps } from "../hooks/use-presented-instance.js";
 import { applyWrite } from "../reconciler/signals.js";
+import { createPortaledComponent } from "./portaled.js";
 
-type WindowComponentProps = {
-    ref?: Ref<Gtk.Window | null> | undefined;
+type WindowComponentProps = PresentedProps<Gtk.Window> & {
+    // eslint-disable-next-line gtkx/accessor-naming
+    transientFor?: Gtk.Window | ReactElement | null | undefined;
 };
 
 const presentWindow = (window: Gtk.Window): void => {
@@ -20,30 +22,29 @@ const destroyWindow = (window: Gtk.Window): void => {
     });
 };
 
-const createWindowComponent = (Component: ElementType): ((props: WindowComponentProps) => ReactNode) => {
-    return ({ ref, ...rest }: WindowComponentProps): ReactNode => {
-        const [window, setWindow] = useState<Gtk.Window | null>(null);
-        const mergedRef = useMergedRef(ref, setWindow);
+const usePresentWindow = (): ((window: Gtk.Window) => void) => presentWindow;
 
-        useLayoutEffect(() => {
-            if (!window) {
-                return;
-            }
+const createPresentedWindowComponent = (Component: ElementType): ((props: PresentedProps<Gtk.Window>) => ReactNode) =>
+    createPresentedComponent<Gtk.Window>(Component, {
+        usePresent: usePresentWindow,
+        dismiss: destroyWindow,
+        wrap: (element, window) => (
+            <ParentWindowContext.Provider value={window}>{element}</ParentWindowContext.Provider>
+        ),
+    });
 
-            presentWindow(window);
+const withDefaultTransientFor = (Component: ElementType): ((props: WindowComponentProps) => ReactNode) => {
+    return (props: WindowComponentProps): ReactNode => {
+        const parent = use(ParentWindowContext);
+        const isDefaulted = props.transientFor === undefined && parent !== null;
 
-            return () => {
-                destroyWindow(window);
-            };
-        }, [window]);
-
-        return (
-            <ParentWindowContext.Provider value={window}>
-                <Component ref={mergedRef} {...rest} />
-            </ParentWindowContext.Provider>
-        );
+        return <Component {...(isDefaulted ? { ...props, transientFor: parent } : props)} />;
     };
 };
 
+const createWindowComponent = (Component: ElementType): ((props: unknown) => ReactNode) =>
+    createPortaledComponent(withDefaultTransientFor(createPresentedWindowComponent(Component)));
+
+export { createPresentedWindowComponent };
 /** @internal */
 export { createWindowComponent };

--- a/packages/react/src/element-config.ts
+++ b/packages/react/src/element-config.ts
@@ -4,7 +4,6 @@ const SINGLE_CHILD_TYPES: string[] = [
     "GtkAspectFrame",
     "GtkButton",
     "GtkCheckButton",
-    "GtkComboBox",
     "GtkDragIcon",
     "GtkExpander",
     "GtkFlowBoxChild",
@@ -42,6 +41,9 @@ const BUILTIN_ELEMENTS: Record<string, ElementConfig> = {
         props: internal("ChildrenProps"),
         component: internal("createWindowComponent"),
         omittedProps: ["child"],
+    },
+    GtkApplicationWindow: {
+        component: internal("createApplicationWindowComponent"),
     },
     GtkLabel: {
         props: internal("ChildrenProps"),
@@ -112,6 +114,7 @@ const BUILTIN_ELEMENTS: Record<string, ElementConfig> = {
     },
     GtkSizeGroup: {
         props: internal("GtkSizeGroupProps"),
+        component: internal("createPortaledComponent"),
     },
     GtkConstraintLayout: {
         props: internal("GtkConstraintLayoutProps"),

--- a/packages/react/src/hooks/use-presented-instance.tsx
+++ b/packages/react/src/hooks/use-presented-instance.tsx
@@ -1,0 +1,50 @@
+import { type ElementType, type ReactNode, type Ref, type RefCallback, useLayoutEffect, useState } from "react";
+import { useMergedRef } from "./use-merged-refs.js";
+
+type PresentedProps<T> = {
+    ref?: Ref<T | null> | undefined;
+};
+
+type PresentedOptions<T> = {
+    usePresent: () => (instance: T) => void;
+    dismiss: (instance: T) => void;
+    wrap?: (element: ReactNode, instance: T | null) => ReactNode;
+};
+
+const usePresentedInstance = <T,>(
+    ref: Ref<T | null> | undefined,
+    present: (instance: T) => void,
+    dismiss: (instance: T) => void,
+): [T | null, RefCallback<T>] => {
+    const [instance, setInstance] = useState<T | null>(null);
+    const mergedRef = useMergedRef(ref, setInstance);
+
+    useLayoutEffect(() => {
+        if (!instance) {
+            return;
+        }
+
+        present(instance);
+
+        return () => {
+            dismiss(instance);
+        };
+    }, [instance, present, dismiss]);
+
+    return [instance, mergedRef];
+};
+
+const createPresentedComponent = <T,>(
+    Component: ElementType,
+    options: PresentedOptions<T>,
+): ((props: PresentedProps<T>) => ReactNode) => {
+    return ({ ref, ...rest }: PresentedProps<T>): ReactNode => {
+        const present = options.usePresent();
+        const [instance, mergedRef] = usePresentedInstance(ref, present, options.dismiss);
+        const element = <Component ref={mergedRef} {...rest} />;
+
+        return options.wrap ? options.wrap(element, instance) : element;
+    };
+};
+
+export { createPresentedComponent, type PresentedProps };

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -1,8 +1,12 @@
 import "./bootstrap.js";
 
 /** @internal */
+export { createApplicationWindowComponent } from "./components/application-window.js";
+/** @internal */
 export { createApplicationComponent } from "./components/application.js";
 export { createElementComponent } from "./components/element.js";
+/** @internal */
+export { createPortaledComponent } from "./components/portaled.js";
 /** @internal */
 export { createWindowComponent } from "./components/window.js";
 export { useMergedRef } from "./hooks/use-merged-refs.js";

--- a/packages/react/src/reconciler/node.ts
+++ b/packages/react/src/reconciler/node.ts
@@ -18,10 +18,10 @@ type SignalTarget = {
 type PlacedChild = {
     node: PlaceableNode;
     object: GObject.Object;
+    typeName: string;
     adopted: GObject.Object | null;
     slot: string;
     behavior: ElementBehavior | null;
-    isAttached: boolean;
 };
 
 type ElementNode = SignalTarget & {
@@ -111,15 +111,17 @@ const createElementNode = (
 
 const createTextNode = (text: string): TextNode => ({ kind: TEXT_KIND, text, parent: null });
 
-const nodeObject = (node: PlaceableNode): GObject.Object | null => {
-    if (node.kind === LAZY_KIND) {
-        const [child] = node.children;
-
-        return child === undefined ? null : nodeObject(child);
+const leafElement = (node: PlaceableNode): ElementNode | null => {
+    if (node.kind !== LAZY_KIND) {
+        return node;
     }
 
-    return node.object;
+    const [child] = node.children;
+
+    return child === undefined ? null : leafElement(child);
 };
+
+const nodeObject = (node: PlaceableNode): GObject.Object | null => leafElement(node)?.object ?? null;
 
 const lazyTarget = (node: LazyNode, adopted: GObject.Object): SignalTarget => ({
     object: adopted,
@@ -141,6 +143,7 @@ export {
     createLazyNode,
     createElementNode,
     createTextNode,
+    leafElement,
     nodeObject,
     lazyTarget,
     getOrCreateContext,

--- a/packages/react/src/reconciler/placement.ts
+++ b/packages/react/src/reconciler/placement.ts
@@ -1,6 +1,6 @@
 import * as GObject from "@gtkx/gi/gobject";
 import * as Gtk from "@gtkx/gi/gtk";
-import { getOrInsert, indexBeforeOrEnd, remove } from "@gtkx/utils";
+import { getOrInsert, indexBeforeOrEnd } from "@gtkx/utils";
 import type { DetachInfo, ElementBehavior, PlaceInfo } from "./registry.js";
 import { applyAdoptedProps, markFlush } from "./apply-props.js";
 import { typeInfoFor } from "./metadata.js";
@@ -11,7 +11,7 @@ import {
     getOrCreateContext,
     LAZY_KIND,
     lazyTarget,
-    nodeObject,
+    leafElement,
     type PlaceableNode,
     type PlacedChild,
 } from "./node.js";
@@ -21,13 +21,20 @@ import { markTextDirty } from "./text.js";
 type AttachContext = { parent: ElementNode; entry: PlacedChild; index: number; sibling: GObject.Object | null };
 
 const createEntry = (slot: string, node: PlaceableNode): PlacedChild | null => {
-    const object = nodeObject(node);
+    const leaf = leafElement(node);
 
-    if (object === null) {
+    if (leaf === null) {
         return null;
     }
 
-    return { node, object, adopted: null, slot, behavior: null, isAttached: false };
+    return {
+        node,
+        object: leaf.object,
+        typeName: leaf.typeName,
+        adopted: null,
+        slot,
+        behavior: null,
+    };
 };
 
 const siblingAt = (entries: PlacedChild[], index: number): GObject.Object | null =>
@@ -80,7 +87,6 @@ const setObjectSlot = (parent: ElementNode, entry: PlacedChild): void => {
     writeSlot(parent, entry, entry.object);
     wireBufferView(entry.node, parent);
     entry.behavior = null;
-    entry.isAttached = true;
 };
 
 const didAttach = (ctx: AttachContext, behavior: ElementBehavior): boolean => {
@@ -99,11 +105,18 @@ const didAttach = (ctx: AttachContext, behavior: ElementBehavior): boolean => {
 
     ctx.entry.behavior = behavior;
     adoptedFrom(ctx.parent, ctx.entry, behavior, claim);
-    ctx.entry.isAttached = true;
     applyLazyProps(ctx.entry);
 
     return true;
 };
+
+const unclaimedChildError = (parentTypeName: string, childTypeName: string): Error =>
+    new Error(
+        `<${childTypeName}> cannot be a child of <${parentTypeName}>. Pass it to the ` +
+        `<${parentTypeName}> prop that takes it, if there is one, portal it to rootElement with createPortal ` +
+        `if it does not belong inside <${parentTypeName}>, or register an attach behavior for ` +
+        `<${parentTypeName}> with defineElements from "@gtkx/react/config" if it belongs among its children.`,
+    );
 
 const runAttach = (parent: ElementNode, entry: PlacedChild, index: number, sibling: GObject.Object | null): void => {
     const ctx: AttachContext = { parent, entry, index, sibling };
@@ -114,9 +127,11 @@ const runAttach = (parent: ElementNode, entry: PlacedChild, index: number, sibli
         }
     }
 
-    if (entry.slot !== DEFAULT_SLOT) {
-        setObjectSlot(parent, entry);
+    if (entry.slot === DEFAULT_SLOT) {
+        throw unclaimedChildError(parent.typeName, entry.typeName);
     }
+
+    setObjectSlot(parent, entry);
 };
 
 const attachEntry = (parent: ElementNode, entry: PlacedChild, index: number, sibling: GObject.Object | null): void => {
@@ -136,9 +151,7 @@ const runDetach = (parent: ElementNode, entry: PlacedChild): void => {
     const behavior = entry.behavior;
 
     if (behavior === null) {
-        if (entry.slot !== DEFAULT_SLOT) {
-            writeSlot(parent, entry, null);
-        }
+        writeSlot(parent, entry, null);
 
         return;
     }
@@ -147,12 +160,6 @@ const runDetach = (parent: ElementNode, entry: PlacedChild): void => {
 };
 
 const detachEntry = (parent: ElementNode, entry: PlacedChild): void => {
-    if (!entry.isAttached) {
-        return;
-    }
-
-    entry.isAttached = false;
-
     applyWrite(() => {
         runDetach(parent, entry);
     });
@@ -174,13 +181,6 @@ const getPosition = (entries: PlacedChild[], before: PlaceableNode | null): numb
 
 const placeNew = (parent: ElementNode, entry: PlacedChild, entries: PlacedChild[], index: number): void => {
     attachEntry(parent, entry, index, siblingAt(entries, index));
-
-    if (!entry.isAttached) {
-        remove(entries, entry);
-
-        return;
-    }
-
     const isInsertedBeforeEnd = index < entries.length - 1;
     const isCannotReorderInPlace = entry.behavior !== null && entry.behavior.reorder === undefined;
 


### PR DESCRIPTION
Portals the elements GTK will not let a parent hold, and refreshes the Adwaita element set.

- **Portaling**: `createPortaledComponent` sends `<GtkWindow>`, `<GtkApplicationWindow>`, `<GtkSizeGroup>` and the Adwaita dialogs to the root element or the contextual application instead of their JSX parent, so they can be declared where they belong in the tree.
- **Adwaita**: `AdwLayout`, `AdwSidebar`, `AdwSidebarSection` and `AdwMultiLayoutView` join the element set, `AdwClampScrollable` gets its own configuration, and the widgets Adwaita deprecated (`AdwLeaflet`, `AdwSqueezer`, `AdwFlap`, `AdwPreferencesWindow`) leave it.

Review notes addressed:

- `multiLayoutSlots` now has a `detach` that unparents the slot child when the view still holds it, so dropping a `*Slot` prop no longer leaves the widget in the view. A test covers it.
- `@gtkx/react/internal` exports `createApplicationWindowComponent` and `createPortaledComponent` in this PR, so the generated store resolves both wrappers.
- `applyWrite` and `getAccessibleMetadata` keep their exports here; they move with the reconciler work in part 10.

Part 8 of 15 in the v1.0.0 release stack. Merge in order.

### Areas touched

- `packages/e2e` (12)
- `packages/react` (10)
