### PR TITLE
Read widget properties over MCP

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,12 @@
     "author": "Eugenio Depalo <eugeniodepalo@gmail.com>",
     "type": "module",
     "exports": {
+        "./env": "./env.d.ts",
+        "./internal": {
+            "source": "./src/internal.ts",
+            "types": "./dist/internal.d.ts",
+            "default": "./dist/internal.js"
+        },
         "./package.json": "./package.json",
         "./refresh-runtime": {
             "source": "./src/refresh-runtime.ts",
@@ -39,8 +45,7 @@
             "source": "./src/vitest-plugin.ts",
             "types": "./dist/vitest-plugin.d.ts",
             "default": "./dist/vitest-plugin.js"
-        },
-        "./env": "./env.d.ts"
+        }
     },
     "bin": {
         "gtkx": "bin/gtkx.js"

--- a/packages/cli/src/internal.ts
+++ b/packages/cli/src/internal.ts
@@ -1,0 +1,2 @@
+export { dispatch } from "./mcp/handlers.js";
+export { WidgetRegistry } from "./mcp/widget-registry.js";

--- a/packages/cli/src/mcp/handlers.ts
+++ b/packages/cli/src/mcp/handlers.ts
@@ -8,11 +8,10 @@ import {
     ServerRequestParamsSchemas,
     widgetNotFoundError,
 } from "@gtkx/mcp/internal";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
 import type { WidgetRegistry } from "./widget-registry.js";
 import { serializeWidget } from "./serialize-widget.js";
 import { loadTestingModule, type TestingModule } from "./testing-loader.js";
+import { readWidgetProperties } from "./widget-properties.js";
 
 type HandlerContext = {
     app: Gtk.Application;
@@ -21,6 +20,13 @@ type HandlerContext = {
 
 type ValidatedHandler = (ctx: HandlerContext, params: unknown) => Promise<unknown>;
 type WidgetTarget = { testing: TestingModule; widget: Gtk.Widget };
+type WidgetParams = { widgetId?: string | undefined };
+type TargetedHandler<Params> = (ctx: HandlerContext, target: WidgetTarget, params: Params) => Promise<unknown>;
+type QueryParams = ServerRequestParams<"widget.query">;
+type QueryBy = QueryParams["by"];
+type QueryRunner = (testing: TestingModule, app: Gtk.Application, params: QueryParams) => Promise<Gtk.Widget[]>;
+
+const TREE_EXPANDER_TOGGLE_ACTION = "listitem.toggle-expand";
 
 const HANDLERS: Record<ServerInitiatedMethod, ValidatedHandler> = {
     "app.getWindows": validated(ServerRequestParamsSchemas["app.getWindows"], ({ registry }) =>
@@ -43,20 +49,22 @@ const HANDLERS: Record<ServerInitiatedMethod, ValidatedHandler> = {
         };
     }),
     "widget.query": validated(ServerRequestParamsSchemas["widget.query"], handleQuery),
-    "widget.getProps": validated(ServerRequestParamsSchemas["widget.getProps"], async ({ registry }, params) => {
-        const { testing, widget } = await widgetTarget(registry, params.widgetId);
-
-        return serializeWidget(widget, (target) => registry.getOrCreateId(target), testing);
-    }),
-    "widget.click": validated(ServerRequestParamsSchemas["widget.click"], async ({ registry }, params) => {
-        const { testing, widget } = await widgetTarget(registry, params.widgetId);
-        await testing.userEvent.click(widget);
+    "widget.getProps": targeted(
+        ServerRequestParamsSchemas["widget.getProps"],
+        ({ registry }, { testing, widget }, params) =>
+            Promise.resolve({
+                ...serializeWidget(widget, (target) => registry.getOrCreateId(target), testing),
+                ...(params.properties !== undefined && {
+                    properties: readWidgetProperties(widget, params.properties, registry),
+                }),
+            }),
+    ),
+    "widget.click": targeted(ServerRequestParamsSchemas["widget.click"], async (_ctx, target) => {
+        await clickTarget(target);
 
         return { success: true };
     }),
-    "widget.type": validated(ServerRequestParamsSchemas["widget.type"], async ({ registry }, params) => {
-        const { testing, widget } = await widgetTarget(registry, params.widgetId);
-
+    "widget.type": targeted(ServerRequestParamsSchemas["widget.type"], async (_ctx, { testing, widget }, params) => {
         if (params.clear) {
             await testing.userEvent.clear(widget);
         }
@@ -65,14 +73,41 @@ const HANDLERS: Record<ServerInitiatedMethod, ValidatedHandler> = {
 
         return { success: true };
     }),
-    "widget.fireEvent": validated(ServerRequestParamsSchemas["widget.fireEvent"], async ({ registry }, params) => {
-        const { testing, widget } = await widgetTarget(registry, params.widgetId);
-        const signalArgs = (params.args ?? []).map((arg) => extractSignalArg(arg));
-        await testing.fireEvent(widget, params.signal, ...signalArgs);
+    "widget.fireEvent": targeted(
+        ServerRequestParamsSchemas["widget.fireEvent"],
+        async (_ctx, { testing, widget }, params) => {
+            const signalArgs = (params.args ?? []).map((arg) => extractSignalArg(arg));
+            const isRealized = widget.getRealized();
+            const isMapped = widget.getMapped();
+            const isSensitive = widget.getSensitive();
+            await testing.fireEvent(widget, params.signal, ...signalArgs);
 
-        return { success: true };
-    }),
+            return {
+                signal: params.signal,
+                isRealized,
+                isMapped,
+                isSensitive,
+                note: emissionNote(isRealized, isMapped),
+            };
+        },
+    ),
     "widget.screenshot": validated(ServerRequestParamsSchemas["widget.screenshot"], handleScreenshot),
+};
+
+const QUERY_RUNNERS: Record<QueryBy, QueryRunner> = {
+    role: runRoleQuery,
+    text: runTextQuery,
+    name: runNameQuery,
+    labelText: runLabelTextQuery,
+};
+
+const SEARCHED_BY: Record<QueryBy, string> = {
+    role: "the accessible role, narrowed by any options given",
+    text: "the text the widget renders",
+    name:
+        "the widget name (gtk_widget_get_name, which reports the GType name such as \"GtkButton\" when no name " +
+        "was set), the accessible label, and the text the widget renders",
+    labelText: "the accessible label, the labelled-by relation, and the label whose mnemonic targets the widget",
 };
 
 function validated<Params>(
@@ -89,6 +124,26 @@ function validated<Params>(
         return handler(ctx, parsed.data);
     };
 }
+
+function targeted<Params extends WidgetParams>(
+    schema: ParamsSchema<Params>,
+    handler: TargetedHandler<Params>,
+): ValidatedHandler {
+    return validated(schema, async (ctx, params) =>
+        handler(ctx, await widgetTarget(ctx.registry, params.widgetId), params));
+}
+
+const clickTarget = async ({ testing, widget }: WidgetTarget): Promise<void> => {
+    if (widget instanceof Gtk.TreeExpander) {
+        await testing.act(() => {
+            widget.activateAction(TREE_EXPANDER_TOGGLE_ACTION, null);
+        });
+
+        return;
+    }
+
+    await testing.userEvent.click(widget);
+};
 
 const widgetTarget = async (registry: WidgetRegistry, widgetId: string | undefined): Promise<WidgetTarget> => ({
     testing: await loadTestingModule(),
@@ -115,6 +170,21 @@ const extractSignalArg = (arg: unknown): unknown => {
     return isTypedArg ? (arg as { value: unknown }).value : arg;
 };
 
+const emissionNote = (isRealized: boolean, isMapped: boolean): string => {
+    if (isRealized && isMapped) {
+        return (
+            "The signal was emitted. Default handlers that animate, such as a button activate, settle " +
+            "asynchronously, so read the widget again rather than assuming the effect has landed."
+        );
+    }
+
+    return (
+        "The signal was emitted on a widget that is not realized and mapped, so a default handler that " +
+        "requires a drawn widget does nothing. Present the containing window or open the containing " +
+        "popover first, then fire the signal again."
+    );
+};
+
 const resolveRole = (value: string | number): Gtk.AccessibleRole | undefined => {
     if (typeof value === "number") {
         return value;
@@ -133,42 +203,56 @@ const matchesOrEmpty = async (find: () => Promise<Gtk.Widget[]>): Promise<Gtk.Wi
     }
 };
 
-async function handleQuery(
-    { app, registry }: HandlerContext,
-    params: ServerRequestParams<"widget.query">,
-): Promise<unknown> {
-    const testing = await loadTestingModule();
-    let widgets: Gtk.Widget[] = [];
+function runRoleQuery(testing: TestingModule, app: Gtk.Application, params: QueryParams): Promise<Gtk.Widget[]> {
+    const roleValue = resolveRole(params.value);
 
-    switch (params.by) {
-        case "role": {
-            const roleValue = resolveRole(params.value);
-
-            if (roleValue === undefined) {
-                throw invalidRequestError(
-                    `Unknown accessible role "${String(params.value)}"; use the lowercase role shown in the ` +
-                    "widget tree, e.g. \"button\", \"list\", \"list_item\", or \"checkbox\".",
-                );
-            }
-
-            widgets = await matchesOrEmpty(() => testing.findAllByRole(app, roleValue, params.options));
-            break;
-        }
-        case "text": {
-            widgets = await matchesOrEmpty(() => testing.findAllByText(app, String(params.value), params.options));
-            break;
-        }
-        case "name": {
-            widgets = await matchesOrEmpty(() => testing.findAllByName(app, String(params.value), params.options));
-            break;
-        }
-        case "labelText": {
-            widgets = await matchesOrEmpty(() => testing.findAllByLabelText(app, String(params.value), params.options));
-            break;
-        }
+    if (roleValue === undefined) {
+        throw invalidRequestError(
+            `Unknown accessible role "${String(params.value)}"; use the lowercase role shown in the ` +
+            "widget tree, e.g. \"button\", \"list\", \"list_item\", or \"checkbox\".",
+        );
     }
 
-    return { widgets: widgets.map((w) => serializeWidget(w, (widget) => registry.getOrCreateId(widget), testing, 0)) };
+    return matchesOrEmpty(() => testing.findAllByRole(app, roleValue, params.options));
+}
+
+function runTextQuery(testing: TestingModule, app: Gtk.Application, params: QueryParams): Promise<Gtk.Widget[]> {
+    return matchesOrEmpty(() => testing.findAllByText(app, String(params.value), params.options));
+}
+
+function runLabelTextQuery(testing: TestingModule, app: Gtk.Application, params: QueryParams): Promise<Gtk.Widget[]> {
+    return matchesOrEmpty(() => testing.findAllByLabelText(app, String(params.value), params.options));
+}
+
+async function runNameQuery(
+    testing: TestingModule,
+    app: Gtk.Application,
+    params: QueryParams,
+): Promise<Gtk.Widget[]> {
+    const matches = await Promise.all([
+        matchesOrEmpty(() => testing.findAllByName(app, String(params.value), params.options)),
+        runLabelTextQuery(testing, app, params),
+        runTextQuery(testing, app, params),
+    ]);
+
+    return [...new Set(matches.flat())];
+}
+
+const emptyQueryHint = (params: QueryParams): string =>
+    `Nothing matched by:"${params.by}" value:"${String(params.value)}", which compared ${SEARCHED_BY[params.by]}. ` +
+    "Call gtkx_get_widget_tree to see what is mounted; by:\"name\" is the widest match, and by:\"role\" accepts " +
+    "options.name to match the accessible name of a known role.";
+
+async function handleQuery({ app, registry }: HandlerContext, params: QueryParams): Promise<unknown> {
+    const testing = await loadTestingModule();
+    const widgets = await QUERY_RUNNERS[params.by](testing, app, params);
+    const resolveId = (widget: Gtk.Widget): string => registry.getOrCreateId(widget);
+
+    return {
+        widgets: widgets.map((widget) => serializeWidget(widget, resolveId, testing, 0)),
+        searched: SEARCHED_BY[params.by],
+        ...(widgets.length === 0 && { hint: emptyQueryHint(params) }),
+    };
 }
 
 const defaultScreenshotTarget = (registry: WidgetRegistry): Gtk.Widget => {
@@ -187,12 +271,9 @@ async function handleScreenshot(
 ): Promise<unknown> {
     const testing = await loadTestingModule();
     const target = params.windowId ? requireWidget(registry, params.windowId) : defaultScreenshotTarget(registry);
-    const result = await testing.screenshot(target);
+    const result = await testing.screenshot(target, { path: params.path });
 
     if (params.path) {
-        mkdirSync(dirname(params.path), { recursive: true });
-        writeFileSync(params.path, Buffer.from(result.data, "base64"));
-
         return { data: result.data, mimeType: result.mimeType, savedPath: params.path };
     }
 
@@ -210,4 +291,4 @@ const dispatch = async (method: string, params: unknown, ctx: HandlerContext): P
     return HANDLERS[method](ctx, params);
 };
 
-export { dispatch, type HandlerContext };
+export { dispatch };

--- a/packages/cli/src/mcp/widget-properties.ts
+++ b/packages/cli/src/mcp/widget-properties.ts
@@ -1,0 +1,153 @@
+import * as GObject from "@gtkx/gi/gobject";
+import * as Gtk from "@gtkx/gi/gtk";
+import { propertyNotFoundError, type SerializedProperty } from "@gtkx/mcp/internal";
+import {
+    type ExternalObject,
+    getHandle,
+    getInstanceType,
+    type Handle,
+    TYPE_ENUM,
+    TYPE_FLAGS,
+    typeIsA,
+    typeName,
+} from "@gtkx/runtime";
+import { fromValue, getValueType } from "@gtkx/runtime/internal";
+import { camelCase, errorMessage, kebabCase } from "@gtkx/utils";
+import type { WidgetRegistry } from "./widget-registry.js";
+
+type PropertyRepresentation = Omit<SerializedProperty, "type">;
+type NativeProperty = { type: bigint; handle: ExternalObject<Handle> };
+
+const SCALAR_TYPES: Set<string> = new Set(["string", "number", "boolean"]);
+
+const canonicalName = (name: string): string => kebabCase(name).replaceAll("_", "-");
+const widgetTypeName = (widget: Gtk.Widget): string => typeName(getInstanceType(widget)) ?? widget.constructor.name;
+const byName = (left: string, right: string): number => left.localeCompare(right);
+
+const isScalar = (value: unknown): value is string | number | boolean | null =>
+    value === null || SCALAR_TYPES.has(typeof value);
+
+function prototypesFor(widget: Gtk.Widget): object[] {
+    const prototypes: object[] = [];
+    let prototype = Object.getPrototypeOf(widget) as object | null;
+
+    while (prototype !== null && prototype !== Object.prototype) {
+        prototypes.push(prototype);
+        prototype = Object.getPrototypeOf(prototype) as object | null;
+    }
+
+    return prototypes;
+}
+
+function getAccessor(widget: Gtk.Widget, member: string): PropertyDescriptor | undefined {
+    for (const prototype of prototypesFor(widget)) {
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, member);
+
+        if (descriptor !== undefined) {
+            return descriptor;
+        }
+    }
+
+    return undefined;
+}
+
+function getReadableNames(prototype: object): string[] {
+    const descriptors = Object.entries(Object.getOwnPropertyDescriptors(prototype));
+
+    return descriptors.filter(([, descriptor]) => descriptor.get !== undefined).map(([member]) => kebabCase(member));
+}
+
+function readablePropertyNames(widget: Gtk.Widget): string[] {
+    const names = prototypesFor(widget).flatMap((prototype) => getReadableNames(prototype));
+
+    return [...new Set(names)].toSorted(byName);
+}
+
+const requireReadableProperty = (widget: Gtk.Widget, property: string): void => {
+    if (getAccessor(widget, camelCase(property))?.get !== undefined) {
+        return;
+    }
+
+    throw propertyNotFoundError(widgetTypeName(widget), property, readablePropertyNames(widget));
+};
+
+function readNativeProperty(widget: Gtk.Widget, property: string): NativeProperty {
+    const value = new GObject.Value();
+    widget.getProperty(property, value);
+    const handle = getHandle(value);
+
+    return { type: getValueType(handle), handle };
+}
+
+function describeObjectValue(value: unknown, registry: WidgetRegistry): PropertyRepresentation {
+    if (typeof value !== "object" || value === null) {
+        return { value: String(value) };
+    }
+
+    const name = typeName(getInstanceType(value)) ?? value.constructor.name;
+
+    if (!(value instanceof Gtk.Widget)) {
+        return { value: name };
+    }
+
+    registry.register(value);
+
+    return { value: name, widgetId: registry.getOrCreateId(value) };
+}
+
+function representValue(value: unknown, registry: WidgetRegistry): PropertyRepresentation {
+    if (isScalar(value)) {
+        return { value };
+    }
+
+    if (typeof value === "bigint") {
+        return { value: value.toString() };
+    }
+
+    if (Array.isArray(value)) {
+        return { value: value.map(String) };
+    }
+
+    return describeObjectValue(value, registry);
+}
+
+function representNativeProperty(native: NativeProperty, registry: WidgetRegistry): PropertyRepresentation {
+    if (typeIsA(native.type, TYPE_ENUM)) {
+        return { value: GObject.enumToString(native.type, Number(fromValue(native.handle))) };
+    }
+
+    if (typeIsA(native.type, TYPE_FLAGS)) {
+        return { value: GObject.flagsToString(native.type, Number(fromValue(native.handle))) };
+    }
+
+    return representValue(fromValue(native.handle), registry);
+}
+
+function serializeProperty(widget: Gtk.Widget, property: string, registry: WidgetRegistry): SerializedProperty {
+    const native = readNativeProperty(widget, property);
+    const type = typeName(native.type) ?? String(native.type);
+
+    try {
+        return { type, ...representNativeProperty(native, registry) };
+    } catch (error) {
+        return { type, value: null, note: `cannot be represented over MCP: ${errorMessage(error)}` };
+    }
+}
+
+function readWidgetProperties(
+    widget: Gtk.Widget,
+    properties: string[],
+    registry: WidgetRegistry,
+): Record<string, SerializedProperty> {
+    const values: Record<string, SerializedProperty> = {};
+
+    for (const name of properties) {
+        const property = canonicalName(name);
+        requireReadableProperty(widget, property);
+        values[property] = serializeProperty(widget, property, registry);
+    }
+
+    return values;
+}
+
+export { readWidgetProperties };

--- a/packages/cli/tests/mcp/client.test.ts
+++ b/packages/cli/tests/mcp/client.test.ts
@@ -2,8 +2,9 @@ import { mkdtempSync, rmSync } from "node:fs";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { McpClient } from "../../src/mcp/client.js";
+import { collectLogged } from "../stderr-text.js";
 
 type ServerContext = {
     server: net.Server;
@@ -127,9 +128,6 @@ const createClient = (ctx: ServerContext): McpClient =>
 
 const spyStderr = () => vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-const stderrText = (stderrSpy: MockInstance<typeof process.stderr.write>): string =>
-    stderrSpy.mock.calls.map((call) => String(call[0])).join("");
-
 function assertLine(line: Record<string, unknown> | undefined): asserts line is Record<string, unknown> {
     if (!line) {
         throw new Error("expected a protocol line to be present");
@@ -237,7 +235,7 @@ describe("McpClient incoming requests", () => {
         const registered = await registerWithStderrSpy(fixture.ctx);
         fixture.ctx.sockets[0]?.write("not json\n");
         await new Promise((resolve) => setTimeout(resolve, 20));
-        expect(stderrText(registered.stderrSpy)).toContain("invalid JSON");
+        expect(collectLogged(registered.stderrSpy)).toContain("invalid JSON");
         registered.stderrSpy.mockRestore();
         registered.client.disconnect();
     });
@@ -300,7 +298,7 @@ describe("McpClient connection failures", () => {
         fixture.ctx.sockets[0]?.destroy();
 
         await vi.waitFor(() => {
-            expect(stderrText(registered.stderrSpy)).toContain("Disconnected");
+            expect(collectLogged(registered.stderrSpy)).toContain("Disconnected");
         });
 
         registered.stderrSpy.mockRestore();

--- a/packages/cli/tests/mcp/fake-widget.ts
+++ b/packages/cli/tests/mcp/fake-widget.ts
@@ -1,11 +1,14 @@
 type FakeWidgetOverrides = {
     type?: string;
+    activateAction?: (name: string, args: unknown) => boolean;
     getFirstChild?: () => unknown;
     getNextSibling?: () => unknown;
     getAccessibleRole?: () => number | undefined;
     getName?: () => string | null;
     getSensitive?: () => boolean;
     getVisible?: () => boolean;
+    getRealized?: () => boolean;
+    getMapped?: () => boolean;
     getCssClasses?: () => string[];
     getLabel?: () => string | null;
     getText?: () => string | null;
@@ -19,6 +22,8 @@ const DEFAULTS = {
     getName: () => null,
     getSensitive: () => true,
     getVisible: () => true,
+    getRealized: () => true,
+    getMapped: () => true,
     getCssClasses: () => [],
 };
 

--- a/packages/cli/tests/mcp/handlers.test.ts
+++ b/packages/cli/tests/mcp/handlers.test.ts
@@ -13,6 +13,11 @@ type FakeApp = {
 type TextMatches = { widgets: { text: string | null }[] };
 type ChildMatches = { widgets: { children: unknown[] }[] };
 
+type WidgetTarget = {
+    widget: never;
+    dispatchWidget: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
 const hoisted = vi.hoisted(() => ({
     findAllByRole: vi.fn(),
     findAllByText: vi.fn(),
@@ -29,7 +34,11 @@ const hoisted = vi.hoisted(() => ({
         return widget.getLabel?.() ?? widget.getText?.() ?? null;
     }),
     listToplevels: vi.fn(() => [] as unknown[]),
+    act: vi.fn((callback: () => unknown) => Promise.resolve(callback())),
     AccessibleRole: { BUTTON: 1, LABEL: 2 },
+    TreeExpander: class TreeExpander {
+        isTreeExpander = true;
+    },
 }));
 
 const {
@@ -50,7 +59,11 @@ const makeApp = (windows: { getTitle?: () => string | null }[] = []): FakeApp =>
     getWindows: () => windows,
 });
 
-const makeWidget = (overrides: FakeWidgetOverrides = {}): never => makeFakeWidget(overrides);
+const makeWidget = (overrides: FakeWidgetOverrides = {}): never => {
+    const widget = makeFakeWidget(overrides);
+
+    return overrides.type === "GtkTreeExpander" ? Object.assign(new hoisted.TreeExpander(), widget) : widget;
+};
 
 const registerWidget = (registry: WidgetRegistry, widget: never): string => {
     registry.register(widget);
@@ -61,7 +74,26 @@ const registerWidget = (registry: WidgetRegistry, widget: never): string => {
 const dispatchQuery = (params: Record<string, unknown>, registry = new WidgetRegistry()): Promise<unknown> =>
     dispatch("widget.query", params, { app: makeApp() as never, registry });
 
+const dispatchMatchingNameQuery = (value: string): Promise<unknown> => {
+    findAllByName.mockResolvedValueOnce([makeWidget()]);
+
+    return dispatchQuery({ by: "name", value });
+};
+
+const makeWidgetTarget = (overrides: FakeWidgetOverrides = {}): WidgetTarget => {
+    const widget = makeWidget(overrides);
+    const registry = new WidgetRegistry();
+    const id = registerWidget(registry, widget);
+
+    return {
+        widget,
+        dispatchWidget: (method, params) =>
+            dispatch(method, { widgetId: id, ...params }, { app: makeApp() as never, registry }),
+    };
+};
+
 vi.mock("@gtkx/testing", () => ({
+    act: hoisted.act,
     findAllByRole: hoisted.findAllByRole,
     findAllByText: hoisted.findAllByText,
     findAllByName: hoisted.findAllByName,
@@ -76,11 +108,16 @@ vi.mock("@gtkx/testing", () => ({
 
 vi.mock("@gtkx/gi/gtk", () => ({
     AccessibleRole: hoisted.AccessibleRole,
+    TreeExpander: hoisted.TreeExpander,
     Window: { listToplevels: hoisted.listToplevels },
 }));
 
 beforeEach(() => {
     vi.clearAllMocks();
+    findAllByRole.mockResolvedValue([]);
+    findAllByText.mockResolvedValue([]);
+    findAllByName.mockResolvedValue([]);
+    findAllByLabelText.mockResolvedValue([]);
 });
 
 describe("dispatch (method routing)", () => {
@@ -177,18 +214,16 @@ describe("widget.query", () => {
         expect(findAllByRole).not.toHaveBeenCalled();
     });
 
-    it("routes text/name/labelText through the matching testing helper", async () => {
+    it("routes text and labelText through the matching testing helper", async () => {
         const widget = makeWidget();
-        findAllByText.mockResolvedValueOnce([widget]);
-        findAllByName.mockResolvedValueOnce([widget]);
-        findAllByLabelText.mockResolvedValueOnce([widget]);
         const registry = new WidgetRegistry();
+        findAllByText.mockResolvedValueOnce([widget]);
         await dispatchQuery({ by: "text", value: "Hi" }, registry);
-        await dispatchQuery({ by: "name", value: "btn" }, registry);
+        findAllByLabelText.mockResolvedValueOnce([widget]);
         await dispatchQuery({ by: "labelText", value: "Submit" }, registry);
         expect(findAllByText).toHaveBeenCalledWith(expect.anything(), "Hi", undefined);
-        expect(findAllByName).toHaveBeenCalledWith(expect.anything(), "btn", undefined);
         expect(findAllByLabelText).toHaveBeenCalledWith(expect.anything(), "Submit", undefined);
+        expect(findAllByName).not.toHaveBeenCalled();
     });
 
     it("returns shallow match summaries without descendants", async () => {
@@ -210,17 +245,76 @@ describe("widget.query", () => {
     });
 });
 
+describe("widget.query by name", () => {
+    it("finds a widget by its accessible label when no widget name matches", async () => {
+        const row = makeWidget({ getLabel: () => "Name", type: "AdwEntryRow" });
+        findAllByLabelText.mockResolvedValueOnce([row]);
+        const result = (await dispatchQuery({ by: "name", value: "Name" })) as TextMatches;
+        expect(result.widgets).toHaveLength(1);
+        expect(result.widgets[0]?.text).toBe("Name");
+    });
+
+    it("finds a widget by its rendered text when no widget name matches", async () => {
+        findAllByText.mockResolvedValueOnce([makeWidget({ getLabel: () => "Save" })]);
+        const result = (await dispatchQuery({ by: "name", value: "Save" })) as TextMatches;
+        expect(result.widgets[0]?.text).toBe("Save");
+    });
+
+    it("compares the widget name, the accessible label, and the rendered text", async () => {
+        await dispatchQuery({ by: "name", value: "Name" });
+        expect(findAllByName).toHaveBeenCalledWith(expect.anything(), "Name", undefined);
+        expect(findAllByLabelText).toHaveBeenCalledWith(expect.anything(), "Name", undefined);
+        expect(findAllByText).toHaveBeenCalledWith(expect.anything(), "Name", undefined);
+    });
+
+    it("returns a widget once when several lookups match it", async () => {
+        const widget = makeWidget();
+        findAllByName.mockResolvedValueOnce([widget]);
+        findAllByLabelText.mockResolvedValueOnce([widget]);
+        findAllByText.mockResolvedValueOnce([widget]);
+        const result = (await dispatchQuery({ by: "name", value: "dup" })) as { widgets: unknown[] };
+        expect(result.widgets).toHaveLength(1);
+    });
+});
+
+describe("widget.query result description", () => {
+    it("spells out that the name query covers the GType fallback and the accessible label", async () => {
+        const result = (await dispatchMatchingNameQuery("GtkButton")) as { searched: string };
+        expect(result.searched).toContain("gtk_widget_get_name");
+        expect(result.searched).toContain("accessible label");
+    });
+
+    it("describes what a role query compared", async () => {
+        findAllByRole.mockResolvedValueOnce([makeWidget()]);
+        const result = (await dispatchQuery({ by: "role", value: "button" })) as { searched: string };
+        expect(result.searched).toContain("accessible role");
+    });
+
+    it("hints at what was compared when nothing matched", async () => {
+        const result = (await dispatchQuery({ by: "name", value: "Missing" })) as { hint: string };
+        expect(result.hint).toContain("Nothing matched by:\"name\" value:\"Missing\"");
+        expect(result.hint).toContain("gtk_widget_get_name");
+        expect(result.hint).toContain("gtkx_get_widget_tree");
+    });
+
+    it("omits the hint when the query matched", async () => {
+        const result = (await dispatchMatchingNameQuery("hit")) as { hint?: string };
+        expect(result.hint).toBeUndefined();
+    });
+});
+
 describe("widget.getProps", () => {
     it("returns the serialized widget when the id is known", async () => {
-        const widget = makeWidget({ getName: () => "ok" });
-        const registry = new WidgetRegistry();
-        const id = registerWidget(registry, widget);
-
-        const result = (await dispatch("widget.getProps", { widgetId: id }, { app: makeApp() as never, registry })) as {
-            name: string | null;
-        };
-
+        const { dispatchWidget } = makeWidgetTarget({ getName: () => "ok" });
+        const result = (await dispatchWidget("widget.getProps", {})) as { name: string | null };
         expect(result.name).toBe("ok");
+    });
+
+    it("names the widget type and the property when the widget has no such property", async () => {
+        const { dispatchWidget } = makeWidgetTarget();
+        const failure = dispatchWidget("widget.getProps", { properties: ["collapsed"] });
+        await expect(failure).rejects.toMatchObject({ code: ErrorCode.PROPERTY_NOT_FOUND });
+        await expect(failure).rejects.toThrow("GtkWidget has no readable property 'collapsed'");
     });
 
     it("throws widgetNotFoundError when the id is unknown", async () => {
@@ -242,35 +336,52 @@ describe("widget.getProps", () => {
 
 describe("widget.click / widget.type / widget.fireEvent", () => {
     it("clicks the resolved widget and reports success", async () => {
-        const widget = makeWidget();
-        const registry = new WidgetRegistry();
-        const id = registerWidget(registry, widget);
-        const result = await dispatch("widget.click", { widgetId: id }, { app: makeApp() as never, registry });
+        const { widget, dispatchWidget } = makeWidgetTarget();
+        const result = await dispatchWidget("widget.click", {});
         expect(click).toHaveBeenCalledWith(widget);
         expect(result).toEqual({ success: true });
     });
 
+    it("toggles a tree expander through its own action instead of clicking the enclosing row", async () => {
+        const activateAction = vi.fn(() => true);
+        const { dispatchWidget } = makeWidgetTarget({ type: "GtkTreeExpander", activateAction });
+        const result = await dispatchWidget("widget.click", {});
+        expect(activateAction).toHaveBeenCalledWith("listitem.toggle-expand", null);
+        expect(click).not.toHaveBeenCalled();
+        expect(result).toEqual({ success: true });
+    });
+
+    it("toggles a tree expander inside the act environment so React sees the new rows", async () => {
+        const { dispatchWidget } = makeWidgetTarget({ type: "GtkTreeExpander", activateAction: () => true });
+        await dispatchWidget("widget.click", {});
+        expect(hoisted.act).toHaveBeenCalledTimes(1);
+    });
+
     it("clears before typing when clear=true", async () => {
-        const widget = makeWidget();
-        const registry = new WidgetRegistry();
-        const id = registerWidget(registry, widget);
-        await dispatch("widget.type", { widgetId: id, text: "hi", clear: true }, { app: makeApp() as never, registry });
+        const { widget, dispatchWidget } = makeWidgetTarget();
+        await dispatchWidget("widget.type", { text: "hi", clear: true });
         expect(clear).toHaveBeenCalledWith(widget);
         expect(typeText).toHaveBeenCalledWith(widget, "hi");
     });
 
     it("unwraps typed signal args before firing", async () => {
-        const widget = makeWidget();
-        const registry = new WidgetRegistry();
-        const id = registerWidget(registry, widget);
-
-        await dispatch(
-            "widget.fireEvent",
-            { widgetId: id, signal: "clicked", args: [{ type: "int", value: 42 }, "plain"] },
-            { app: makeApp() as never, registry },
-        );
-
+        const { widget, dispatchWidget } = makeWidgetTarget();
+        const args = [{ type: "int", value: 42 }, "plain"];
+        await dispatchWidget("widget.fireEvent", { signal: "clicked", args });
         expect(fireEvent).toHaveBeenCalledWith(widget, "clicked", 42, "plain");
+    });
+
+    it("reports the state of a widget that can act on the signal", async () => {
+        const { dispatchWidget } = makeWidgetTarget();
+        const result = await dispatchWidget("widget.fireEvent", { signal: "clicked" });
+        expect(result).toMatchObject({ signal: "clicked", isRealized: true, isMapped: true, isSensitive: true });
+    });
+
+    it("reports that an unrealized widget could not act on the signal", async () => {
+        const { dispatchWidget } = makeWidgetTarget({ getRealized: () => false, getMapped: () => false });
+        const result = await dispatchWidget("widget.fireEvent", { signal: "activate" });
+        expect(result).toMatchObject({ isRealized: false, isMapped: false });
+        expect((result as { note: string }).note).toContain("not realized and mapped");
     });
 });
 
@@ -288,7 +399,7 @@ describe("widget.screenshot", () => {
         };
 
         expect(result).toEqual({ data: "abc", mimeType: "image/png" });
-        expect(screenshot).toHaveBeenCalledWith(window);
+        expect(screenshot).toHaveBeenCalledWith(window, { path: undefined });
     });
 
     it("screenshots the named window when windowId is supplied", async () => {
@@ -297,7 +408,23 @@ describe("widget.screenshot", () => {
         const id = registerWidget(registry, window);
         screenshot.mockResolvedValueOnce({ data: "x", mimeType: "image/png" });
         await dispatch("widget.screenshot", { windowId: id }, { app: makeApp() as never, registry });
-        expect(screenshot).toHaveBeenCalledWith(window);
+        expect(screenshot).toHaveBeenCalledWith(window, { path: undefined });
+    });
+
+    it("forwards the output path and reports where the capture was saved", async () => {
+        const window = makeWidget();
+        const registry = new WidgetRegistry();
+        const id = registerWidget(registry, window);
+        screenshot.mockResolvedValueOnce({ data: "y", mimeType: "image/png" });
+
+        const result = await dispatch(
+            "widget.screenshot",
+            { windowId: id, path: "/screenshots/gtkx/shot.png" },
+            { app: makeApp() as never, registry },
+        );
+
+        expect(screenshot).toHaveBeenCalledWith(window, { path: "/screenshots/gtkx/shot.png" });
+        expect(result).toEqual({ data: "y", mimeType: "image/png", savedPath: "/screenshots/gtkx/shot.png" });
     });
 
     it("throws when no windows are available and no windowId is supplied", async () => {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -10,10 +10,12 @@
     },
     "devDependencies": {
         "@codspeed/vitest-plugin": "^5.7.1",
+        "@gtkx/cli": "workspace:*",
         "@gtkx/config": "workspace:*",
-        "@gtkx/runtime": "workspace:*",
+        "@gtkx/mcp": "workspace:*",
         "@gtkx/native": "workspace:*",
         "@gtkx/react": "workspace:*",
+        "@gtkx/runtime": "workspace:*",
         "@gtkx/testing": "workspace:*",
         "@gtkx/utils": "workspace:*",
         "@gtkx/vitest": "workspace:*",
@@ -22,7 +24,15 @@
     "nx": {
         "targets": {
             "test:asan": {
-                "cache": false,
+                "cache": true,
+                "inputs": [
+                    "default",
+                    "^default",
+                    "{workspaceRoot}/rust-toolchain.toml",
+                    "{workspaceRoot}/scripts/asan-e2e.ts",
+                    "{workspaceRoot}/scripts/rust-nightly.ts"
+                ],
+                "outputs": [],
                 "dependsOn": [
                     "gtkx:codegen",
                     "@gtkx/vitest:build",

--- a/packages/e2e/tests/mcp/tree-expander-click.test.tsx
+++ b/packages/e2e/tests/mcp/tree-expander-click.test.tsx
@@ -1,0 +1,146 @@
+import type * as GObject from "@gtkx/gi/gobject";
+import { dispatch, WidgetRegistry } from "@gtkx/cli/internal";
+import * as Gtk from "@gtkx/gi/gtk";
+import { GtkButton, GtkListView, GtkNoSelection, GtkSignalListItemFactory } from "@gtkx/jsx/gtk";
+import { render, screen, waitFor } from "@gtkx/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applicationProps } from "../helpers/application.js";
+
+type TreeProps = { tree: Gtk.TreeListModel };
+
+const EXPANDABLE_ROOT = "alpha";
+const LEAF_ROOT = "beta";
+const ROOT_NAMES = [EXPANDABLE_ROOT, LEAF_ROOT];
+const CHILD_NAMES = ["alpha-child"];
+const boundExpanders: Map<string, Gtk.TreeExpander> = new Map();
+
+const childModelFor = (item: GObject.Object): Gtk.StringList | null =>
+    item instanceof Gtk.StringObject && item.getString() === EXPANDABLE_ROOT ? Gtk.StringList.new(CHILD_NAMES) : null;
+
+const newTree = (): Gtk.TreeListModel =>
+    Gtk.TreeListModel.new(Gtk.StringList.new(ROOT_NAMES), false, false, childModelFor);
+
+const getCell = (object: GObject.Object): Gtk.TreeExpander | null => {
+    const child = object instanceof Gtk.ListItem ? object.getChild() : null;
+
+    return child instanceof Gtk.TreeExpander ? child : null;
+};
+
+const getRow = (object: GObject.Object): Gtk.TreeListRow | null => {
+    const item = object instanceof Gtk.ListItem ? object.getItem() : null;
+
+    return item instanceof Gtk.TreeListRow ? item : null;
+};
+
+const getRowText = (row: Gtk.TreeListRow): string => {
+    const item = row.getItem();
+
+    return item instanceof Gtk.StringObject ? item.getString() : "";
+};
+
+const setCellText = (expander: Gtk.TreeExpander, text: string): void => {
+    const label = expander.getChild();
+
+    if (label instanceof Gtk.Label) {
+        label.setLabel(text);
+    }
+};
+
+const handleSetup = (object: GObject.Object): void => {
+    if (!(object instanceof Gtk.ListItem)) {
+        return;
+    }
+
+    const expander = new Gtk.TreeExpander();
+    expander.setChild(new Gtk.Label());
+    object.setChild(expander);
+};
+
+const handleBind = (object: GObject.Object): void => {
+    const expander = getCell(object);
+    const row = getRow(object);
+
+    if (expander === null || row === null) {
+        return;
+    }
+
+    const text = getRowText(row);
+    expander.setListRow(row);
+    setCellText(expander, text);
+    boundExpanders.set(text, expander);
+};
+
+const Tree = ({ tree }: TreeProps) => (
+    <GtkListView
+        model={<GtkNoSelection model={tree} />}
+        factory={<GtkSignalListItemFactory onSetup={handleSetup} onBind={handleBind} />}
+    />
+);
+
+const clickThroughMcp = async (widget: Gtk.Widget): Promise<void> => {
+    const registry = new WidgetRegistry();
+    registry.refresh();
+    registry.register(widget);
+    const app = new Gtk.Application(applicationProps());
+    await dispatch("widget.click", { widgetId: registry.getOrCreateId(widget) }, { app, registry });
+};
+
+const findBoundExpander = async (text: string): Promise<Gtk.TreeExpander> => {
+    await waitFor(() => {
+        expect(boundExpanders.has(text)).toBe(true);
+    });
+
+    const expander = boundExpanders.get(text);
+
+    if (expander === undefined) {
+        throw new Error(`No tree expander was bound for "${text}"`);
+    }
+
+    return expander;
+};
+
+beforeEach(() => {
+    boundExpanders.clear();
+});
+
+describe("widget.click on a tree expander", () => {
+    it("expands the row behind the expander instead of acting on the enclosing list row", async () => {
+        const tree = newTree();
+        await render(<Tree tree={tree} />);
+        const expander = await findBoundExpander(EXPANDABLE_ROOT);
+        expect(expander.getListRow()?.getExpanded()).toBe(false);
+        expect(tree.getNItems()).toBe(ROOT_NAMES.length);
+        await clickThroughMcp(expander);
+        expect(expander.getListRow()?.getExpanded()).toBe(true);
+        expect(tree.getNItems()).toBe(ROOT_NAMES.length + CHILD_NAMES.length);
+    });
+
+    it("collapses the row again on a second click", async () => {
+        const tree = newTree();
+        await render(<Tree tree={tree} />);
+        const expander = await findBoundExpander(EXPANDABLE_ROOT);
+        await clickThroughMcp(expander);
+        await clickThroughMcp(expander);
+        expect(expander.getListRow()?.getExpanded()).toBe(false);
+        expect(tree.getNItems()).toBe(ROOT_NAMES.length);
+    });
+
+    it("leaves a row that has no children unexpanded", async () => {
+        const tree = newTree();
+        await render(<Tree tree={tree} />);
+        const expander = await findBoundExpander(LEAF_ROOT);
+        await clickThroughMcp(expander);
+        expect(expander.getListRow()?.getExpanded()).toBe(false);
+        expect(tree.getNItems()).toBe(ROOT_NAMES.length);
+    });
+});
+
+describe("widget.click on widgets that are not tree expanders", () => {
+    it("still delivers a button click", async () => {
+        const handleClicked = vi.fn();
+        await render(<GtkButton label="Press" onClicked={handleClicked} />);
+        const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON);
+        await clickThroughMcp(button);
+        expect(handleClicked).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/e2e/tests/mcp/widget-properties.test.tsx
+++ b/packages/e2e/tests/mcp/widget-properties.test.tsx
@@ -1,0 +1,269 @@
+import type { SerializedProperty, SerializedWidget } from "@gtkx/mcp/internal";
+import type { ReactNode, RefObject } from "react";
+import { dispatch, WidgetRegistry } from "@gtkx/cli/internal";
+import * as Adw from "@gtkx/gi/adw";
+import * as Gio from "@gtkx/gi/gio";
+import * as Gtk from "@gtkx/gi/gtk";
+import {
+    AdwApplication,
+    AdwApplicationWindow,
+    AdwBreakpoint,
+    AdwNavigationPage,
+    AdwNavigationSplitView,
+} from "@gtkx/jsx/adw";
+import { GtkBox, GtkEntry, GtkLabel } from "@gtkx/jsx/gtk";
+import { ErrorCode, ProtocolError } from "@gtkx/mcp/internal";
+import { rootElement } from "@gtkx/react";
+import { render, waitFor } from "@gtkx/testing";
+import { kebabCase } from "@gtkx/utils";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { applicationProps } from "../helpers/application.js";
+import { createAppIdFactory } from "../helpers/unique-name.js";
+
+type WidgetProps = SerializedWidget & { properties?: Record<string, SerializedProperty> };
+type Probe = { registry: WidgetRegistry; read: (properties?: string[]) => Promise<WidgetProps> };
+
+const APP_FLAGS = Gio.ApplicationFlags.NON_UNIQUE;
+const uniqueAppId = createAppIdFactory("org.gtkx.mcpprops");
+const WIDE_CONDITION = "max-width: 100000px";
+
+const renderAdw = (element: ReactNode) =>
+    render(
+        <AdwApplication applicationId={uniqueAppId()} flags={APP_FLAGS}>
+            {element}
+        </AdwApplication>,
+        { container: rootElement },
+    );
+
+const getWidget = <T extends Gtk.Widget>(ref: RefObject<T | null>): T => {
+    if (ref.current === null) {
+        throw new Error("Expected the widget to be rendered");
+    }
+
+    return ref.current;
+};
+
+const probeFor = (widget: Gtk.Widget): Probe => {
+    const registry = new WidgetRegistry();
+    registry.refresh();
+    registry.register(widget);
+    const app = new Gtk.Application(applicationProps());
+    const widgetId = registry.getOrCreateId(widget);
+
+    return {
+        registry,
+        read: async (properties) =>
+            await dispatch(
+                "widget.getProps",
+                properties === undefined ? { widgetId } : { widgetId, properties },
+                { app, registry },
+            ) as WidgetProps,
+    };
+};
+
+const getHint = (error: unknown): string => {
+    if (!(error instanceof ProtocolError)) {
+        throw new Error(`Expected a ProtocolError, got ${String(error)}`);
+    }
+
+    const data = error.data;
+
+    return typeof data === "object" && data !== null && "hint" in data ? String(data.hint) : "";
+};
+
+const getFailure = async (read: Promise<unknown>): Promise<unknown> => {
+    try {
+        await read;
+    } catch (error) {
+        return error;
+    }
+
+    throw new Error("Expected the read to fail");
+};
+
+const readProperty = async (widget: Gtk.Widget, name: string): Promise<SerializedProperty> => {
+    const result = await probeFor(widget).read([name]);
+    const property = result.properties?.[kebabCase(name)];
+
+    if (property === undefined) {
+        throw new Error(`Expected property "${name}" in ${JSON.stringify(result.properties)}`);
+    }
+
+    return property;
+};
+
+describe("widget.getProps summary", () => {
+    it("returns the fixed summary alone when no properties are asked for", async () => {
+        const ref = createRef<Gtk.Label>();
+        await render(<GtkLabel ref={ref}>Summary</GtkLabel>);
+        const result = await probeFor(getWidget(ref)).read();
+        expect(result.text).toBe("Summary");
+        expect(result.role).toBe("label");
+        expect(result.properties).toBeUndefined();
+    });
+
+    it("keeps the summary alongside the properties that were asked for", async () => {
+        const ref = createRef<Gtk.Label>();
+        await render(<GtkLabel ref={ref}>Both</GtkLabel>);
+        const result = await probeFor(getWidget(ref)).read(["label"]);
+        expect(result.text).toBe("Both");
+        expect(result.children).toEqual([]);
+        expect(result.properties?.label).toEqual({ type: "gchararray", value: "Both" });
+    });
+});
+
+describe("widget.getProps property values", () => {
+    it("reads a string property", async () => {
+        const ref = createRef<Gtk.Label>();
+        await render(<GtkLabel ref={ref}>Hello</GtkLabel>);
+        expect(await readProperty(getWidget(ref), "label")).toEqual({ type: "gchararray", value: "Hello" });
+    });
+
+    it("reads a boolean property under either spelling", async () => {
+        const ref = createRef<Gtk.Label>();
+        await render(<GtkLabel ref={ref} useMarkup={true}>Marked</GtkLabel>);
+        const kebab = await readProperty(getWidget(ref), "use-markup");
+        const camel = await readProperty(getWidget(ref), "useMarkup");
+        expect(kebab).toEqual({ type: "gboolean", value: true });
+        expect(camel).toEqual(kebab);
+    });
+
+    it("reads an enum property as its value name", async () => {
+        const ref = createRef<Gtk.Box>();
+        await render(<GtkBox ref={ref} orientation={Gtk.Orientation.VERTICAL} />);
+
+        expect(await readProperty(getWidget(ref), "orientation")).toEqual({
+            type: "GtkOrientation",
+            value: "GTK_ORIENTATION_VERTICAL",
+        });
+    });
+
+    it("reads a flags property as its value names", async () => {
+        const ref = createRef<Gtk.Entry>();
+        const hintValue = Gtk.InputHints.SPELLCHECK | Gtk.InputHints.LOWERCASE;
+        await render(<GtkEntry ref={ref} inputHints={hintValue} />);
+        const hints = await readProperty(getWidget(ref), "input-hints");
+        expect(hints.type).toBe("GtkInputHints");
+        expect(String(hints.value)).toContain("GTK_INPUT_HINT_SPELLCHECK");
+        expect(String(hints.value)).toContain("GTK_INPUT_HINT_LOWERCASE");
+    });
+});
+
+describe("widget.getProps array and object property values", () => {
+    it("reads a string array property", async () => {
+        const ref = createRef<Gtk.Label>();
+        await render(<GtkLabel ref={ref} cssClasses={["dim-label", "heading"]}>Classy</GtkLabel>);
+
+        expect(await readProperty(getWidget(ref), "css-classes")).toEqual({
+            type: "GStrv",
+            value: ["dim-label", "heading"],
+        });
+    });
+
+    it("reads a widget-valued property as its type and a resolvable widget id", async () => {
+        const boxRef = createRef<Gtk.Box>();
+        const labelRef = createRef<Gtk.Label>();
+
+        await render(
+            <GtkBox ref={boxRef}>
+                <GtkLabel ref={labelRef}>Child</GtkLabel>
+            </GtkBox>,
+        );
+
+        const probe = probeFor(getWidget(labelRef));
+        const result = await probe.read(["parent"]);
+        const parent = result.properties?.parent;
+        expect(parent?.type).toBe("GtkWidget");
+        expect(parent?.value).toBe("GtkBox");
+        expect(probe.registry.get(parent?.widgetId ?? "")).toBe(getWidget(boxRef));
+    });
+});
+
+describe("widget.getProps on an unknown property", () => {
+    it("names the widget type and the property", async () => {
+        const ref = createRef<Gtk.Label>();
+        await render(<GtkLabel ref={ref}>Nope</GtkLabel>);
+        const failure = probeFor(getWidget(ref)).read(["collapsed"]);
+        await expect(failure).rejects.toMatchObject({ code: ErrorCode.PROPERTY_NOT_FOUND });
+        await expect(failure).rejects.toThrow(/GtkLabel has no readable property 'collapsed'/);
+    });
+
+    it("lists the readable properties as a hint", async () => {
+        const ref = createRef<Gtk.Label>();
+        await render(<GtkLabel ref={ref}>Nope</GtkLabel>);
+        const failure = await getFailure(probeFor(getWidget(ref)).read(["collapsed"]));
+        expect(getHint(failure)).toContain("use-markup");
+    });
+});
+
+describe("widget.getProps on adaptive Adwaita widgets", () => {
+    it("reads collapsed on a navigation split view", async () => {
+        const viewRef = createRef<Adw.NavigationSplitView>();
+
+        await renderAdw(
+            <AdwApplicationWindow>
+                <AdwNavigationSplitView ref={viewRef} collapsed={true}>
+                    <AdwNavigationPage tag="content" title="Content">
+                        <GtkLabel>Content</GtkLabel>
+                    </AdwNavigationPage>
+                </AdwNavigationSplitView>
+            </AdwApplicationWindow>,
+        );
+
+        expect(await readProperty(getWidget(viewRef), "collapsed")).toEqual({ type: "gboolean", value: true });
+    });
+
+    it("reads collapsed as false when the panes stay side by side", async () => {
+        const viewRef = createRef<Adw.NavigationSplitView>();
+
+        await renderAdw(
+            <AdwApplicationWindow>
+                <AdwNavigationSplitView ref={viewRef} collapsed={false}>
+                    <AdwNavigationPage tag="content" title="Content">
+                        <GtkLabel>Content</GtkLabel>
+                    </AdwNavigationPage>
+                </AdwNavigationSplitView>
+            </AdwApplicationWindow>,
+        );
+
+        expect(await readProperty(getWidget(viewRef), "collapsed")).toEqual({ type: "gboolean", value: false });
+    });
+});
+
+describe("widget.getProps on an Adwaita application window", () => {
+    it("reads current-breakpoint as the breakpoint that applied", async () => {
+        const windowRef = createRef<Adw.ApplicationWindow>();
+
+        await renderAdw(
+            <AdwApplicationWindow
+                ref={windowRef}
+                breakpoints={<AdwBreakpoint condition={Adw.BreakpointCondition.parse(WIDE_CONDITION)} />}
+            >
+                <GtkLabel>Adaptive</GtkLabel>
+            </AdwApplicationWindow>,
+        );
+
+        await waitFor(async () => {
+            expect(await readProperty(getWidget(windowRef), "currentBreakpoint")).toEqual({
+                type: "AdwBreakpoint",
+                value: "AdwBreakpoint",
+            });
+        });
+    });
+
+    it("reads current-breakpoint as null when no breakpoint applies", async () => {
+        const windowRef = createRef<Adw.ApplicationWindow>();
+
+        await renderAdw(
+            <AdwApplicationWindow ref={windowRef}>
+                <GtkLabel>Static</GtkLabel>
+            </AdwApplicationWindow>,
+        );
+
+        expect(await readProperty(getWidget(windowRef), "current-breakpoint")).toEqual({
+            type: "AdwBreakpoint",
+            value: null,
+        });
+    });
+});

--- a/packages/mcp/src/internal.ts
+++ b/packages/mcp/src/internal.ts
@@ -3,12 +3,14 @@ export {
     invalidRequestError,
     methodNotFoundError,
     ProtocolError,
+    propertyNotFoundError,
     widgetNotFoundError,
 } from "./protocol/errors.js";
 export {
     DEFAULT_SOCKET_PATH,
     type ParamsSchema,
     type Request,
+    type SerializedProperty,
     type SerializedWidget,
     type ServerInitiatedMethod,
     type ServerRequestParams,

--- a/packages/mcp/src/protocol/errors.ts
+++ b/packages/mcp/src/protocol/errors.ts
@@ -9,6 +9,7 @@ const ErrorCode = {
     REQUEST_TIMEOUT: 1005,
     INVALID_REQUEST: 1006,
     METHOD_NOT_FOUND: 1007,
+    PROPERTY_NOT_FOUND: 1008,
 } as const;
 
 function isErrorCode(code: number): code is ErrorCode {
@@ -37,6 +38,18 @@ function connectionWriteFailedError(applicationId: string): ProtocolError {
 
 function widgetNotFoundError(widgetId: string): ProtocolError {
     return new ProtocolError(ErrorCode.WIDGET_NOT_FOUND, `Widget '${widgetId}' not found`, { widgetId });
+}
+
+function propertyNotFoundError(widgetType: string, property: string, readableProperties: string[]): ProtocolError {
+    return new ProtocolError(
+        ErrorCode.PROPERTY_NOT_FOUND,
+        `${widgetType} has no readable property '${property}'`,
+        {
+            widgetType,
+            property,
+            hint: `Readable properties of ${widgetType}: ${readableProperties.join(", ")}`,
+        },
+    );
 }
 
 function requestTimeoutError(timeout: number): ProtocolError {
@@ -78,6 +91,7 @@ export {
     appNotFoundError,
     connectionWriteFailedError,
     widgetNotFoundError,
+    propertyNotFoundError,
     requestTimeoutError,
     invalidRequestError,
     methodNotFoundError,

--- a/packages/mcp/src/protocol/schemas.ts
+++ b/packages/mcp/src/protocol/schemas.ts
@@ -17,6 +17,13 @@ type SerializedWidget = {
     children: SerializedWidget[];
 };
 
+type SerializedProperty = {
+    type: string;
+    value: string | number | boolean | string[] | null;
+    widgetId?: string;
+    note?: string;
+};
+
 type AppInfo = {
     applicationId: string;
     pid: number;
@@ -81,6 +88,13 @@ const widgetIdParams: z.ZodObject<{ widgetId: z.ZodString }> = z.object({
     widgetId: z.string(),
 });
 
+const widgetPropsParams: z.ZodObject<
+    { widgetId: z.ZodString; properties: z.ZodOptional<z.ZodArray<z.ZodString>> }
+> = z.object({
+    widgetId: z.string(),
+    properties: z.array(z.string()).optional(),
+});
+
 const treeParams: z.ZodObject<
     { rootId: z.ZodOptional<z.ZodString>; maxDepth: z.ZodOptional<z.ZodNumber> }
 > = z.object({
@@ -127,7 +141,7 @@ const ServerRequestParamsSchemas: {
     "app.getWindows": typeof emptyParams;
     "widget.getTree": typeof treeParams;
     "widget.query": typeof queryParams;
-    "widget.getProps": typeof widgetIdParams;
+    "widget.getProps": typeof widgetPropsParams;
     "widget.click": typeof widgetIdParams;
     "widget.type": typeof typeParams;
     "widget.fireEvent": typeof fireEventParams;
@@ -136,7 +150,7 @@ const ServerRequestParamsSchemas: {
     "app.getWindows": emptyParams,
     "widget.getTree": treeParams,
     "widget.query": queryParams,
-    "widget.getProps": widgetIdParams,
+    "widget.getProps": widgetPropsParams,
     "widget.click": widgetIdParams,
     "widget.type": typeParams,
     "widget.fireEvent": fireEventParams,
@@ -154,8 +168,8 @@ export {
     ResponseSchema,
     RegisterParamsSchema,
     widgetIdParams,
+    widgetPropsParams,
     treeParams,
-    queryOptionsSchema,
     queryParams,
     typeParams,
     fireEventParams,
@@ -165,6 +179,7 @@ export {
     type Request,
     type Response,
     type SerializedWidget,
+    type SerializedProperty,
     type AppInfo,
     type ServerRequestParams,
     type ParamsSchema,

--- a/packages/mcp/src/reference.ts
+++ b/packages/mcp/src/reference.ts
@@ -1,9 +1,9 @@
 import { type ApiReference, type ApiSymbol, loadApiReference, resolveGirPath, resolveLibraries } from "@gtkx/codegen";
 import { loadConfig } from "@gtkx/config";
 import { type McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ErrorCode, McpError, type ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
-import { statSync } from "node:fs";
-import { resolve } from "node:path";
+import { type CallToolResult, ErrorCode, McpError, type ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import { existsSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
 import { defineTool, textContent, textError, type Tool, type ToolArgs } from "./tool.js";
 
@@ -12,8 +12,26 @@ type ReferenceApi = Pick<
     "lookup" | "namespaceOverview" | "namespaces" | "overview" | "search" | "symbolNames"
 >;
 
+type ProjectSource = "argument" | "workingDirectory" | "app";
+
+type ResolvedProject = {
+    root: string;
+    source: ProjectSource;
+};
+
+type ScopedReference = ResolvedProject & {
+    reference: ReferenceApi;
+};
+
+type ReferenceProviderOptions = {
+    getAppRoot: () => string | undefined;
+    getWorkingDirectory?: () => string;
+};
+
 type ReferenceProvider = {
-    get(): Promise<ReferenceApi>;
+    get(projectRoot?: string): Promise<ScopedReference>;
+    load(project: ResolvedProject): Promise<ScopedReference>;
+    resolve(projectRoot?: string): ResolvedProject;
 };
 
 type WatchedFile = {
@@ -24,6 +42,7 @@ type WatchedFile = {
 
 type LoadedReference = {
     reference: ApiReference;
+    root: string;
     watched: WatchedFile[];
 };
 
@@ -39,6 +58,13 @@ type ResourceServer = Pick<McpServer, "registerResource">;
 
 const FRESHNESS_INTERVAL_MS = 2000;
 const FAILURE_RETRY_MS = 5000;
+const CONFIG_EXTENSIONS = ["ts", "mts", "cts", "js", "mjs", "cjs", "json"];
+
+const PROJECT_SOURCE_LABELS: Record<ProjectSource, string> = {
+    argument: "requested with `projectRoot`",
+    workingDirectory: "found from the working directory",
+    app: "taken from a connected app; pass `projectRoot` to document another project",
+};
 
 const SYMBOL_KIND = z.enum([
     "element",
@@ -56,7 +82,17 @@ const SYMBOL_DESCRIPTION =
     "Qualified symbol name (`Gtk.Button`, `Gtk.Orientation`, `GLib.idleAdd`), JSX element name (`GtkButton`), " +
     "or bare symbol name when unambiguous (`Button`).";
 
+const PROJECT_ROOT_DESCRIPTION =
+    "Directory of the GTKX project whose bindings to document, absolute or relative to the working directory. " +
+    "Any directory inside the project works; its `gtkx.config.ts` decides the documented libraries. Omit to use " +
+    "the project containing the working directory, falling back to a connected app's project.";
+
+const projectRootShape = {
+    projectRoot: z.string().optional().describe(PROJECT_ROOT_DESCRIPTION),
+};
+
 const listApiShape = {
+    ...projectRootShape,
     namespace: z
         .string()
         .optional()
@@ -64,6 +100,7 @@ const listApiShape = {
 };
 
 const searchApiShape = {
+    ...projectRootShape,
     query: z.string().describe("Case-insensitive substring of a symbol name, e.g. `headerbar` or `orientation`."),
     namespace: z.string().optional().describe("Restrict matches to one namespace (e.g. `Gtk`)."),
     kind: SYMBOL_KIND.optional().describe("Restrict matches to one symbol kind."),
@@ -71,6 +108,7 @@ const searchApiShape = {
 };
 
 const apiDocsShape = {
+    ...projectRootShape,
     symbol: z.string().describe(SYMBOL_DESCRIPTION),
     kind: SYMBOL_KIND.optional().describe("Disambiguate when several kinds share the symbol name."),
 };
@@ -92,13 +130,55 @@ const isFresh = (loaded: LoadedReference): boolean =>
         return current.mtimeMs === file.mtimeMs && current.size === file.size;
     });
 
-const loadReference = async (root: string): Promise<LoadedReference> => {
-    const { config, configFile } = await loadConfig(root);
+const hasConfigFile = (directory: string): boolean =>
+    CONFIG_EXTENSIONS.some((extension) => existsSync(join(directory, `gtkx.config.${extension}`)));
+
+const findProjectRoot = (start: string): string | undefined => {
+    const current = resolve(start);
+    const parent = dirname(current);
+
+    if (hasConfigFile(current)) {
+        return current;
+    }
+
+    return parent === current ? undefined : findProjectRoot(parent);
+};
+
+const projectAt = (candidate: string, source: ProjectSource): ResolvedProject => ({
+    root: findProjectRoot(candidate) ?? resolve(candidate),
+    source,
+});
+
+const resolveProject = (
+    workingDirectory: string,
+    getAppRoot: () => string | undefined,
+    projectRoot: string | undefined,
+): ResolvedProject => {
+    if (projectRoot !== undefined) {
+        return projectAt(projectRoot, "argument");
+    }
+
+    const discovered = findProjectRoot(workingDirectory);
+
+    if (discovered !== undefined) {
+        return { root: discovered, source: "workingDirectory" };
+    }
+
+    const appRoot = getAppRoot();
+
+    return appRoot === undefined
+        ? { root: resolve(workingDirectory), source: "workingDirectory" }
+        : projectAt(appRoot, "app");
+};
+
+const loadReference = async (requestedRoot: string): Promise<LoadedReference> => {
+    const { config, configFile, root } = await loadConfig(requestedRoot);
 
     if (config.codegen === false) {
         throw new Error(
             `codegen is disabled for the project at ${root}, so there are no generated bindings to document. ` +
-            "Remove `codegen: false` from gtkx.config.ts to use the API reference.",
+            "Remove `codegen: false` from gtkx.config.ts to use the API reference, or point the `projectRoot` " +
+            "argument at another project.",
         );
     }
 
@@ -116,7 +196,7 @@ const loadReference = async (root: string): Promise<LoadedReference> => {
     const reference = loadApiReference({ libraries, girPath });
     const watched = [watchFile(resolve(root, configFile)), ...reference.girFiles.map((file) => watchFile(file))];
 
-    return { reference, watched };
+    return { reference, root, watched };
 };
 
 const markFailed = async (entry: CacheEntry): Promise<void> => {
@@ -150,31 +230,67 @@ const revalidate = (cache: ReferenceCache, root: string, entry: CacheEntry): Cac
     return current === undefined || current === entry ? startLoad(cache, root) : current;
 };
 
-const currentReference = async (cache: ReferenceCache, root: string): Promise<ReferenceApi> => {
+const currentReference = async (cache: ReferenceCache, root: string): Promise<LoadedReference> => {
     const entry = resolveEntry(cache, root);
     const loaded = await entry.pending;
 
     if (Date.now() - entry.verifiedAt < FRESHNESS_INTERVAL_MS) {
-        return loaded.reference;
+        return loaded;
     }
 
     if (isFresh(loaded)) {
         entry.verifiedAt = Date.now();
 
-        return loaded.reference;
+        return loaded;
     }
 
-    const revalidated = await revalidate(cache, root, entry).pending;
-
-    return revalidated.reference;
+    return revalidate(cache, root, entry).pending;
 };
 
-const createReferenceProvider = (resolveRoot: () => string): ReferenceProvider => {
-    const cache: ReferenceCache = new Map();
+const defaultWorkingDirectory = (): string => process.cwd();
 
-    return {
-        get: () => currentReference(cache, resolve(resolveRoot())),
+const createReferenceProvider = (options: ReferenceProviderOptions): ReferenceProvider => {
+    const cache: ReferenceCache = new Map();
+    const getWorkingDirectory = options.getWorkingDirectory ?? defaultWorkingDirectory;
+
+    const resolve = (projectRoot?: string): ResolvedProject =>
+        resolveProject(getWorkingDirectory(), options.getAppRoot, projectRoot);
+
+    const load = async (project: ResolvedProject): Promise<ScopedReference> => {
+        const loaded = await currentReference(cache, project.root);
+
+        return { reference: loaded.reference, root: loaded.root, source: project.source };
     };
+
+    const get = (projectRoot?: string): Promise<ScopedReference> => load(resolve(projectRoot));
+
+    return { get, load, resolve };
+};
+
+const projectNote = (project: ResolvedProject): string =>
+    `Project: ${project.root} (${PROJECT_SOURCE_LABELS[project.source]})`;
+
+const withProjectNote = (result: CallToolResult, note: string): CallToolResult => ({
+    ...result,
+    content: [...result.content, { type: "text", text: note }],
+});
+
+const scopedResult = async (
+    provider: ReferenceProvider,
+    projectRoot: string | undefined,
+    render: (reference: ReferenceApi) => CallToolResult,
+): Promise<CallToolResult> => {
+    const resolved = provider.resolve(projectRoot);
+
+    try {
+        const scoped = await provider.load(resolved);
+
+        return withProjectNote(render(scoped.reference), projectNote(scoped));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        return withProjectNote(textError(message), projectNote(resolved));
+    }
 };
 
 const formatCandidates = (candidates: ApiSymbol[]): string =>
@@ -198,6 +314,52 @@ const buildSearchOptions = (args: ToolArgs<typeof searchApiShape>): SearchOption
     return options;
 };
 
+const listApiResult = (reference: ReferenceApi, namespace: string | undefined): CallToolResult => {
+    if (namespace === undefined) {
+        return textContent(reference.overview());
+    }
+
+    const overview = reference.namespaceOverview(namespace);
+
+    if (overview === undefined) {
+        const names = reference
+            .namespaces()
+            .map((summary) => summary.name)
+            .join(", ");
+
+        return textError(`Unknown namespace "${namespace}". Available namespaces: ${names}`);
+    }
+
+    return textContent(overview);
+};
+
+const searchApiResult = (reference: ReferenceApi, args: ToolArgs<typeof searchApiShape>): CallToolResult => {
+    const results = reference.search(buildSearchOptions(args));
+
+    if (results.length === 0) {
+        return textContent(`No symbols matched "${args.query}". Try a shorter substring or \`gtkx_list_api\`.`);
+    }
+
+    return textContent(JSON.stringify(results, null, 2));
+};
+
+const apiDocsResult = (reference: ReferenceApi, args: ToolArgs<typeof apiDocsShape>): CallToolResult => {
+    const result = reference.lookup(args.symbol, args.kind);
+
+    if (result.outcome === "notFound") {
+        return textError(`No symbol named "${args.symbol}". Use \`gtkx_search_api\` to find the right name.`);
+    }
+
+    if (result.outcome === "ambiguous") {
+        return textError(
+            `"${args.symbol}" matches several symbols. Pass a qualified name or a kind:\n` +
+            formatCandidates(result.candidates),
+        );
+    }
+
+    return textContent(result.markdown);
+};
+
 const listApiTool = (provider: ReferenceProvider): Tool =>
     defineTool({
         name: "gtkx_list_api",
@@ -207,26 +369,8 @@ const listApiTool = (provider: ReferenceProvider): Tool =>
             "List the project's generated GTK4 bindings API (`@gtkx/gi` and `@gtkx/jsx`). Without a namespace, " +
             "returns every namespace with symbol counts; with a namespace, lists all of its symbols grouped by kind.",
         inputSchema: listApiShape,
-        handler: async ({ namespace }) => {
-            const reference = await provider.get();
-
-            if (namespace === undefined) {
-                return textContent(reference.overview());
-            }
-
-            const overview = reference.namespaceOverview(namespace);
-
-            if (overview === undefined) {
-                const names = reference
-                    .namespaces()
-                    .map((summary) => summary.name)
-                    .join(", ");
-
-                return textError(`Unknown namespace "${namespace}". Available namespaces: ${names}`);
-            }
-
-            return textContent(overview);
-        },
+        handler: ({ namespace, projectRoot }) =>
+            scopedResult(provider, projectRoot, (reference) => listApiResult(reference, namespace)),
     });
 
 const searchApiTool = (provider: ReferenceProvider): Tool =>
@@ -238,16 +382,7 @@ const searchApiTool = (provider: ReferenceProvider): Tool =>
             "Search the project's generated GTK4 bindings API by symbol name. Returns matching symbols with " +
             "their namespace, kind, and a one-line summary; fetch full pages with `gtkx_get_api_docs`.",
         inputSchema: searchApiShape,
-        handler: async (args) => {
-            const reference = await provider.get();
-            const results = reference.search(buildSearchOptions(args));
-
-            if (results.length === 0) {
-                return textContent(`No symbols matched "${args.query}". Try a shorter substring or \`gtkx_list_api\`.`);
-            }
-
-            return textContent(JSON.stringify(results, null, 2));
-        },
+        handler: (args) => scopedResult(provider, args.projectRoot, (reference) => searchApiResult(reference, args)),
     });
 
 const getApiDocsTool = (provider: ReferenceProvider): Tool =>
@@ -260,23 +395,7 @@ const getApiDocsTool = (provider: ReferenceProvider): Tool =>
             "(props, signals, methods) or `@gtkx/gi` classes, interfaces, records, enums, callbacks, aliases, " +
             "functions, and constants.",
         inputSchema: apiDocsShape,
-        handler: async ({ symbol, kind }) => {
-            const reference = await provider.get();
-            const result = reference.lookup(symbol, kind);
-
-            if (result.outcome === "notFound") {
-                return textError(`No symbol named "${symbol}". Use \`gtkx_search_api\` to find the right name.`);
-            }
-
-            if (result.outcome === "ambiguous") {
-                return textError(
-                    `"${symbol}" matches several symbols. Pass a qualified name or a kind:\n` +
-                    formatCandidates(result.candidates),
-                );
-            }
-
-            return textContent(result.markdown);
-        },
+        handler: (args) => scopedResult(provider, args.projectRoot, (reference) => apiDocsResult(reference, args)),
     });
 
 const buildReferenceTools = (provider: ReferenceProvider): Tool[] => [
@@ -300,28 +419,31 @@ const withLoadFallback = async <T>(load: () => Promise<T>, fallback: T): Promise
     }
 };
 
+const namesStartingWith = (names: string[], value: string): string[] =>
+    names.filter((name) => name.toLowerCase().startsWith(value.toLowerCase()));
+
+const completeNames = (
+    provider: ReferenceProvider,
+    value: string,
+    collect: (reference: ReferenceApi) => string[],
+): Promise<string[]> =>
+    withLoadFallback(async () => {
+        const { reference } = await provider.get();
+
+        return namesStartingWith(collect(reference), value);
+    }, []);
+
 const namespaceCompleter =
     (provider: ReferenceProvider) =>
         (value: string): Promise<string[]> =>
-            withLoadFallback(async () => {
-                const reference = await provider.get();
+            completeNames(provider, value, (reference) => reference.namespaces().map((summary) => summary.name));
 
-                return reference
-                    .namespaces()
-                    .map((summary) => summary.name)
-                    .filter((name) => name.toLowerCase().startsWith(value.toLowerCase()));
-            }, []);
-
-const completeSymbol = async (provider: ReferenceProvider, namespace: string, value: string): Promise<string[]> => {
+const completeSymbol = (provider: ReferenceProvider, namespace: string, value: string): Promise<string[]> => {
     if (namespace.length === 0) {
-        return [];
+        return Promise.resolve([]);
     }
 
-    return withLoadFallback(async () => {
-        const reference = await provider.get();
-
-        return reference.symbolNames(namespace).filter((name) => name.toLowerCase().startsWith(value.toLowerCase()));
-    }, []);
+    return completeNames(provider, value, (reference) => reference.symbolNames(namespace));
 };
 
 const resourceNotFound = (message: string): McpError => new McpError(ErrorCode.InvalidParams, message);
@@ -332,7 +454,7 @@ const symbolPage = async (
     namespace: string,
     symbol: string,
 ): Promise<ReadResourceResult> => {
-    const reference = await provider.get();
+    const { reference } = await provider.get();
     const result = reference.lookup(`${namespace}.${symbol}`);
 
     if (result.outcome === "page") {
@@ -358,7 +480,7 @@ const registerIndexResource = (server: ResourceServer, provider: ReferenceProvid
             mimeType: "text/markdown",
         },
         async (uri) => {
-            const reference = await provider.get();
+            const { reference } = await provider.get();
 
             return markdownResource(uri, reference.overview());
         },
@@ -372,7 +494,7 @@ const registerNamespaceResource = (server: ResourceServer, provider: ReferencePr
             list: () =>
                 withLoadFallback(
                     async () => {
-                        const reference = await provider.get();
+                        const { reference } = await provider.get();
 
                         return {
                             resources: reference.namespaces().map((summary) => ({
@@ -395,7 +517,7 @@ const registerNamespaceResource = (server: ResourceServer, provider: ReferencePr
         },
         async (uri, variables) => {
             const namespace = variableValue(variables.namespace);
-            const reference = await provider.get();
+            const { reference } = await provider.get();
             const overview = reference.namespaceOverview(namespace);
 
             if (overview === undefined) {
@@ -442,4 +564,5 @@ export {
     registerReferenceResources,
     type ReferenceApi,
     type ReferenceProvider,
+    type ResolvedProject,
 };

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -15,6 +15,7 @@ import {
     treeParams,
     typeParams,
     widgetIdParams,
+    widgetPropsParams,
 } from "./protocol/schemas.js";
 import { buildReferenceTools, createReferenceProvider, registerReferenceResources } from "./reference.js";
 import { SocketServer } from "./socket-server.js";
@@ -48,6 +49,14 @@ const applicationIdShape = { applicationId: z.string().optional().describe(APPLI
 const widgetIdShape = {
     ...applicationIdShape,
     widgetId: widgetIdParams.shape.widgetId.describe(WIDGET_ID_DESCRIPTION),
+};
+
+const widgetPropsShape = {
+    ...widgetIdShape,
+    properties: widgetPropsParams.shape.properties.describe(
+        "GObject property names to read as well, in kebab-case or camelCase (\"current-breakpoint\" or " +
+        "\"currentBreakpoint\"). Omit for the summary alone.",
+    ),
 };
 
 const treeShape = {
@@ -175,6 +184,26 @@ const screenshotTool = (appRouter: AppRouter): Tool =>
         },
     });
 
+const widgetPropsTool = (appRouter: AppRouter): Tool =>
+    defineTool({
+        name: "gtkx_get_widget_props",
+        title: "Get widget properties",
+        kind: "readOnly",
+        description:
+            "Get a fixed summary of one widget by ID: type, accessible role, name, text, sensitivity, " +
+            "visibility, CSS classes, and the full subtree of descendant widgets. Pass `properties` to read " +
+            "GObject properties too; each comes back under its canonical kebab-case name as `{type, value}`, " +
+            "where an enum or flags value is its GType value name, a 64-bit integer a decimal string, and an " +
+            "object its GType name plus `widgetId` when it is a widget. Asking for a property the widget does " +
+            "not have fails; a value that cannot be marshalled carries a `note` instead.",
+        inputSchema: widgetPropsShape,
+        handler: async ({ applicationId, ...params }) => {
+            const result = await appRouter.sendToApp(applicationId, "widget.getProps", params);
+
+            return textContent(JSON.stringify(result, null, 2));
+        },
+    });
+
 function buildInspectionTools(appRouter: AppRouter): Tool[] {
     return [
         listAppsTool(appRouter),
@@ -209,21 +238,7 @@ function buildInspectionTools(appRouter: AppRouter): Tool[] {
                 return textContent(JSON.stringify(result, null, 2));
             },
         }),
-        defineTool({
-            name: "gtkx_get_widget_props",
-            title: "Get widget properties",
-            kind: "readOnly",
-            description:
-                "Get a fixed summary of one widget by ID: type, accessible role, name, text, sensitivity, " +
-                "visibility, CSS classes, and the full subtree of descendant widgets. It does not return " +
-                "arbitrary GObject properties.",
-            inputSchema: widgetIdShape,
-            handler: async ({ applicationId, ...params }) => {
-                const result = await appRouter.sendToApp(applicationId, "widget.getProps", params);
-
-                return textContent(JSON.stringify(result, null, 2));
-            },
-        }),
+        widgetPropsTool(appRouter),
         screenshotTool(appRouter),
     ];
 }
@@ -234,7 +249,9 @@ function buildInteractionTools(appRouter: AppRouter): Tool[] {
             name: "gtkx_click",
             title: "Click widget",
             kind: "action",
-            description: "Click a widget. Works with buttons, checkboxes, and other interactive widgets.",
+            description:
+                "Click a widget. Works with buttons, checkboxes, and other interactive widgets. Clicking a " +
+                "tree expander toggles the row's expansion, the same as clicking its arrow.",
             inputSchema: widgetIdShape,
             handler: async ({ applicationId, ...params }) => {
                 await appRouter.sendToApp(applicationId, "widget.click", params);
@@ -261,9 +278,9 @@ function buildInteractionTools(appRouter: AppRouter): Tool[] {
             description: "Emit a GTK4 signal on a widget. Use this for custom interactions.",
             inputSchema: fireEventShape,
             handler: async ({ applicationId, ...params }) => {
-                await appRouter.sendToApp(applicationId, "widget.fireEvent", params);
+                const result = await appRouter.sendToApp(applicationId, "widget.fireEvent", params);
 
-                return textContent("Fired event");
+                return textContent(JSON.stringify(result, null, 2));
             },
         }),
     ];
@@ -290,7 +307,7 @@ const createMcpServer = (options: CreateMcpServerOptions): McpServerHandle => {
     });
 
     const mcpServer = new McpServer({ name: "gtkx-mcp", version: options.version });
-    const referenceProvider = createReferenceProvider(() => appRouter.getProjectRoot() ?? process.cwd());
+    const referenceProvider = createReferenceProvider({ getAppRoot: () => appRouter.getProjectRoot() });
 
     for (const tool of [...buildTools(appRouter), ...buildReferenceTools(referenceProvider)]) {
         registerTool(mcpServer, tool);

--- a/packages/mcp/tests/app-router.test.ts
+++ b/packages/mcp/tests/app-router.test.ts
@@ -19,6 +19,12 @@ type RouterContext = {
     router: AppRouter;
 };
 
+type PingExchange = {
+    conn: TestConnection;
+    promise: Promise<unknown>;
+    sent: Request;
+};
+
 const createdConnections: TestConnection[] = [];
 const ctx = {} as RouterContext;
 
@@ -84,6 +90,13 @@ function onRegistered(router: AppRouter): ReturnType<typeof vi.fn> {
     return listener;
 }
 
+function registerWithRegisterSpy(params: { applicationId: string; pid?: number }): ReturnType<typeof vi.fn> {
+    const onRegister = onRegistered(ctx.router);
+    emitRegister(makeConnection("c1"), params);
+
+    return onRegister;
+}
+
 function registerWithUnregisterSpy(): { conn: TestConnection; onUnregister: ReturnType<typeof vi.fn> } {
     const conn = makeConnection("c1");
     const onUnregister = onUnregistered(ctx.router);
@@ -117,6 +130,13 @@ function registerAppForContext(applicationId: string, connectionId = "c1"): Test
     return conn;
 }
 
+function sendPingRequest(applicationId: string | undefined, params?: unknown): PingExchange {
+    const conn = registerAppForContext("app-a");
+    const promise = ctx.router.sendToApp(applicationId, "ping", params);
+
+    return { conn, promise, sent: lastOutgoingRequest(conn) };
+}
+
 class FakeSocket extends Duplex {
     lines: string[] = [];
 
@@ -139,9 +159,7 @@ describe("AppRouter registration — basics", () => {
 
     it("registers an app and emits appRegistered with its info", () => {
         const { connections, router } = ctx;
-        const conn = makeConnection("c1");
-        const onRegister = onRegistered(router);
-        emitRegister(conn, { applicationId: "app-a", pid: 1234 });
+        const onRegister = registerWithRegisterSpy({ applicationId: "app-a", pid: 1234 });
         expect(onRegister).toHaveBeenCalledWith({ applicationId: "app-a", pid: 1234 });
         expect(router.hasConnectedApps()).toBe(true);
         expect(router.getApps()).toEqual([{ applicationId: "app-a", pid: 1234 }]);
@@ -171,9 +189,7 @@ describe("AppRouter registration — basics", () => {
 
     it("rejects registration with invalid params", () => {
         const { connections, router } = ctx;
-        const conn = makeConnection("c1");
-        const onRegister = onRegistered(router);
-        emitRegister(conn, { applicationId: "app-a" });
+        const onRegister = registerWithRegisterSpy({ applicationId: "app-a" });
         expect(onRegister).not.toHaveBeenCalled();
         expect(router.hasConnectedApps()).toBe(false);
         const response = lastResponse(connections);
@@ -240,10 +256,8 @@ describe("AppRouter getDefaultApp", () => {
     });
 
     it("returns the first registered app", () => {
-        const { router } = ctx;
-        const conn = makeConnection("c1");
-        emitRegister(conn, { applicationId: "app-a", pid: 1 });
-        expect(router.getDefaultApp()?.info.applicationId).toBe("app-a");
+        registerAppForContext("app-a");
+        expect(ctx.router.getDefaultApp()?.info.applicationId).toBe("app-a");
     });
 });
 
@@ -251,11 +265,9 @@ describe("AppRouter waitForApp", () => {
     setupRouterContext();
 
     it("resolves immediately when an app is already registered", async () => {
-        const { router } = ctx;
-        const conn = makeConnection("c1");
-        emitRegister(conn, { applicationId: "app-a", pid: 1 });
+        registerAppForContext("app-a");
 
-        await expect(router.waitForApp()).resolves.toEqual({
+        await expect(ctx.router.waitForApp()).resolves.toEqual({
             applicationId: "app-a",
             pid: 1,
         });
@@ -280,25 +292,19 @@ describe("AppRouter sendToApp — happy paths", () => {
     setupRouterContext();
 
     it("sends a request to the named app and resolves with the response result", async () => {
-        const conn = registerAppForContext("app-a");
-        const promise = ctx.router.sendToApp("app-a", "ping", { hello: "world" });
-        const sent = lastOutgoingRequest(conn);
+        const { conn, promise, sent } = sendPingRequest("app-a", { hello: "world" });
         conn.feed(`${JSON.stringify({ id: sent.id, result: { ok: true } })}\n`);
         await expect(promise).resolves.toEqual({ ok: true });
     });
 
     it("sends to the default app when applicationId is undefined", async () => {
-        const conn = registerAppForContext("app-a");
-        const promise = ctx.router.sendToApp(undefined, "ping");
-        const sent = lastOutgoingRequest(conn);
+        const { conn, promise, sent } = sendPingRequest(undefined);
         conn.feed(`${JSON.stringify({ id: sent.id, result: 42 })}\n`);
         await expect(promise).resolves.toBe(42);
     });
 
     it("ignores responses for unknown request ids", async () => {
-        const conn = registerAppForContext("app-a");
-        const promise = ctx.router.sendToApp("app-a", "ping");
-        const sent = lastOutgoingRequest(conn);
+        const { conn, promise, sent } = sendPingRequest("app-a");
         conn.feed(`${JSON.stringify({ id: "unknown", result: 1 })}\n`);
         conn.feed(`${JSON.stringify({ id: sent.id, result: 2 })}\n`);
         await expect(promise).resolves.toBe(2);
@@ -347,9 +353,7 @@ describe("AppRouter sendToApp — transport errors", () => {
     });
 
     it("rejects with the ProtocolError described by an error response", async () => {
-        const conn = registerAppForContext("app-a");
-        const promise = ctx.router.sendToApp("app-a", "ping");
-        const sent = lastOutgoingRequest(conn);
+        const { conn, promise, sent } = sendPingRequest("app-a");
 
         conn.feed(
             `${JSON.stringify({

--- a/packages/mcp/tests/connection-registry.test.ts
+++ b/packages/mcp/tests/connection-registry.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Message } from "../src/protocol/schemas.js";
-import {
-    collectFirstFrame,
-    connectClient,
-    setupSocketServer,
-    socketCtx,
-    waitForConnection,
-} from "./socket-server-harness.js";
+import { collectFirstFrame, setupSocketServer, socketCtx, startWithConnection } from "./socket-server-harness.js";
 
 describe("ConnectionRegistry", () => {
     describe("ConnectionRegistry send", () => {
@@ -21,14 +15,10 @@ describe("ConnectionRegistry", () => {
         });
 
         it("delivers a message to the connected client", async () => {
-            const { server, socketPath, registry } = socketCtx;
-            await server.start();
-            const connectionPromise = waitForConnection(registry);
-            const client = await connectClient(socketPath);
-            const connection = await connectionPromise;
+            const { client, connection } = await startWithConnection();
 
             const parsed = await collectFirstFrame<Message>(client, () => {
-                registry.send(connection.id, { id: "out-1", result: 42 });
+                socketCtx.registry.send(connection.id, { id: "out-1", result: 42 });
             },
             );
 
@@ -40,11 +30,8 @@ describe("ConnectionRegistry", () => {
         setupSocketServer();
 
         it("rejects in-flight requests and drains the connection when dispose runs", async () => {
-            const { server, socketPath, registry } = socketCtx;
-            await server.start();
-            const connectionPromise = waitForConnection(registry);
-            await connectClient(socketPath);
-            const connection = await connectionPromise;
+            const { registry } = socketCtx;
+            const { connection } = await startWithConnection();
             const pending = connection.send("ping", {}, 5000);
 
             const disconnection: Promise<void> = new Promise((resolve) => {

--- a/packages/mcp/tests/protocol/errors.test.ts
+++ b/packages/mcp/tests/protocol/errors.test.ts
@@ -5,6 +5,7 @@ import {
     invalidRequestError,
     methodNotFoundError,
     noAppConnectedError,
+    propertyNotFoundError,
     ProtocolError,
     requestTimeoutError,
     widgetNotFoundError,
@@ -71,6 +72,24 @@ describe("widgetNotFoundError", () => {
         expect(error.code).toBe(ErrorCode.WIDGET_NOT_FOUND);
         expect(error.message).toContain("widget-123");
         expect(error.data).toEqual({ widgetId: "widget-123" });
+    });
+});
+
+describe("propertyNotFoundError", () => {
+    it("names the widget type and the property", () => {
+        const error = propertyNotFoundError("GtkLabel", "collapsed", ["label", "use-markup"]);
+        expect(error.code).toBe(ErrorCode.PROPERTY_NOT_FOUND);
+        expect(error.message).toBe("GtkLabel has no readable property 'collapsed'");
+    });
+
+    it("hints at the properties that can be read", () => {
+        const error = propertyNotFoundError("GtkLabel", "collapsed", ["label", "use-markup"]);
+
+        expect(error.data).toEqual({
+            widgetType: "GtkLabel",
+            property: "collapsed",
+            hint: "Readable properties of GtkLabel: label, use-markup",
+        });
     });
 });
 

--- a/packages/mcp/tests/protocol/schemas.test.ts
+++ b/packages/mcp/tests/protocol/schemas.test.ts
@@ -22,6 +22,13 @@ describe("ServerRequestParamsSchemas", () => {
         expect(ServerRequestParamsSchemas["widget.getProps"].safeParse({ widgetId: "3" }).success).toBe(true);
     });
 
+    it("makes the widget.getProps property list optional", () => {
+        const schema = ServerRequestParamsSchemas["widget.getProps"];
+        expect(schema.safeParse({ widgetId: "3" }).data?.properties).toBeUndefined();
+        expect(schema.safeParse({ widgetId: "3", properties: ["collapsed"] }).success).toBe(true);
+        expect(schema.safeParse({ widgetId: "3", properties: "collapsed" }).success).toBe(false);
+    });
+
     it("accepts an empty payload for app.getWindows", () => {
         expect(ServerRequestParamsSchemas["app.getWindows"].safeParse({}).success).toBe(true);
     });

--- a/packages/mcp/tests/reference.test.ts
+++ b/packages/mcp/tests/reference.test.ts
@@ -1,7 +1,7 @@
 import type { ApiLookupResult, ApiReference, ApiSymbol } from "@gtkx/codegen";
-import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +12,7 @@ import {
     type ReferenceApi,
     type ReferenceProvider,
     registerReferenceResources,
+    type ResolvedProject,
 } from "../src/reference.js";
 
 type FakeReference = ReferenceApi & Pick<ApiReference, "girFiles">;
@@ -22,6 +23,23 @@ type RegisteredResource = {
     uriOrTemplate: string | ResourceTemplate;
     config: { mimeType?: string };
     read: ReadCallback;
+};
+
+type ProjectDirs = {
+    explicit: string;
+    app: string;
+    workingDirectory: string;
+    nested: string;
+    elsewhere: string;
+};
+
+type ScopingCase = {
+    name: string;
+    workingDirectory: keyof ProjectDirs;
+    appRoot?: keyof ProjectDirs;
+    projectRoot?: keyof ProjectDirs;
+    expectedRoot: keyof ProjectDirs;
+    expectedSource: "argument" | "workingDirectory" | "app";
 };
 
 const { loadApiReferenceMock, loadConfigMock, resolveGirPathMock, resolveLibrariesMock } = vi.hoisted(() => ({
@@ -51,7 +69,53 @@ const fakeReference: FakeReference = {
     lookup: (query): ApiLookupResult => lookupFake(query),
 };
 
-const provider: ReferenceProvider = { get: () => Promise.resolve(fakeReference) };
+const provider: ReferenceProvider = {
+    get: (projectRoot) => Promise.resolve({ reference: fakeReference, ...resolveFake(projectRoot) }),
+    load: (project) => Promise.resolve({ reference: fakeReference, ...project }),
+    resolve: (projectRoot) => resolveFake(projectRoot),
+};
+
+const SCOPING_CASES: ScopingCase[] = [
+    {
+        name: "prefers an explicit project root over a registered app",
+        workingDirectory: "workingDirectory",
+        appRoot: "app",
+        projectRoot: "explicit",
+        expectedRoot: "explicit",
+        expectedSource: "argument",
+    },
+    {
+        name: "prefers the project containing the working directory over a registered app",
+        workingDirectory: "nested",
+        appRoot: "app",
+        expectedRoot: "workingDirectory",
+        expectedSource: "workingDirectory",
+    },
+    {
+        name: "falls back to a registered app when the working directory is not a project",
+        workingDirectory: "elsewhere",
+        appRoot: "app",
+        expectedRoot: "app",
+        expectedSource: "app",
+    },
+    {
+        name: "resolves from the working directory with no app and no explicit root",
+        workingDirectory: "nested",
+        expectedRoot: "workingDirectory",
+        expectedSource: "workingDirectory",
+    },
+    {
+        name: "resolves the working directory itself when no project encloses it",
+        workingDirectory: "elsewhere",
+        expectedRoot: "elsewhere",
+        expectedSource: "workingDirectory",
+    },
+];
+
+const resolveFake = (projectRoot?: string): { root: string; source: "app" | "argument" } => ({
+    root: projectRoot ?? "/apps/hello-world",
+    source: projectRoot === undefined ? "app" : "argument",
+});
 
 function lookupFake(query: string): ApiLookupResult {
     if (query === "Gtk.Button" || query === "Button") {
@@ -85,9 +149,68 @@ function getText(result: { content: { type: string }[] }): string {
     return (first as { type: "text"; text: string }).text;
 }
 
+function getNote(result: { content: { type: string }[] }): string {
+    const last = result.content.at(-1);
+
+    if (last?.type !== "text") {
+        throw new Error("Expected text content");
+    }
+
+    return (last as { type: "text"; text: string }).text;
+}
+
 function stubLoadedReference(reference: FakeReference = fakeReference): void {
-    loadConfigMock.mockResolvedValue({ config: {}, configFile: "gtkx.config.ts" });
+    loadConfigMock.mockImplementation((root: string) =>
+        Promise.resolve({ config: {}, configFile: "gtkx.config.ts", root }),
+    );
+
     loadApiReferenceMock.mockReturnValue(reference);
+}
+
+function makeProjectDirs(base: string): ProjectDirs {
+    const dirs: ProjectDirs = {
+        explicit: join(base, "explicit"),
+        app: join(base, "app"),
+        workingDirectory: join(base, "working"),
+        nested: join(base, "working", "src", "nested"),
+        elsewhere: join(base, "elsewhere"),
+    };
+
+    mkdirSync(dirs.nested, { recursive: true });
+    mkdirSync(dirs.elsewhere, { recursive: true });
+
+    for (const root of [dirs.explicit, dirs.app, dirs.workingDirectory]) {
+        mkdirSync(root, { recursive: true });
+        writeFileSync(join(root, "gtkx.config.ts"), "export default {};");
+    }
+
+    return dirs;
+}
+
+async function withProjectDirs(run: (dirs: ProjectDirs) => Promise<void>): Promise<void> {
+    const base = mkdtempSync(join(tmpdir(), "gtkx-projects-"));
+
+    try {
+        stubLoadedReference();
+        await run(makeProjectDirs(base));
+    } finally {
+        rmSync(base, { recursive: true, force: true });
+    }
+}
+
+function makeProvider(getWorkingDirectory: () => string, appRoot?: string): ReferenceProvider {
+    return createReferenceProvider({ getAppRoot: () => appRoot, getWorkingDirectory });
+}
+
+function dirFor(dirs: ProjectDirs, key: keyof ProjectDirs | undefined): string | undefined {
+    return key === undefined ? undefined : dirs[key];
+}
+
+async function missingSymbolError(): Promise<CallToolResult> {
+    const result = await getTool("gtkx_get_api_docs").handler({ symbol: "Missing" });
+    expect(result.isError).toBe(true);
+
+    return result;
 }
 
 async function withFrozenClock(run: (setNow: (now: number) => void) => Promise<void>): Promise<void> {
@@ -197,10 +320,39 @@ beforeEach(() => {
     vi.clearAllMocks();
 });
 
+describe("createReferenceProvider — project scoping", () => {
+    it.each(SCOPING_CASES)("$name", async (scoping) => {
+        await withProjectDirs(async (dirs) => {
+            const expectedRoot = dirs[scoping.expectedRoot];
+            const scoped = makeProvider(() => dirs[scoping.workingDirectory], dirFor(dirs, scoping.appRoot));
+            const resolved = await scoped.get(dirFor(dirs, scoping.projectRoot));
+            expect(loadConfigMock).toHaveBeenCalledExactlyOnceWith(expectedRoot);
+            expect(resolved.root).toBe(expectedRoot);
+            expect(resolved.source).toBe(scoping.expectedSource);
+        });
+    });
+});
+
+describe("createReferenceProvider — root discovery", () => {
+    it("reads the project root the configuration was found in", async () => {
+        await withProjectDirs(async (dirs) => {
+            loadConfigMock.mockResolvedValueOnce({
+                config: {},
+                configFile: "gtkx.config.ts",
+                root: dirs.workingDirectory,
+            });
+
+            await expect(makeProvider(() => dirs.elsewhere).get()).resolves.toMatchObject({
+                root: dirs.workingDirectory,
+            });
+        });
+    });
+});
+
 describe("createReferenceProvider — caching", () => {
     it("loads the reference once per project root and caches it", async () => {
         stubLoadedReference();
-        const cached = createReferenceProvider(() => "/project");
+        const cached = makeProvider(() => "/project");
         await cached.get();
         await cached.get();
         expect(loadConfigMock).toHaveBeenCalledExactlyOnceWith("/project");
@@ -215,7 +367,7 @@ describe("createReferenceProvider — caching", () => {
     it("loads separately when the resolved root changes", async () => {
         stubLoadedReference();
         const roots = ["/one", "/two"];
-        const changing = createReferenceProvider(() => roots.shift() ?? "/two");
+        const changing = makeProvider(() => roots.shift() ?? "/two");
         await changing.get();
         await changing.get();
         expect(loadApiReferenceMock).toHaveBeenCalledTimes(2);
@@ -226,25 +378,30 @@ describe("createReferenceProvider — caching", () => {
 
 describe("createReferenceProvider — failures and reloads", () => {
     it("rejects when codegen is disabled and retries after the backoff window", async () => {
-        loadConfigMock.mockResolvedValueOnce({ config: { codegen: false }, configFile: "gtkx.config.ts" });
-        loadConfigMock.mockResolvedValueOnce({ config: {}, configFile: "gtkx.config.ts" });
+        loadConfigMock.mockResolvedValueOnce({
+            config: { codegen: false },
+            configFile: "gtkx.config.ts",
+            root: "/project",
+        });
+
+        loadConfigMock.mockResolvedValueOnce({ config: {}, configFile: "gtkx.config.ts", root: "/project" });
         loadApiReferenceMock.mockReturnValue(fakeReference);
 
         await withFrozenClock(async (setNow) => {
-            const failing = createReferenceProvider(() => "/project");
+            const failing = makeProvider(() => "/project");
             await expect(failing.get()).rejects.toThrow(/codegen is disabled/);
             await expect(failing.get()).rejects.toThrow(/codegen is disabled/);
             expect(loadConfigMock).toHaveBeenCalledTimes(1);
             setNow(10_000);
-            await expect(failing.get()).resolves.toBe(fakeReference);
+            await expect(failing.get()).resolves.toMatchObject({ reference: fakeReference });
             expect(loadConfigMock).toHaveBeenCalledTimes(2);
         });
     });
 
     it("rejects when no GIR search paths are available", async () => {
-        loadConfigMock.mockResolvedValue({ config: {}, configFile: "gtkx.config.ts" });
+        loadConfigMock.mockResolvedValue({ config: {}, configFile: "gtkx.config.ts", root: "/project" });
         resolveGirPathMock.mockReturnValueOnce([]);
-        const failing = createReferenceProvider(() => "/project");
+        const failing = makeProvider(() => "/project");
         await expect(failing.get()).rejects.toThrow(/No GIR search paths available/);
     });
 
@@ -252,7 +409,7 @@ describe("createReferenceProvider — failures and reloads", () => {
         await withGirFile(async (girFile, setNow) => {
             writeFileSync(girFile, "before");
             stubLoadedReference({ ...fakeReference, girFiles: [girFile] });
-            const watching = createReferenceProvider(() => "/project");
+            const watching = makeProvider(() => "/project");
             await watching.get();
             writeFileSync(girFile, "after-with-different-size");
             await watching.get();
@@ -291,7 +448,19 @@ describe("gtkx_search_api", () => {
 
     it("forwards namespace, kind, and limit filters", async () => {
         const search = vi.fn(() => [buttonSymbol]);
-        const filtering: ReferenceProvider = { get: () => Promise.resolve({ ...fakeReference, search }) };
+
+        const scoped = {
+            reference: { ...fakeReference, search },
+            root: "/apps/hello-world",
+            source: "app",
+        } as const;
+
+        const filtering: ReferenceProvider = {
+            get: () => Promise.resolve(scoped),
+            load: () => Promise.resolve(scoped),
+            resolve: () => ({ root: "/apps/hello-world", source: "app" }),
+        };
+
         const tool = buildReferenceTools(filtering).find((candidate) => candidate.name === "gtkx_search_api");
 
         if (!tool) {
@@ -323,9 +492,51 @@ describe("gtkx_get_api_docs", () => {
     });
 
     it("errors with a search hint when the symbol is unknown", async () => {
-        const result = await getTool("gtkx_get_api_docs").handler({ symbol: "Missing" });
-        expect(result.isError).toBe(true);
-        expect(getText(result)).toContain("gtkx_search_api");
+        expect(getText(await missingSymbolError())).toContain("gtkx_search_api");
+    });
+});
+
+describe("reference tools — project scoping", () => {
+    it("names the project every successful answer is scoped to", async () => {
+        const listed = await getTool("gtkx_list_api").handler({});
+        const searched = await getTool("gtkx_search_api").handler({ query: "button" });
+        const documented = await getTool("gtkx_get_api_docs").handler({ symbol: "Gtk.Button" });
+        expect(listed.isError).toBeUndefined();
+        expect(getText(documented)).toBe("BUTTON PAGE");
+
+        for (const result of [listed, searched, documented]) {
+            expect(getNote(result)).toContain("Project: /apps/hello-world");
+            expect(getNote(result)).toContain("connected app");
+        }
+    });
+
+    it("keeps the payload as the first content block", async () => {
+        const searched = await getTool("gtkx_search_api").handler({ query: "button" });
+        expect(JSON.parse(getText(searched))).toEqual([buttonSymbol]);
+        expect(searched.content).toHaveLength(2);
+    });
+
+    it("forwards an explicit project root and names it in the answer", async () => {
+        const load = vi.fn((project: ResolvedProject) => provider.load(project));
+
+        const forwarding: ReferenceProvider = {
+            get: (projectRoot) => provider.get(projectRoot),
+            load,
+            resolve: (projectRoot) => resolveFake(projectRoot),
+        };
+
+        const tools = buildReferenceTools(forwarding);
+
+        for (const tool of tools) {
+            const result = await tool.handler({ projectRoot: "/projects/tablestar", query: "b", symbol: "Gtk.Button" });
+            expect(getNote(result)).toBe("Project: /projects/tablestar (requested with `projectRoot`)");
+        }
+
+        expect(load.mock.calls.map(([project]) => project.root)).toEqual(tools.map(() => "/projects/tablestar"));
+    });
+
+    it("names the project on errors as well", async () => {
+        expect(getNote(await missingSymbolError())).toContain("Project: /apps/hello-world");
     });
 });
 
@@ -356,7 +567,12 @@ describe("registerReferenceResources — index and namespaces", () => {
     });
 
     it("degrades gracefully when the reference cannot load", async () => {
-        const failing: ReferenceProvider = { get: () => Promise.reject(new Error("codegen is disabled")) };
+        const failing: ReferenceProvider = {
+            get: () => Promise.reject(new Error("codegen is disabled")),
+            load: () => Promise.reject(new Error("codegen is disabled")),
+            resolve: (projectRoot) => resolveFake(projectRoot),
+        };
+
         const namespaceResource = findResource(registerAllWith(failing), "gtkx-api-namespace");
         const template = getTemplate(namespaceResource);
         await expect(getListCallback(template)({} as never)).resolves.toEqual({ resources: [] });

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -144,8 +144,12 @@ async function runListAppsWithFailingWait(thrown: unknown): Promise<{ type: "tex
     return result.content[0] as { type: "text"; text: string };
 }
 
-async function runWidgetActionTool(tool: string, payload: Record<string, unknown>): Promise<WidgetActionRun> {
-    const sendToApp = vi.fn();
+async function runWidgetActionTool(
+    tool: string,
+    payload: Record<string, unknown>,
+    response?: unknown,
+): Promise<WidgetActionRun> {
+    const sendToApp = vi.fn(() => Promise.resolve(response));
     const appRouter = makeAppRouter({ sendToApp: sendToApp as never });
     const result = await getTool(appRouter, tool).handler(payload as never);
 
@@ -435,6 +439,25 @@ describe("buildTools — gtkx_get_widget_props", () => {
         const text = result.content[0] as { type: "text"; text: string };
         expect(JSON.parse(text.text)).toEqual({ label: "Click me" });
     });
+
+    it("forwards the requested property names to the app", async () => {
+        const properties = { collapsed: { type: "gboolean", value: true } };
+        const sendToApp = vi.fn(() => Promise.resolve({ properties }));
+        const appRouter = makeAppRouter({ sendToApp: sendToApp as never });
+
+        const result = await getTool(appRouter, "gtkx_get_widget_props").handler({
+            widgetId: "w1",
+            properties: ["collapsed"],
+        } as never);
+
+        expect(sendToApp).toHaveBeenCalledWith(undefined, "widget.getProps", {
+            widgetId: "w1",
+            properties: ["collapsed"],
+        });
+
+        const text = result.content[0] as { type: "text"; text: string };
+        expect(JSON.parse(text.text)).toEqual({ properties });
+    });
 });
 
 describe("buildTools — gtkx_click", () => {
@@ -458,9 +481,19 @@ describe("buildTools — gtkx_type", () => {
 describe("buildTools — gtkx_fire_event", () => {
     it("forwards signal name and args", async () => {
         const payload = { widgetId: "w1", signal: "clicked", args: ["arg1"] };
-        const { sendToApp, result } = await runWidgetActionTool("gtkx_fire_event", payload);
+        const response = { signal: "clicked", isRealized: true, isMapped: true, isSensitive: true, note: "emitted" };
+        const { sendToApp, result } = await runWidgetActionTool("gtkx_fire_event", payload, response);
         expect(sendToApp).toHaveBeenCalledWith(undefined, "widget.fireEvent", payload);
-        expect(result.content[0]).toEqual({ type: "text", text: "Fired event" });
+        expect(result.content[0]).toEqual({ type: "text", text: JSON.stringify(response, null, 2) });
+    });
+
+    it("reports the widget state back to the caller instead of a fixed string", async () => {
+        const response = { signal: "activate", isRealized: false, isMapped: false, isSensitive: true, note: "n/a" };
+        const payload = { widgetId: "w1", signal: "activate" };
+        const { result } = await runWidgetActionTool("gtkx_fire_event", payload, response);
+        const text = (result.content[0] as { text: string }).text;
+        expect(text).toContain('"isRealized": false');
+        expect(text).toContain('"isMapped": false');
     });
 });
 

--- a/packages/mcp/tests/socket-server-harness.ts
+++ b/packages/mcp/tests/socket-server-harness.ts
@@ -99,6 +99,14 @@ const startWithClient = async (): Promise<net.Socket> => {
     return connectClient(socketCtx.socketPath);
 };
 
+const startWithConnection = async (): Promise<{ client: net.Socket; connection: ProtocolConnection }> => {
+    await socketCtx.server.start();
+    const connectionPromise = waitForConnection(socketCtx.registry);
+    const client = await connectClient(socketCtx.socketPath);
+
+    return { client, connection: await connectionPromise };
+};
+
 const nextRequest = (registry: ConnectionRegistry): Promise<Request> =>
     new Promise((resolve) => {
         registry.addEventListener(
@@ -127,13 +135,12 @@ const collectFirstFrame = async <T>(client: net.Socket, act: () => void): Promis
 };
 
 export {
-    connectClient,
-    tryConnect,
-    waitForConnection,
-    socketCtx,
-    setupSocketServer,
-    startWithClient,
-    nextRequest,
     collectFirstFrame,
-    type SocketServerContext,
+    connectClient,
+    nextRequest,
+    setupSocketServer,
+    socketCtx,
+    startWithClient,
+    startWithConnection,
+    tryConnect,
 };

--- a/packages/mcp/tests/socket-server.test.ts
+++ b/packages/mcp/tests/socket-server.test.ts
@@ -12,9 +12,17 @@ import {
     setupSocketServer,
     socketCtx,
     startWithClient,
+    startWithConnection,
     tryConnect,
-    waitForConnection,
 } from "./socket-server-harness.js";
+
+const collectErrorResponse = async (payload: string): Promise<Response> => {
+    const client = await startWithClient();
+
+    return collectFirstFrame<Response>(client, () => {
+        client.write(payload);
+    });
+};
 
 describe("SocketServer lifecycle", () => {
     setupSocketServer();
@@ -66,15 +74,11 @@ describe("SocketServer connections", () => {
     setupSocketServer();
 
     it("registers a connection and emits a disconnection event", async () => {
-        const { server, socketPath, registry } = socketCtx;
-        await server.start();
-        const connectionPromise = waitForConnection(registry);
-        const client = await connectClient(socketPath);
-        const connection = await connectionPromise;
+        const { client, connection } = await startWithConnection();
         expect(connection.id).toBeTruthy();
 
         const disconnectionPromise: Promise<ProtocolConnection> = new Promise((resolve) => {
-            registry.addEventListener(
+            socketCtx.registry.addEventListener(
                 "disconnection",
                 (event) => {
                     resolve((event as ConnectionEvent).detail);
@@ -135,30 +139,19 @@ describe("SocketServer framing — error responses", () => {
     setupSocketServer();
 
     it("returns an Invalid JSON error response for malformed lines", async () => {
-        const client = await startWithClient();
-        const parsed = await collectFirstFrame<Response>(client, () => client.write("not-json\n"));
+        const parsed = await collectErrorResponse("not-json\n");
         expect(parsed.id).toBe("unknown");
         expect(parsed.error?.message).toContain("Invalid JSON");
     });
 
     it("returns an Invalid message format error for unknown shapes", async () => {
-        const client = await startWithClient();
-
-        const parsed = await collectFirstFrame<Response>(client, () =>
-            client.write(`${JSON.stringify({ random: true })}\n`),
-        );
-
+        const parsed = await collectErrorResponse(`${JSON.stringify({ random: true })}\n`);
         expect(parsed.id).toBe("unknown");
         expect(parsed.error?.message).toContain("Invalid message format");
     });
 
     it("returns an Invalid message format error when a request payload fails schema validation", async () => {
-        const client = await startWithClient();
-
-        const parsed = await collectFirstFrame<Response & { id: unknown }>(client, () =>
-            client.write(`${JSON.stringify({ id: 7, method: "ping" })}\n`),
-        );
-
+        const parsed = await collectErrorResponse(`${JSON.stringify({ id: 7, method: "ping" })}\n`);
         expect(parsed.error?.message).toContain("Invalid message format");
     });
 });

--- a/packages/testing/tests/password-entry.test.tsx
+++ b/packages/testing/tests/password-entry.test.tsx
@@ -1,0 +1,44 @@
+import * as Gtk from "@gtkx/gi/gtk";
+import { GtkPasswordEntry } from "@gtkx/jsx/gtk";
+import { describe, expect, it } from "vitest";
+import { getWidgetText, prettyWidget, render, screen } from "../src/index.js";
+import { getWidgetTextContent } from "../src/widget-accessible-properties.js";
+
+const SECRET = "hunter2";
+
+const renderPasswordEntry = async (text: string): Promise<Gtk.Widget> => {
+    await render(<GtkPasswordEntry name="password" text={text} />);
+
+    return screen.findByName("password");
+};
+
+describe("password entry", () => {
+    it("reads its text like any other entry", async () => {
+        const entry = await renderPasswordEntry(SECRET);
+        expect(getWidgetText(entry)).toBe(SECRET);
+        expect(getWidgetTextContent(entry)).toContain(SECRET);
+        expect(prettyWidget(entry)).toContain(SECRET);
+    });
+
+    it("reads no text when it is empty", async () => {
+        const entry = await renderPasswordEntry("");
+        expect(getWidgetText(entry)).toBeNull();
+    });
+
+    it("reports its text as the display value and as the selection", async () => {
+        const entry = await renderPasswordEntry(SECRET);
+        expect(entry).toHaveDisplayValue(SECRET);
+        expect(entry).toBeInstanceOf(Gtk.Editable);
+
+        if (entry instanceof Gtk.Editable) {
+            entry.selectRegion(0, -1);
+        }
+
+        expect(entry).toHaveSelection(SECRET);
+    });
+
+    it("takes its accessible name from its text", async () => {
+        await renderPasswordEntry(SECRET);
+        expect(await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { name: SECRET })).not.toBeNull();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,9 +380,15 @@ importers:
       '@codspeed/vitest-plugin':
         specifier: ^5.7.1
         version: 5.7.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)(tinybench@2.9.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))(vitest@4.1.10)
+      '@gtkx/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@gtkx/config':
         specifier: workspace:*
         version: link:../config
+      '@gtkx/mcp':
+        specifier: workspace:*
+        version: link:../mcp
       '@gtkx/native':
         specifier: workspace:*
         version: link:../native


### PR DESCRIPTION
Adds widget property reads to the MCP bridge, so an agent driving a running application can inspect state rather than infer it from the tree.

- `gtkx_get_widget_props` lists the readable properties of a widget and returns their values, resolving object values to the widgets already in the registry.
- Property names are matched case-insensitively against the accessors each prototype in the chain declares, and an unknown name reports the readable ones.

`readNativeProperty` hands `g_object_get_property` a zero-filled `GValue`, which GLib initializes from the property's own `GParamSpec`. The suite runs under `G_DEBUG=fatal-criticals`, so a mis-typed read would fail rather than pass quietly.

Part 11 of 15 in the v1.0.0 release stack. Merge in order.

### Areas touched

- `packages/mcp` (13)
- `packages/cli` (7)
- `packages/e2e` (3)
- `packages/testing` (1)
