### PR TITLE
Deduplicate and de-deprecate the gtk-demo sources

### DIFF
--- a/examples/gtk-demo/README.md
+++ b/examples/gtk-demo/README.md
@@ -14,7 +14,7 @@ The demos live under `src/demos`, grouped by category:
 - **opengl**: `@gtkx/gl` driving `GtkGLArea`, with gears and a Shadertoy player.
 - **advanced**, **input**, **drawing**, **media**, **navigation**, **benchmark**, and **games** cover text rendering and font features, entries and text views, drawing areas and paintables, video playback, stacks and revealers, and a minesweeper.
 
-The shell around them uses `Menu` and `Dialog` from `@gtkx/components`, `@gtkx/css` for styling, portals for demos that open their own windows, and a `GSimpleAction` set wired to a menu and shortcut controller. `tests/` exercises the app with `@gtkx/testing`.
+The shell around them uses `ListView` from `@gtkx/components` for the sidebar, a `GtkWindow` for demos that open their own window, and a `GSimpleAction` set wired to a `GMenu` and a `GtkShortcutController`. `tests/` exercises the app with `@gtkx/testing`.
 
 `gtkx.config.ts` declares `Gtk-4.0`, `Adw-1`, and `GtkSource-5`, with the application ID `org.gtkx.gtk-demo`. The GtkSourceView 5 development package must be installed; see [CONTRIBUTING.md](../../CONTRIBUTING.md#system-dependencies).
 

--- a/examples/gtk-demo/package.json
+++ b/examples/gtk-demo/package.json
@@ -20,6 +20,7 @@
         "@gtkx/runtime": "workspace:*",
         "@gtkx/gl": "workspace:*",
         "@gtkx/react": "workspace:*",
+        "@gtkx/utils": "workspace:*",
         "react": "catalog:"
     },
     "devDependencies": {
@@ -100,9 +101,7 @@
                         "transitive": true
                     }
                 ],
-                "outputs": [
-                    "{projectRoot}/coverage"
-                ],
+                "outputs": [],
                 "dependsOn": [
                     "...",
                     "codegen",
@@ -114,7 +113,11 @@
                     "gtkx:codegen",
                     "@gtkx/gl:codegen",
                     "codegen"
-                ]
+                ],
+                "options": {
+                    "cwd": ".",
+                    "command": "eslint examples/gtk-demo"
+                }
             },
             "coverage": {
                 "command": "vitest run --coverage",

--- a/examples/gtk-demo/src/app.tsx
+++ b/examples/gtk-demo/src/app.tsx
@@ -19,11 +19,12 @@ import {
     GtkToggleButton,
     GtkWindow,
 } from "@gtkx/jsx/gtk";
-import { createPortal, quit, rootElement, useParentWindow } from "@gtkx/react";
+import { quit, useParentWindow } from "@gtkx/react";
 import * as path from "node:path/posix";
 import { type ComponentType, type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import { path as logoResourcePath } from "#data/icons/org.gtk.Demo4.svg";
 import type { Demo as DemoDefinition, DemoProviderProps } from "./demos/types.js";
+import { EmptyState } from "./components/empty-state.js";
 import { Sidebar } from "./components/sidebar.js";
 import { SourceViewer } from "./components/source-viewer.js";
 import { DemoProvider, parseTitle, useDemo } from "./context/demo-context.js";
@@ -111,11 +112,7 @@ const InfoTab = () => {
     const { currentDemo } = useDemo();
 
     if (!currentDemo) {
-        return (
-            <GtkBox orientation={Gtk.Orientation.VERTICAL} valign={Gtk.Align.CENTER} halign={Gtk.Align.CENTER} vexpand>
-                <GtkLabel cssClasses={["dim-label"]}>Select a demo from the sidebar</GtkLabel>
-            </GtkBox>
-        );
+        return <EmptyState message="Select a demo from the sidebar" />;
     }
 
     const { displayTitle } = parseTitle(currentDemo.title);
@@ -182,29 +179,25 @@ const DemoWindow = ({ onClose }: DemoWindowProps) => {
 
     return (
         <DemoStateProvider window={windowRef} onClose={onClose}>
-            {createPortal(
-                <GtkWindow
-                    ref={windowRef}
-                    name="demo-window"
-                    transientFor={hostWindow}
-                    title={demoWindowTitle(currentDemo, windowTitle)}
-                    defaultWidth={sizing.defaultWidth}
-                    defaultHeight={sizing.defaultHeight}
-                    resizable={sizing.isResizable}
-                    deletable={sizing.isDeletable}
-                    cssClasses={currentDemo.windowCssClasses}
-                    defaultWidget={defaultWidget}
-                    titlebar={titlebar}
-                    onCloseRequest={() => {
-                        onClose();
+            <GtkWindow
+                ref={windowRef}
+                name="demo-window"
+                title={demoWindowTitle(currentDemo, windowTitle)}
+                defaultWidth={sizing.defaultWidth}
+                defaultHeight={sizing.defaultHeight}
+                resizable={sizing.isResizable}
+                deletable={sizing.isDeletable}
+                cssClasses={currentDemo.windowCssClasses}
+                defaultWidget={defaultWidget}
+                titlebar={titlebar}
+                onCloseRequest={() => {
+                    onClose();
 
-                        return Gdk.EVENT_STOP;
-                    }}
-                >
-                    <DemoComponent onClose={onClose} window={windowRef} />
-                </GtkWindow>,
-                rootElement,
-            )}
+                    return Gdk.EVENT_STOP;
+                }}
+            >
+                <DemoComponent onClose={onClose} window={windowRef} />
+            </GtkWindow>
         </DemoStateProvider>
     );
 };

--- a/examples/gtk-demo/src/components/empty-state.tsx
+++ b/examples/gtk-demo/src/components/empty-state.tsx
@@ -1,0 +1,14 @@
+import * as Gtk from "@gtkx/gi/gtk";
+import { GtkBox, GtkLabel } from "@gtkx/jsx/gtk";
+
+type EmptyStateProps = {
+    message: string;
+};
+
+const EmptyState = ({ message }: EmptyStateProps) => (
+    <GtkBox orientation={Gtk.Orientation.VERTICAL} valign={Gtk.Align.CENTER} halign={Gtk.Align.CENTER} vexpand>
+        <GtkLabel cssClasses={["dim-label"]}>{message}</GtkLabel>
+    </GtkBox>
+);
+
+export { EmptyState };

--- a/examples/gtk-demo/src/components/source-viewer.tsx
+++ b/examples/gtk-demo/src/components/source-viewer.tsx
@@ -1,8 +1,8 @@
-import * as Gtk from "@gtkx/gi/gtk";
 import * as GtkSource from "@gtkx/gi/gtksource";
-import { GtkBox, GtkLabel, GtkScrolledWindow } from "@gtkx/jsx/gtk";
+import { GtkScrolledWindow } from "@gtkx/jsx/gtk";
 import { GtkSourceBuffer, GtkSourceView } from "@gtkx/jsx/gtksource";
 import { useDemo } from "../context/demo-context.js";
+import { EmptyState } from "./empty-state.js";
 
 const SourceViewer = () => {
     const { currentDemo } = useDemo();
@@ -39,16 +39,7 @@ const SourceViewer = () => {
                             )}
                         />
                     )
-                : (
-                        <GtkBox
-                            orientation={Gtk.Orientation.VERTICAL}
-                            valign={Gtk.Align.CENTER}
-                            halign={Gtk.Align.CENTER}
-                            vexpand
-                        >
-                            <GtkLabel cssClasses={["dim-label"]}>No source</GtkLabel>
-                        </GtkBox>
-                    )}
+                : <EmptyState message="No source" />}
         </GtkScrolledWindow>
     );
 };

--- a/examples/gtk-demo/src/demos/advanced/font-features.tsx
+++ b/examples/gtk-demo/src/demos/advanced/font-features.tsx
@@ -57,28 +57,25 @@ type FontFeaturesState = ReturnType<typeof useFontFeaturesState>;
 type FontFeaturesStyles = ReturnType<typeof useFontFeaturesStyles>;
 type FontFeaturesHandlers = ReturnType<typeof useFontFeaturesHandlers>;
 
-type PreviewStyleArgs = {
+type TextStyleValuesArgs = {
     fontDesc: Pango.FontDescription | null;
-    size: number;
     fgColor: Gdk.RGBA;
     letterSpacing: number;
+};
+
+type PreviewStyleArgs = TextStyleValuesArgs & {
+    size: number;
     lineHeight: number;
 };
 
-type EditStyleArgs = {
-    fontDesc: Pango.FontDescription | null;
+type EditStyleArgs = TextStyleValuesArgs & {
     size: number;
     fontFeaturesString: string;
-    fgColor: Gdk.RGBA;
-    letterSpacing: number;
 };
 
-type WaterfallStyleArgs = {
-    fontDesc: Pango.FontDescription | null;
+type WaterfallStyleArgs = TextStyleValuesArgs & {
     wfSize: number;
     fontFeaturesString: string;
-    fgColor: Gdk.RGBA;
-    letterSpacing: number;
 };
 
 type SliderEntryRowProps = {
@@ -125,6 +122,11 @@ type FontFeaturesPreviewLabelProps = {
     state: FontFeaturesState;
     styles: FontFeaturesStyles;
     attributes: Pango.AttrList | null;
+};
+
+type FontFeaturesSectionProps = {
+    state: FontFeaturesState;
+    handlers: FontFeaturesHandlers;
 };
 
 type FontFeaturesContextValue = {
@@ -509,16 +511,25 @@ const buildBgStyle = (bgColor: Gdk.RGBA) => {
     `;
 };
 
-const buildPreviewStyle = ({ fontDesc, size, fgColor, letterSpacing, lineHeight }: PreviewStyleArgs) => {
-    const fontFamily = fontDesc?.getFamily() ?? "Sans";
+const buildTextStyleValues = ({ fontDesc, fgColor, letterSpacing }: TextStyleValuesArgs) => {
     const { r, g, b } = rgbColor(fgColor);
+
+    return {
+        fontFamily: fontDesc?.getFamily() ?? "Sans",
+        color: `rgb(${String(r)}, ${String(g)}, ${String(b)})`,
+        spacing: `${String(letterSpacing / 1024)}em`,
+    };
+};
+
+const buildPreviewStyle = ({ fontDesc, size, fgColor, letterSpacing, lineHeight }: PreviewStyleArgs) => {
+    const { fontFamily, color, spacing } = buildTextStyleValues({ fontDesc, fgColor, letterSpacing });
 
     return css`
         label& {
             font-family: "${fontFamily}";
             font-size: ${size}pt;
-            color: rgb(${r}, ${g}, ${b});
-            letter-spacing: ${letterSpacing / 1024}em;
+            color: ${color};
+            letter-spacing: ${spacing};
             line-height: ${lineHeight};
             padding: 16px;
         }
@@ -526,31 +537,29 @@ const buildPreviewStyle = ({ fontDesc, size, fgColor, letterSpacing, lineHeight 
 };
 
 const buildEditStyle = ({ fontDesc, size, fontFeaturesString, fgColor, letterSpacing }: EditStyleArgs) => {
-    const fontFamily = fontDesc?.getFamily() ?? "Sans";
-    const { r, g, b } = rgbColor(fgColor);
+    const { fontFamily, color, spacing } = buildTextStyleValues({ fontDesc, fgColor, letterSpacing });
 
     return css`
         textview& {
             font-family: "${fontFamily}";
             font-size: ${size}pt;
             font-feature-settings: ${fontFeaturesString};
-            color: rgb(${r}, ${g}, ${b});
-            letter-spacing: ${letterSpacing / 1024}em;
+            color: ${color};
+            letter-spacing: ${spacing};
         }
     `;
 };
 
 const buildWaterfallStyle = ({ fontDesc, wfSize, fontFeaturesString, fgColor, letterSpacing }: WaterfallStyleArgs) => {
-    const fontFamily = fontDesc?.getFamily() ?? "Sans";
-    const { r, g, b } = rgbColor(fgColor);
+    const { fontFamily, color, spacing } = buildTextStyleValues({ fontDesc, fgColor, letterSpacing });
 
     return css`
         label& {
             font-family: "${fontFamily}";
             font-size: ${wfSize}pt;
             font-feature-settings: ${fontFeaturesString};
-            color: rgb(${r}, ${g}, ${b});
-            letter-spacing: ${letterSpacing / 1024}em;
+            color: ${color};
+            letter-spacing: ${spacing};
         }
     `;
 };
@@ -805,7 +814,7 @@ const FontFeaturesFontButton = ({ state }: { state: FontFeaturesState }) => {
     );
 };
 
-const FontFeaturesGrid = ({ state, handlers }: { state: FontFeaturesState; handlers: FontFeaturesHandlers }) => {
+const FontFeaturesGrid = ({ state, handlers }: FontFeaturesSectionProps) => {
     const { size, letterSpacing, lineHeight, viewMode } = state;
     const { setSize, setLetterSpacing, setLineHeight } = state;
 
@@ -866,8 +875,7 @@ const applyRgba = (value: Gdk.RGBA | null, apply: (color: Gdk.RGBA) => void) => 
 const ColorRow = ({ row, label, name, rgba, onChanged }: ColorRowProps) => (
     <>
         <GtkGridLayoutChild column={0} row={row}>
-            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-            <GtkLabel xalign={0} valign={Gtk.Align.BASELINE}>
+            <GtkLabel xalign={0} valign={Gtk.Align.BASELINE_FILL}>
                 {label}
             </GtkLabel>
         </GtkGridLayoutChild>
@@ -877,14 +885,13 @@ const ColorRow = ({ row, label, name, rgba, onChanged }: ColorRowProps) => (
                 rgba={rgba}
                 dialog={<GtkColorDialog />}
                 onNotifyRgba={onChanged}
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
-                valign={Gtk.Align.BASELINE}
+                valign={Gtk.Align.BASELINE_FILL}
             />
         </GtkGridLayoutChild>
     </>
 );
 
-const FontFeaturesColorRows = ({ state, handlers }: { state: FontFeaturesState; handlers: FontFeaturesHandlers }) => {
+const FontFeaturesColorRows = ({ state, handlers }: FontFeaturesSectionProps) => {
     const { fgColor, setFgColor, bgColor, setBgColor } = state;
 
     const handleForegroundChanged = (value: Gdk.RGBA | null) => {
@@ -932,8 +939,7 @@ const SliderScaleCell = (props: SliderEntryRowProps) => (
         <GtkScale
             hexpand
             widthRequest={100}
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            valign={Gtk.Align.BASELINE}
+            valign={Gtk.Align.BASELINE_FILL}
             adjustment={(
                 <GtkAdjustment
                     value={props.value}
@@ -954,8 +960,7 @@ const SliderScaleCell = (props: SliderEntryRowProps) => (
 const SliderEntryRow = (props: SliderEntryRowProps) => (
     <>
         <GtkGridLayoutChild column={0} row={props.row}>
-            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-            <GtkLabel xalign={0} valign={Gtk.Align.BASELINE}>
+            <GtkLabel xalign={0} valign={Gtk.Align.BASELINE_FILL}>
                 {props.label}
             </GtkLabel>
         </GtkGridLayoutChild>
@@ -965,8 +970,7 @@ const SliderEntryRow = (props: SliderEntryRowProps) => (
                 name={props.entryName}
                 widthChars={4}
                 maxWidthChars={4}
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
-                valign={Gtk.Align.BASELINE}
+                valign={Gtk.Align.BASELINE_FILL}
                 text={props.displayText}
                 onActivate={props.onEntryActivate}
                 sensitive={props.isSensitive}
@@ -975,7 +979,7 @@ const SliderEntryRow = (props: SliderEntryRowProps) => (
     </>
 );
 
-const FontFeaturesExpander = ({ state, handlers }: { state: FontFeaturesState; handlers: FontFeaturesHandlers }) => {
+const FontFeaturesExpander = ({ state, handlers }: FontFeaturesSectionProps) => {
     const { checkStates, radioStates } = state;
 
     return (
@@ -1004,7 +1008,7 @@ const FontFeaturesExpander = ({ state, handlers }: { state: FontFeaturesState; h
     );
 };
 
-const FontFeaturesSidebar = ({ state, handlers }: { state: FontFeaturesState; handlers: FontFeaturesHandlers }) => (
+const FontFeaturesSidebar = ({ state, handlers }: FontFeaturesSectionProps) => (
     <GtkBox
         orientation={Gtk.Orientation.VERTICAL}
         spacing={6}
@@ -1195,8 +1199,7 @@ const FontFeaturesPreviewControlsRow = ({
                     name="plain_toggle"
                     label="Plain"
                     active={viewMode === "plain"}
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    valign={Gtk.Align.BASELINE}
+                    valign={Gtk.Align.BASELINE_FILL}
                     onToggled={handlePlainToggled}
                 />
                 <GtkToggleButton
@@ -1204,8 +1207,7 @@ const FontFeaturesPreviewControlsRow = ({
                     label="Waterfall"
                     group={plainToggle}
                     active={viewMode === "waterfall"}
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    valign={Gtk.Align.BASELINE}
+                    valign={Gtk.Align.BASELINE_FILL}
                     onToggled={handleWaterfallToggled}
                 />
             </GtkBox>

--- a/examples/gtk-demo/src/demos/advanced/fontrendering.tsx
+++ b/examples/gtk-demo/src/demos/advanced/fontrendering.tsx
@@ -67,6 +67,12 @@ type ComputeTextLayoutArgs = {
     shouldHintMetrics: boolean;
 };
 
+type FontContextArgs = {
+    surface: ReturnType<Context["getTarget"]>;
+    fontOptions: FontOptions;
+    shouldHintMetrics: boolean;
+};
+
 type FontRenderingControlsProps = {
     state: FontRenderingState;
     onZoomIn: () => void;
@@ -239,15 +245,33 @@ const createGridFontOptions = (
     return fontOptions;
 };
 
+const createFontContext = ({ surface, fontOptions, shouldHintMetrics }: FontContextArgs) => {
+    const cr = Context.create(surface);
+    cr.setFontOptions(fontOptions);
+    const pangoContext = PangoCairo.createContext(cr);
+    PangoCairo.contextSetFontOptions(pangoContext, fontOptions);
+    pangoContext.setRoundGlyphPositions(shouldHintMetrics);
+
+    return { cr, pangoContext };
+};
+
+const createTextLayout = (context: Pango.Context, fontDesc: Pango.FontDescription, text: string): Pango.Layout => {
+    const layout = Pango.Layout.new(context);
+    layout.setFontDescription(fontDesc);
+    layout.setText(text, -1);
+
+    return layout;
+};
+
+const repeatedGlyphText = (ch: string): string => `${ch}${ZWNJ}${ch}${ZWNJ}${ch}${ZWNJ}${ch}`;
+
 const setupGridLayout = (
     context: Pango.Context,
     fontDesc: Pango.FontDescription,
     text: string,
 ): { logicalRect: Pango.Rectangle; ch: string; iter: Pango.LayoutIter } | null => {
     let ch = text[0] ?? " ";
-    const layout = Pango.Layout.new(context);
-    layout.setFontDescription(fontDesc);
-    layout.setText(`${ch}${ZWNJ}${ch}${ZWNJ}${ch}${ZWNJ}${ch}`, -1);
+    const layout = createTextLayout(context, fontDesc, repeatedGlyphText(ch));
     let [, logicalRect] = layout.getPixelExtents();
     const iter = layout.getIter();
     const glyphItem = iter.getRun();
@@ -258,7 +282,7 @@ const setupGridLayout = (
 
     if (glyphItem.glyphs.numGlyphs < 8) {
         ch = "a";
-        layout.setText(`${ch}${ZWNJ}${ch}${ZWNJ}${ch}${ZWNJ}${ch}`, -1);
+        layout.setText(repeatedGlyphText(ch), -1);
         [, logicalRect] = layout.getPixelExtents();
     }
 
@@ -270,11 +294,12 @@ const setupGridLayout = (
 const withMeasurementContext = <T,>(inputs: MeasurementInputs, body: (pangoContext: Pango.Context) => T): T => {
     const fontOptions = createGridFontOptions(inputs.hintStyle, inputs.isAntialiased, inputs.shouldHintMetrics);
     const target = ImageSurface.create(Format.ARGB32, 1, 1);
-    const cr = Context.create(target);
-    cr.setFontOptions(fontOptions);
-    const pangoContext = PangoCairo.createContext(cr);
-    PangoCairo.contextSetFontOptions(pangoContext, fontOptions);
-    pangoContext.setRoundGlyphPositions(inputs.shouldHintMetrics);
+
+    const { pangoContext } = createFontContext({
+        surface: target,
+        fontOptions,
+        shouldHintMetrics: inputs.shouldHintMetrics,
+    });
 
     try {
         return body(pangoContext);
@@ -285,9 +310,7 @@ const withMeasurementContext = <T,>(inputs: MeasurementInputs, body: (pangoConte
 
 const measureTextSurface = (inputs: MeasurementInputs): { width: number; height: number } => {
     const { width, height } = withMeasurementContext(inputs, (pangoContext) => {
-        const layout = Pango.Layout.new(pangoContext);
-        layout.setFontDescription(inputs.fontDesc);
-        layout.setText(inputs.text || " ", -1);
+        const layout = createTextLayout(pangoContext, inputs.fontDesc, inputs.text || " ");
         const [inkRect] = layout.getExtents();
         const inkW = Math.ceil(inkRect.width / PANGO_SCALE);
         const inkH = Math.ceil(inkRect.height / PANGO_SCALE);
@@ -334,14 +357,13 @@ const renderSmallSurface = ({
     ch: string;
     shouldHintMetrics: boolean;
 }): { iter: Pango.LayoutIter } | null => {
-    const smallCr = Context.create(small);
-    smallCr.setFontOptions(fontOptions);
-    const smallCtx = PangoCairo.createContext(smallCr);
-    PangoCairo.contextSetFontOptions(smallCtx, fontOptions);
-    smallCtx.setRoundGlyphPositions(shouldHintMetrics);
-    const smallLayout = Pango.Layout.new(smallCtx);
-    smallLayout.setFontDescription(fontDesc);
-    smallLayout.setText(`${ch}${ZWNJ}${ch}${ZWNJ}${ch}${ZWNJ}${ch}`, -1);
+    const { cr: smallCr, pangoContext: smallCtx } = createFontContext({
+        surface: small,
+        fontOptions,
+        shouldHintMetrics,
+    });
+
+    const smallLayout = createTextLayout(smallCtx, fontDesc, repeatedGlyphText(ch));
     let [, smallLogical] = smallLayout.getPixelExtents();
     const smallIter = smallLayout.getIter();
     const smallGlyphItem = smallIter.getRun();
@@ -351,7 +373,7 @@ const renderSmallSurface = ({
     }
 
     if (smallGlyphItem.glyphs.numGlyphs < 8) {
-        smallLayout.setText(`a${ZWNJ}a${ZWNJ}a${ZWNJ}a`, -1);
+        smallLayout.setText(repeatedGlyphText("a"), -1);
         [, smallLogical] = smallLayout.getPixelExtents();
     }
 
@@ -577,16 +599,16 @@ function useOverlayAnimation(state: FontRenderingState) {
 const drawSmallSurface = (ctx: DrawTextModeContext) => {
     const { target, surfaceWidth, surfaceHeight, fontOptions, state, cr } = ctx;
     const small = Surface.createSimilar(target, Content.COLOR_ALPHA, surfaceWidth, surfaceHeight);
-    const smallCr = Context.create(small);
+
+    const { cr: smallCr, pangoContext: smallContext } = createFontContext({
+        surface: small,
+        fontOptions,
+        shouldHintMetrics: state.shouldHintMetrics,
+    });
+
     smallCr.setSourceRgb(1, 1, 1);
     smallCr.paint();
-    smallCr.setFontOptions(fontOptions);
-    const smallContext = PangoCairo.createContext(smallCr);
-    PangoCairo.contextSetFontOptions(smallContext, fontOptions);
-    smallContext.setRoundGlyphPositions(state.shouldHintMetrics);
-    const smallLayout = Pango.Layout.new(smallContext);
-    smallLayout.setFontDescription(state.fontDesc);
-    smallLayout.setText(state.text || " ", -1);
+    const smallLayout = createTextLayout(smallContext, state.fontDesc, state.text || " ");
     smallCr.setSourceRgba(0, 0, 0, state.pixelAlphaRef.current);
     smallCr.translate(10, 10);
     PangoCairo.showLayout(smallCr, smallLayout);
@@ -696,14 +718,14 @@ const drawExtents = ({
 const drawOutlineLayer = (ctx: DrawTextModeContext) => {
     const { target, surfaceWidth, surfaceHeight, fontOptions, state, cr } = ctx;
     const outlineSurface = Surface.createSimilar(target, Content.COLOR_ALPHA, surfaceWidth, surfaceHeight);
-    const outlineCr = Context.create(outlineSurface);
-    outlineCr.setFontOptions(fontOptions);
-    const outlineCtx = PangoCairo.createContext(outlineCr);
-    PangoCairo.contextSetFontOptions(outlineCtx, fontOptions);
-    outlineCtx.setRoundGlyphPositions(state.shouldHintMetrics);
-    const outlineLayout = Pango.Layout.new(outlineCtx);
-    outlineLayout.setFontDescription(state.fontDesc);
-    outlineLayout.setText(state.text || " ", -1);
+
+    const { cr: outlineCr, pangoContext: outlineCtx } = createFontContext({
+        surface: outlineSurface,
+        fontOptions,
+        shouldHintMetrics: state.shouldHintMetrics,
+    });
+
+    const outlineLayout = createTextLayout(outlineCtx, state.fontDesc, state.text || " ");
     outlineCr.translate(10, 10);
     PangoCairo.layoutPath(outlineCr, outlineLayout);
     outlineCr.setSourceRgba(0, 0, 0, 1);
@@ -727,14 +749,8 @@ const computeTextLayout = ({
 }: ComputeTextLayoutArgs) => {
     const target = cr.getTarget();
     const offscreen = Surface.createSimilar(target, Content.COLOR_ALPHA, width, height);
-    const offCr = Context.create(offscreen);
-    offCr.setFontOptions(fontOptions);
-    const context = PangoCairo.createContext(offCr);
-    PangoCairo.contextSetFontOptions(context, fontOptions);
-    context.setRoundGlyphPositions(shouldHintMetrics);
-    const layout = Pango.Layout.new(context);
-    layout.setFontDescription(fontDesc);
-    layout.setText(text || " ", -1);
+    const { pangoContext } = createFontContext({ surface: offscreen, fontOptions, shouldHintMetrics });
+    const layout = createTextLayout(pangoContext, fontDesc, text || " ");
     const [inkRect, logicalRect] = layout.getExtents();
     const baseline = layout.getBaseline();
 
@@ -796,12 +812,8 @@ function useDrawGridMode(state: FontRenderingState) {
         const fontOptions = createGridFontOptions(hintStyle, isAntialiased, shouldHintMetrics);
         const target = cr.getTarget();
         const tmpSurface = Surface.createSimilar(target, Content.COLOR_ALPHA, 1, 1);
-        const tmpCr = Context.create(tmpSurface);
-        tmpCr.setFontOptions(fontOptions);
-        const context = PangoCairo.createContext(tmpCr);
-        PangoCairo.contextSetFontOptions(context, fontOptions);
-        context.setRoundGlyphPositions(shouldHintMetrics);
-        const layoutSetup = setupGridLayout(context, fontDesc, text);
+        const { pangoContext } = createFontContext({ surface: tmpSurface, fontOptions, shouldHintMetrics });
+        const layoutSetup = setupGridLayout(pangoContext, fontDesc, text);
 
         if (!layoutSetup) {
             return;

--- a/examples/gtk-demo/src/demos/advanced/markup.tsx
+++ b/examples/gtk-demo/src/demos/advanced/markup.tsx
@@ -8,7 +8,7 @@ import {
     GtkTextBuffer,
     GtkTextView,
 } from "@gtkx/jsx/gtk";
-import { createContext, useContext, useRef, useState } from "react";
+import { createContext, type ReactNode, useContext, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import sourceCode from "./markup.tsx?raw";
 import markupContent from "./markup.txt?raw";
@@ -73,6 +73,17 @@ const syncMarkupFromSource = (sourceView: Gtk.TextView | null, markupRef: React.
     markupRef.current = buffer.getText(startIter, endIter, false);
 };
 
+const MarkupScroller = ({ children }: { children: ReactNode }) => (
+    <GtkScrolledWindow
+        vexpand
+        hexpand
+        hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
+        vscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
+    >
+        {children}
+    </GtkScrolledWindow>
+);
+
 const MarkupStack = ({ isShowingSource, formattedViewRef, sourceViewRef, onFormattedRealized }: MarkupStackProps) => (
     <GtkStack
         name="markup-stack"
@@ -82,12 +93,7 @@ const MarkupStack = ({ isShowingSource, formattedViewRef, sourceViewRef, onForma
         transitionType={Gtk.StackTransitionType.NONE}
     >
         <GtkStackPage name="formatted" title="Formatted">
-            <GtkScrolledWindow
-                vexpand
-                hexpand
-                hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
-                vscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
-            >
+            <MarkupScroller>
                 <GtkTextView
                     name="formatted-view"
                     ref={formattedViewRef}
@@ -97,15 +103,10 @@ const MarkupStack = ({ isShowingSource, formattedViewRef, sourceViewRef, onForma
                     rightMargin={10}
                     onRealize={onFormattedRealized}
                 />
-            </GtkScrolledWindow>
+            </MarkupScroller>
         </GtkStackPage>
         <GtkStackPage name="source" title="Source">
-            <GtkScrolledWindow
-                vexpand
-                hexpand
-                hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
-                vscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
-            >
+            <MarkupScroller>
                 <GtkTextView
                     name="source-view"
                     ref={sourceViewRef}
@@ -114,7 +115,7 @@ const MarkupStack = ({ isShowingSource, formattedViewRef, sourceViewRef, onForma
                     rightMargin={10}
                     buffer={<GtkTextBuffer>{SAMPLE_MARKUP}</GtkTextBuffer>}
                 />
-            </GtkScrolledWindow>
+            </MarkupScroller>
         </GtkStackPage>
     </GtkStack>
 );

--- a/examples/gtk-demo/src/demos/constraints/constraint-helpers.tsx
+++ b/examples/gtk-demo/src/demos/constraints/constraint-helpers.tsx
@@ -11,21 +11,14 @@ type ConstraintContainerProps = {
 
 const A = Gtk.ConstraintAttribute;
 
-const topEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => (
-    <GtkConstraint target={target} targetAttribute={A.TOP} sourceAttribute={A.TOP} constant={8} />
+const edgeConstraint = (target: Gtk.ConstraintTarget, edge: Gtk.ConstraintAttribute, constant: number): ReactNode => (
+    <GtkConstraint target={target} targetAttribute={edge} sourceAttribute={edge} constant={constant} />
 );
 
-const bottomEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => (
-    <GtkConstraint target={target} targetAttribute={A.BOTTOM} sourceAttribute={A.BOTTOM} constant={-8} />
-);
-
-const startEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => (
-    <GtkConstraint target={target} targetAttribute={A.START} sourceAttribute={A.START} constant={8} />
-);
-
-const endEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => (
-    <GtkConstraint target={target} targetAttribute={A.END} sourceAttribute={A.END} constant={-8} />
-);
+const topEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => edgeConstraint(target, A.TOP, 8);
+const bottomEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => edgeConstraint(target, A.BOTTOM, -8);
+const startEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => edgeConstraint(target, A.START, 8);
+const endEdgeConstraint = (target: Gtk.ConstraintTarget): ReactNode => edgeConstraint(target, A.END, -8);
 
 const ConstraintContainer = ({ layoutManager, handlers, controllers }: ConstraintContainerProps): ReactNode => (
     <GtkBox name="container" hexpand vexpand layoutManager={layoutManager} controllers={controllers}>

--- a/examples/gtk-demo/src/demos/css/errorstates.tsx
+++ b/examples/gtk-demo/src/demos/css/errorstates.tsx
@@ -172,8 +172,7 @@ const FieldLabel = ({ row, target, children }: FieldLabelProps) => (
         <GtkLabel
             useUnderline
             halign={Gtk.Align.END}
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            valign={Gtk.Align.BASELINE}
+            valign={Gtk.Align.BASELINE_FILL}
             cssClasses={["dim-label"]}
             mnemonicWidget={target}
         >
@@ -192,8 +191,7 @@ const DetailsEntryRow = ({ detailsEntry, setDetailsEntry, onChange }: EntryRowPr
                 ref={(node) => {
                     setDetailsEntry(node);
                 }}
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
-                valign={Gtk.Align.BASELINE}
+                valign={Gtk.Align.BASELINE_FILL}
                 onChanged={onChange}
             />
         </GtkGridLayoutChild>
@@ -215,8 +213,7 @@ const MoreDetailsEntryRow = ({
                 ref={(node) => {
                     setMoreDetailsEntry(node);
                 }}
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
-                valign={Gtk.Align.BASELINE}
+                valign={Gtk.Align.BASELINE_FILL}
                 cssClasses={hasMoreDetailsError ? ["error"] : []}
                 tooltipText={hasMoreDetailsError ? "Must have details first" : ""}
                 accessibleInvalid={
@@ -239,8 +236,7 @@ const LevelScaleRow = ({ levelScale, setLevelScale, onValueChanged }: LevelScale
                     setLevelScale(node);
                 }}
                 orientation={Gtk.Orientation.HORIZONTAL}
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
-                valign={Gtk.Align.BASELINE}
+                valign={Gtk.Align.BASELINE_FILL}
                 drawValue={false}
                 adjustment={<GtkAdjustment value={50} lower={0} upper={100} stepIncrement={1} pageIncrement={10} />}
                 onValueChanged={(scale) => {
@@ -258,8 +254,7 @@ const ModeErrorLabel = ({ setErrorLabel }: ModeErrorLabelProps) => (
                 setErrorLabel(node);
             }}
             halign={Gtk.Align.START}
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            valign={Gtk.Align.BASELINE}
+            valign={Gtk.Align.BASELINE_FILL}
             cssClasses={["error"]}
         >
             Level too low
@@ -281,8 +276,7 @@ const ModeSwitchRow = ({ state, onStateSet }: ModeSwitchRowProps) => {
                         setModeSwitch(node);
                     }}
                     halign={Gtk.Align.START}
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    valign={Gtk.Align.BASELINE}
+                    valign={Gtk.Align.BASELINE_FILL}
                     accessibleKeyShortcuts="Control+M"
                     accessibleInvalid={showError ? Gtk.AccessibleInvalidState.TRUE : Gtk.AccessibleInvalidState.FALSE}
                     accessibleErrorMessage={showError && errorLabel ? [errorLabel] : undefined}

--- a/examples/gtk-demo/src/demos/dialogs/dialog.tsx
+++ b/examples/gtk-demo/src/demos/dialogs/dialog.tsx
@@ -39,7 +39,7 @@ const dialogDemo: Demo = {
     id: "dialog",
     title: "Dialogs",
     description: "Dialogs are used to pop up transient windows for information and user feedback.",
-    keywords: ["GtkMessageDialog"],
+    keywords: [],
     component: DialogDemo,
     sourceCode,
     isResizable: false,

--- a/examples/gtk-demo/src/demos/dialogs/pickers.tsx
+++ b/examples/gtk-demo/src/demos/dialogs/pickers.tsx
@@ -337,17 +337,9 @@ const FilePickerRow = ({ fileState, handlers, fileButtonWidget, setFileButtonWid
 
 const UriPickerRow = ({ uriButtonWidget, setUriButtonWidget, onLaunchUri }: UriRowProps) => (
     <>
-        <GtkGridLayoutChild column={0} row={3}>
-            <GtkLabel
-                useUnderline
-                halign={Gtk.Align.START}
-                valign={Gtk.Align.CENTER}
-                hexpand
-                mnemonicWidget={uriButtonWidget}
-            >
-                _URI:
-            </GtkLabel>
-        </GtkGridLayoutChild>
+        <PickerLabel row={3} target={uriButtonWidget}>
+            _URI:
+        </PickerLabel>
         <GtkGridLayoutChild column={1} row={3}>
             <GtkButton
                 ref={(node) => {

--- a/examples/gtk-demo/src/demos/drawing/drawingarea.tsx
+++ b/examples/gtk-demo/src/demos/drawing/drawingarea.tsx
@@ -7,6 +7,12 @@ import sourceCode from "./drawingarea.tsx?raw";
 
 const CHECK_SIZE = 16;
 
+const SUBCIRCLES: { rgb: [number, number, number]; angle: number }[] = [
+    { rgb: [1, 0, 0], angle: 0.5 },
+    { rgb: [0, 1, 0], angle: 0.5 + 2 / 0.3 },
+    { rgb: [0, 0, 1], angle: 0.5 + 4 / 0.3 },
+];
+
 const drawingAreaDemo: Demo = {
     id: "drawingarea",
     title: "Drawing Area",
@@ -64,36 +70,20 @@ const draw3Circles = (
     { xc, yc, radius, alpha }: { xc: number; yc: number; radius: number; alpha: number },
 ) => {
     const subradius = radius * (2 / 3 - 0.1);
-    cr.setSourceRgba(1, 0, 0, alpha);
 
-    ovalPath(cr, {
-        xc: xc + (radius / 3) * Math.cos(Math.PI * 0.5),
-        yc: yc - (radius / 3) * Math.sin(Math.PI * 0.5),
-        xr: subradius,
-        yr: subradius,
-    });
+    for (const { rgb, angle } of SUBCIRCLES) {
+        const [r, g, b] = rgb;
+        cr.setSourceRgba(r, g, b, alpha);
 
-    cr.fill();
-    cr.setSourceRgba(0, 1, 0, alpha);
+        ovalPath(cr, {
+            xc: xc + (radius / 3) * Math.cos(Math.PI * angle),
+            yc: yc - (radius / 3) * Math.sin(Math.PI * angle),
+            xr: subradius,
+            yr: subradius,
+        });
 
-    ovalPath(cr, {
-        xc: xc + (radius / 3) * Math.cos(Math.PI * (0.5 + 2 / 0.3)),
-        yc: yc - (radius / 3) * Math.sin(Math.PI * (0.5 + 2 / 0.3)),
-        xr: subradius,
-        yr: subradius,
-    });
-
-    cr.fill();
-    cr.setSourceRgba(0, 0, 1, alpha);
-
-    ovalPath(cr, {
-        xc: xc + (radius / 3) * Math.cos(Math.PI * (0.5 + 4 / 0.3)),
-        yc: yc - (radius / 3) * Math.sin(Math.PI * (0.5 + 4 / 0.3)),
-        xr: subradius,
-        yr: subradius,
-    });
-
-    cr.fill();
+        cr.fill();
+    }
 };
 
 const drawKnockoutGroups = (_self: Gtk.DrawingArea, cr: Context, width: number, height: number) => {

--- a/examples/gtk-demo/src/demos/gestures/cursors.tsx
+++ b/examples/gtk-demo/src/demos/gestures/cursors.tsx
@@ -194,8 +194,7 @@ const CursorRow = ({ info }: { info: CursorInfo }) => {
         <GtkListBoxRow activatable={false}>
             <GtkBox spacing={10} marginStart={10} marginEnd={10} marginTop={10} marginBottom={10}>
                 <CursorPreview info={info} />
-                {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-                <GtkLabel halign={Gtk.Align.START} valign={Gtk.Align.BASELINE} hexpand xalign={0}>
+                <GtkLabel halign={Gtk.Align.START} valign={Gtk.Align.BASELINE_FILL} hexpand xalign={0}>
                     {info.name}
                 </GtkLabel>
                 <CursorFrame cursor={cursors[0]} tooltip={tooltips[0]} />

--- a/examples/gtk-demo/src/demos/input/hypertext.tsx
+++ b/examples/gtk-demo/src/demos/input/hypertext.tsx
@@ -15,9 +15,8 @@ import {
     GtkTextTag,
     GtkTextView,
 } from "@gtkx/jsx/gtk";
+import { tryResolveExecutable } from "@gtkx/utils";
 import { spawn } from "node:child_process";
-import { accessSync, constants } from "node:fs";
-import { delimiter, join } from "node:path";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Demo } from "../types.js";
 import { lookupIconPaintable } from "../icon-paintable.js";
@@ -83,6 +82,8 @@ type LinkKeyPressArgs = {
     setCurrentPage: (page: number) => void;
 };
 
+const SPEAK_COMMAND = "espeak-ng";
+
 const hypertextDemo: Demo = {
     id: "hypertext",
     title: "Text View/Hypertext",
@@ -100,32 +101,8 @@ const hypertextDemo: Demo = {
     isResizable: false,
 };
 
-function isExecutable(path: string): boolean {
-    try {
-        accessSync(path, constants.X_OK);
-
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-function resolveExecutable(command: string): string {
-    const searchPaths = (process.env.PATH ?? "").split(delimiter).filter((entry) => entry.length > 0);
-
-    for (const directory of searchPaths) {
-        const candidate = join(directory, command);
-
-        if (isExecutable(candidate)) {
-            return candidate;
-        }
-    }
-
-    return command;
-}
-
 function sayWord(word: string): void {
-    spawn(resolveExecutable("espeak-ng"), [word], { stdio: "ignore" });
+    spawn(tryResolveExecutable(SPEAK_COMMAND) ?? SPEAK_COMMAND, [word], { stdio: "ignore" });
 }
 
 function InlineIcon({ iconName, size }: { iconName: string; size: number }) {

--- a/examples/gtk-demo/src/demos/input/password-entry.tsx
+++ b/examples/gtk-demo/src/demos/input/password-entry.tsx
@@ -6,10 +6,12 @@ import type { Demo, DemoProps, DemoProviderProps } from "../types.js";
 import { useDemo } from "../../context/demo-context.js";
 import sourceCode from "./password-entry.tsx?raw";
 
+type TextNotifyHandler = (pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => void;
+
 type PasswordEntryContextValue = {
     arePasswordsMatching: boolean;
-    handlePasswordNotify: (pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => void;
-    handleConfirmNotify: (pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => void;
+    handlePasswordNotify: TextNotifyHandler;
+    handleConfirmNotify: TextNotifyHandler;
 };
 
 const PasswordEntryContext = createContext<PasswordEntryContextValue | null>(null);
@@ -41,22 +43,18 @@ function usePasswordEntryContext(): PasswordEntryContextValue {
     return ctx;
 }
 
+const createTextNotifyHandler = (setText: (text: string) => void): TextNotifyHandler => (pspec, self) => {
+    if (pspec.getName() === "text") {
+        setText(self.getText());
+    }
+};
+
 function PasswordEntryProvider({ children }: DemoProviderProps) {
     const [password, setPassword] = useState("");
     const [confirm, setConfirm] = useState("");
     const arePasswordsMatching = password.length > 0 && password === confirm;
-
-    const handlePasswordNotify = (pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => {
-        if (pspec.getName() === "text") {
-            setPassword(self.getText());
-        }
-    };
-
-    const handleConfirmNotify = (pspec: GObject.ParamSpec, self: Gtk.PasswordEntry) => {
-        if (pspec.getName() === "text") {
-            setConfirm(self.getText());
-        }
-    };
+    const handlePasswordNotify = createTextNotifyHandler(setPassword);
+    const handleConfirmNotify = createTextNotifyHandler(setConfirm);
 
     const value = {
         arePasswordsMatching,

--- a/examples/gtk-demo/src/demos/layout/fixed2.tsx
+++ b/examples/gtk-demo/src/demos/layout/fixed2.tsx
@@ -41,14 +41,10 @@ function computeFixedTransform(
 ): Gsk.Transform | undefined {
     const angle = duration * 90;
     const scale = 2 + Math.sin(duration * Math.PI);
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const labelWidth = label?.getAllocatedWidth() ?? 50;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const labelHeight = label?.getAllocatedHeight() ?? 20;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const containerWidth = fixed?.getAllocatedWidth() ?? 400;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const containerHeight = fixed?.getAllocatedHeight() ?? 300;
+    const labelWidth = label?.getWidth() ?? 50;
+    const labelHeight = label?.getHeight() ?? 20;
+    const containerWidth = fixed?.getWidth() ?? 400;
+    const containerHeight = fixed?.getHeight() ?? 300;
     const centerPoint = new Graphene.Point();
     centerPoint.init(containerWidth / 2, containerHeight / 2);
     const offsetPoint = new Graphene.Point();

--- a/examples/gtk-demo/src/demos/layout/sizegroup.tsx
+++ b/examples/gtk-demo/src/demos/layout/sizegroup.tsx
@@ -115,20 +115,26 @@ function DropdownRow({ row, selection, dropdowns, setSelection, setDropdowns }: 
     );
 }
 
+const PaddedColumn = ({ children }: { children: ReactNode }) => (
+    <GtkBox
+        orientation={Gtk.Orientation.VERTICAL}
+        spacing={5}
+        marginStart={5}
+        marginEnd={5}
+        marginTop={5}
+        marginBottom={5}
+    >
+        {children}
+    </GtkBox>
+);
+
 const OptionsFrame = ({ frame, ...state }: OptionsFrameProps) => (
     <GtkFrame name={frame.name} label={frame.label}>
-        <GtkBox
-            orientation={Gtk.Orientation.VERTICAL}
-            spacing={5}
-            marginStart={5}
-            marginEnd={5}
-            marginTop={5}
-            marginBottom={5}
-        >
+        <PaddedColumn>
             {frame.rows.map((row) => (
                 <DropdownRow key={row.labelText} row={row} {...state} />
             ))}
-        </GtkBox>
+        </PaddedColumn>
     </GtkFrame>
 );
 
@@ -145,14 +151,7 @@ function SizeGroupDemo() {
     const state = { selection, dropdowns, setSelection, setDropdowns };
 
     return (
-        <GtkBox
-            orientation={Gtk.Orientation.VERTICAL}
-            spacing={5}
-            marginStart={5}
-            marginEnd={5}
-            marginTop={5}
-            marginBottom={5}
-        >
+        <PaddedColumn>
             <GtkSizeGroup mode={mode} widgets={groupedDropdowns(dropdowns)} />
             {FRAMES.map((frame) => (
                 <OptionsFrame key={frame.name} frame={frame} {...state} />
@@ -164,7 +163,7 @@ function SizeGroupDemo() {
                 active={isGroupingEnabled}
                 onToggled={handleToggle}
             />
-        </GtkBox>
+        </PaddedColumn>
     );
 }
 

--- a/examples/gtk-demo/src/demos/lists/listbox.tsx
+++ b/examples/gtk-demo/src/demos/lists/listbox.tsx
@@ -164,19 +164,15 @@ const MessageAvatar = ({ message }: { message: Message }) => (
 const MessageHeader = ({ message }: { message: Message }) => (
     <GtkGridLayoutChild column={1} row={0}>
         <GtkBox hexpand baselinePosition={Gtk.BaselinePosition.TOP}>
-            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-            <GtkButton receivesDefault hasFrame={false} valign={Gtk.Align.BASELINE}>
-                {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-                <GtkLabel valign={Gtk.Align.BASELINE} attributes={boldAttrs}>
+            <GtkButton receivesDefault hasFrame={false} valign={Gtk.Align.BASELINE_FILL}>
+                <GtkLabel valign={Gtk.Align.BASELINE_FILL} attributes={boldAttrs}>
                     {message.senderName}
                 </GtkLabel>
             </GtkButton>
-            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-            <GtkLabel valign={Gtk.Align.BASELINE} cssClasses={["dim-label"]}>
+            <GtkLabel valign={Gtk.Align.BASELINE_FILL} cssClasses={["dim-label"]}>
                 {message.senderNick}
             </GtkLabel>
-            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-            <GtkLabel hexpand xalign={1} valign={Gtk.Align.BASELINE} cssClasses={["dim-label"]}>
+            <GtkLabel hexpand xalign={1} valign={Gtk.Align.BASELINE_FILL} cssClasses={["dim-label"]}>
                 {formatShortTime(message.time)}
             </GtkLabel>
         </GtkBox>

--- a/examples/gtk-demo/src/demos/lists/listview-selections.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-selections.tsx
@@ -166,10 +166,9 @@ const listviewSelectionsDemo: Demo = {
     id: "listview-selections",
     title: "Lists/Selections",
     description:
-        "The GtkDropDown widget is a modern alternative to GtkComboBox. It uses list models instead of tree " +
-        "models, and the content is displayed using widgets instead of cell renderers.\n\nThis example also " +
-        "shows a custom widget that can replace GtkEntryCompletion or GtkComboBoxText. It is not currently " +
-        "part of GTK.",
+        "The GtkDropDown widget presents a list of choices. It is backed by a list model, and each item is " +
+        "displayed with a widget produced by a factory.\n\nThis example also shows a custom entry that " +
+        "completes what you type from a word list and offers the matches in a popover. It is not part of GTK.",
     keywords: ["suggestion", "completion"],
     component: ListViewSelectionsDemo,
     sourceCode,

--- a/examples/gtk-demo/src/demos/lists/listview-settings.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-settings.tsx
@@ -1,4 +1,4 @@
-import { ColumnView, type ColumnViewColumn, ListView } from "@gtkx/components";
+import { ColumnView, type ColumnViewColumn, type ListItem, ListView } from "@gtkx/components";
 import * as Gio from "@gtkx/gi/gio";
 import * as GLib from "@gtkx/gi/glib";
 import * as Gtk from "@gtkx/gi/gtk";
@@ -16,6 +16,7 @@ import {
 } from "@gtkx/jsx/gtk";
 import { createContext, useContext, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
+import { collectExpandableIds } from "../../collect-expandable-ids.js";
 import sourceCode from "./listview-settings.tsx?raw";
 
 type KeyInfo = {
@@ -35,13 +36,6 @@ type SchemaTreeNode = {
 
 type NodeIdSource = {
     next: number;
-};
-
-type SchemaTreeItemData = {
-    id: string;
-    value: string;
-    hideExpander?: true;
-    children?: SchemaTreeItemData[];
 };
 
 type ListViewSettingsState = ReturnType<typeof useListViewSettingsState>;
@@ -296,9 +290,9 @@ function loadKeysForNode(nodeId: string): KeyInfo[] {
     return schema.listKeys().map((keyName) => readKeyInfo(schema, settings, keyName));
 }
 
-function schemaNodeToItem(node: SchemaTreeNode): SchemaTreeItemData {
+function schemaNodeToItem(node: SchemaTreeNode): ListItem<string> {
     if (node.children.length === 0) {
-        return { id: node.nodeId, value: node.schemaId, hideExpander: true };
+        return { id: node.nodeId, value: node.schemaId, shouldHideExpander: true };
     }
 
     return {
@@ -399,18 +393,6 @@ function commitKeyInfoEdit({ keyInfo, newText, widget, state }: CommitKeyInfoEdi
     }
 }
 
-function collectSchemaExpandableIds(nodes: SchemaTreeItemData[]): string[] {
-    const ids: string[] = [];
-
-    for (const node of nodes) {
-        if (node.children && node.children.length > 0) {
-            ids.push(node.id, ...collectSchemaExpandableIds(node.children));
-        }
-    }
-
-    return ids;
-}
-
 const renderKeyInfoCell =
     (getText: (keyInfo: KeyInfo) => string, shouldWrap = false) =>
         ({ item }: { item: KeyInfo }) => (
@@ -477,6 +459,7 @@ function renderSchemaItem({ item: schemaId }: { item: string }) {
 
 const SchemaSidebar = ({ onSelectionChanged }: { onSelectionChanged: (ids: string[]) => void }) => {
     const items = getSchemaTree().map((node) => schemaNodeToItem(node));
+    const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
     return (
         <GtkScrolledWindow>
@@ -484,9 +467,13 @@ const SchemaSidebar = ({ onSelectionChanged }: { onSelectionChanged: (ids: strin
                 name="sidebar"
                 tabBehavior={Gtk.ListTabBehavior.ITEM}
                 selectionMode={Gtk.SelectionMode.BROWSE}
-                onSelectionChanged={onSelectionChanged}
+                selectedIds={selectedIds}
+                onSelectionChanged={(ids: string[]) => {
+                    setSelectedIds(ids);
+                    onSelectionChanged(ids);
+                }}
                 cssClasses={["navigation-sidebar"]}
-                expandedIds={collectSchemaExpandableIds(items)}
+                expandedIds={collectExpandableIds(items)}
                 renderItem={renderSchemaItem}
                 items={items}
             />

--- a/examples/gtk-demo/src/demos/lists/listview-words.tsx
+++ b/examples/gtk-demo/src/demos/lists/listview-words.tsx
@@ -1,3 +1,4 @@
+import type { ListItem } from "@gtkx/components";
 import { ListView } from "@gtkx/components";
 import * as Gtk from "@gtkx/gi/gtk";
 import {
@@ -13,7 +14,7 @@ import {
 } from "@gtkx/jsx/gtk";
 import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { createContext, type RefObject, useContext, useEffect, useRef, useState } from "react";
+import { createContext, type RefObject, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { Demo, DemoProviderProps } from "../types.js";
 import { useDemo } from "../../context/demo-context.js";
 import sourceCode from "./listview-words.tsx?raw";
@@ -22,31 +23,37 @@ type FilterState = {
     wasCanceled: boolean;
 };
 
+type WordScan = {
+    items: ListItem<string>[];
+    lower: string[];
+};
+
 type FilterStep = {
     ctx: FilterState;
-    words: string[];
-    lower: string;
-    result: string[];
+    scan: WordScan;
+    needle: string;
+    matched: WordScan;
     offset: number;
-    onChunk: (matched: string[], progress: number) => void;
+    onChunk: (matched: WordScan, progress: number) => void;
 };
 
 type FilterResult = {
+    words: WordScan;
     search: string;
-    words: string[];
+    scan: WordScan;
     progress: number;
 };
 
 type WordsContextValue = {
     searchText: string;
     setSearchText: (value: string) => void;
-    filteredWords: string[];
+    filteredItems: ListItem<string>[];
     filterProgress: number;
     handleOpen: () => void;
 };
 
 type WordsListProps = {
-    filteredWords: string[];
+    filteredItems: ListItem<string>[];
     filterProgress: number;
 };
 
@@ -58,6 +65,7 @@ const LOREM_IPSUM =
     "commodi consequat";
 
 const FILTER_CHUNK_SIZE = 50_000;
+const NO_MATCHES: ListItem<string>[] = [];
 const initialWords = loadInitialWords();
 const WordsContext = createContext<WordsContextValue | null>(null);
 
@@ -140,12 +148,25 @@ async function openWordsFile(
     }
 }
 
+function scanWords(words: string[]): WordScan {
+    const scan: WordScan = { items: [], lower: [] };
+
+    for (const word of words) {
+        scan.items.push({ id: word, value: word });
+        scan.lower.push(word.toLowerCase());
+    }
+
+    return scan;
+}
+
 function collectMatches(step: FilterStep, end: number) {
     for (let index = step.offset; index < end; index++) {
-        const word = step.words[index];
+        const item = step.scan.items[index];
+        const lower = step.scan.lower[index];
 
-        if (word?.toLowerCase().includes(step.lower)) {
-            step.result.push(word);
+        if (item !== undefined && lower?.includes(step.needle)) {
+            step.matched.items.push(item);
+            step.matched.lower.push(lower);
         }
     }
 }
@@ -155,10 +176,10 @@ function runFilterStep(step: FilterStep) {
         return;
     }
 
-    const total = step.words.length;
+    const total = step.scan.items.length;
     const end = Math.min(step.offset + FILTER_CHUNK_SIZE, total);
     collectMatches(step, end);
-    step.onChunk([...step.result], total > 0 ? end / total : 1);
+    step.onChunk({ items: [...step.matched.items], lower: [...step.matched.lower] }, total > 0 ? end / total : 1);
 
     if (end < total) {
         setTimeout(() => {
@@ -167,28 +188,36 @@ function runFilterStep(step: FilterStep) {
     }
 }
 
-function selectFilteredWords(words: string[], searchText: string, result: FilterResult | null) {
-    if (searchText === "") {
-        return { filteredWords: words, filterProgress: 1 };
-    }
-
-    if (result === null) {
-        return { filteredWords: words, filterProgress: 0 };
-    }
-
-    if (result.search !== searchText) {
-        return { filteredWords: result.words, filterProgress: 0 };
-    }
-
-    return { filteredWords: result.words, filterProgress: result.progress };
+function canNarrow(previous: FilterResult | null, words: WordScan, searchText: string): previous is FilterResult {
+    return previous?.words === words && previous.progress === 1 && searchText.startsWith(previous.search);
 }
 
-function useFilteredWords(words: string[], searchText: string) {
+function selectFilteredWords(words: WordScan, searchText: string, result: FilterResult | null) {
+    if (searchText === "") {
+        return { filteredItems: words.items, filterProgress: 1 };
+    }
+
+    if (result?.words !== words || result.search !== searchText) {
+        return { filteredItems: NO_MATCHES, filterProgress: 0 };
+    }
+
+    return { filteredItems: result.scan.items, filterProgress: result.progress };
+}
+
+function startFilter(step: Omit<FilterStep, "matched" | "offset">) {
+    setTimeout(() => {
+        runFilterStep({ ...step, matched: { items: [], lower: [] }, offset: 0 });
+    }, 0);
+}
+
+function useFilteredWords(words: WordScan, searchText: string) {
     const [result, setResult] = useState<FilterResult | null>(null);
     const filterRef = useRef<FilterState>({ wasCanceled: false });
+    const lastRef = useRef<FilterResult | null>(null);
 
     useEffect(() => {
         filterRef.current.wasCanceled = true;
+        lastRef.current = canNarrow(lastRef.current, words, searchText) ? lastRef.current : null;
 
         if (searchText === "") {
             return;
@@ -197,18 +226,16 @@ function useFilteredWords(words: string[], searchText: string) {
         const ctx: FilterState = { wasCanceled: false };
         filterRef.current = ctx;
 
-        setTimeout(() => {
-            runFilterStep({
-                ctx,
-                words,
-                lower: searchText.toLowerCase(),
-                result: [],
-                offset: 0,
-                onChunk: (matched, progress) => {
-                    setResult({ search: searchText, words: matched, progress });
-                },
-            });
-        }, 0);
+        startFilter({
+            ctx,
+            scan: lastRef.current?.scan ?? words,
+            needle: searchText.toLowerCase(),
+            onChunk: (matched, progress) => {
+                const next: FilterResult = { words, search: searchText, scan: matched, progress };
+                lastRef.current = next;
+                setResult(next);
+            },
+        });
 
         return () => {
             ctx.wasCanceled = true;
@@ -239,7 +266,7 @@ function renderWord({ item: word }: { item: string }) {
     );
 }
 
-const WordsList = ({ filteredWords, filterProgress }: WordsListProps) => (
+const WordsList = ({ filteredItems, filterProgress }: WordsListProps) => (
     <GtkOverlay
         vexpand
         hexpand
@@ -263,7 +290,7 @@ const WordsList = ({ filteredWords, filterProgress }: WordsListProps) => (
                 hexpand
                 estimatedItemHeight={32}
                 selectionMode={Gtk.SelectionMode.NONE}
-                items={filteredWords.map((word) => ({ id: word, value: word }))}
+                items={filteredItems}
                 renderItem={renderWord}
             />
         </GtkScrolledWindow>
@@ -273,7 +300,8 @@ const WordsList = ({ filteredWords, filterProgress }: WordsListProps) => (
 function ListViewWordsProvider({ window, children }: DemoProviderProps) {
     const [words, setWords] = useState(initialWords);
     const [searchText, setSearchText] = useState("");
-    const { filteredWords, filterProgress } = useFilteredWords(words, searchText);
+    const scan = useMemo(() => scanWords(words), [words]);
+    const { filteredItems, filterProgress } = useFilteredWords(scan, searchText);
 
     const handleOpen = () => {
         void openWordsFile(window, (filePath) => loadWordsFromFile(filePath, setWords, setSearchText));
@@ -282,7 +310,7 @@ function ListViewWordsProvider({ window, children }: DemoProviderProps) {
     const value = {
         searchText,
         setSearchText,
-        filteredWords,
+        filteredItems,
         filterProgress,
         handleOpen,
     };
@@ -297,16 +325,16 @@ function ListViewWordsTitlebar() {
 }
 
 function ListViewWordsDemo() {
-    const { searchText, setSearchText, filteredWords, filterProgress } = useWordsContext();
+    const { searchText, setSearchText, filteredItems, filterProgress } = useWordsContext();
     const { setWindowTitle } = useDemo();
 
     useEffect(() => {
-        setWindowTitle(`${String(filteredWords.length)} lines`);
+        setWindowTitle(`${String(filteredItems.length)} lines`);
 
         return () => {
             setWindowTitle(null);
         };
-    }, [filteredWords.length, setWindowTitle]);
+    }, [filteredItems.length, setWindowTitle]);
 
     return (
         <GtkBox orientation={Gtk.Orientation.VERTICAL} spacing={0} vexpand hexpand>
@@ -319,7 +347,7 @@ function ListViewWordsDemo() {
                 }}
                 hexpand
             />
-            <WordsList filteredWords={filteredWords} filterProgress={filterProgress} />
+            <WordsList filteredItems={filteredItems} filterProgress={filterProgress} />
         </GtkBox>
     );
 }

--- a/examples/gtk-demo/src/demos/opengl/gears.tsx
+++ b/examples/gtk-demo/src/demos/opengl/gears.tsx
@@ -677,10 +677,8 @@ const computeViewTransform = (rotation: ViewRotation): number[] => {
 
 const renderGearsFrame = ({ glState, area, rotation, angle }: RenderFrameParams): void => {
     const scale = area.getScaleFactor();
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const width = area.getAllocatedWidth() * scale;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const height = area.getAllocatedHeight() * scale;
+    const width = area.getWidth() * scale;
+    const height = area.getHeight() * scale;
     const projection = mat4Perspective(Math.PI / 3, width / height, 1, 1024);
     gl.viewport(0, 0, width, height);
     gl.clearColor(0, 0, 0, 0);
@@ -757,8 +755,7 @@ function GearsDemo() {
                 <GtkGLArea
                     name="gl-area"
                     ref={handleGLAreaRef}
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    useEs
+                    allowedApis={Gdk.GLAPI.GLES}
                     hasDepthBuffer
                     hexpand
                     vexpand

--- a/examples/gtk-demo/src/demos/opengl/shadertoy.tsx
+++ b/examples/gtk-demo/src/demos/opengl/shadertoy.tsx
@@ -1340,8 +1340,7 @@ const ShaderPreview = ({ shaderCode }: { shaderCode: string }) => {
     return (
         <GtkGLArea
             ref={glAreaRef}
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            useEs
+            allowedApis={Gdk.GLAPI.GLES}
             onRender={handleRender}
             onResize={handleResize}
             onUnrealize={handleUnrealize}
@@ -1549,8 +1548,7 @@ const ShadertoyGLAreaPanel = ({
             <GtkGLArea
                 name="shadertoy-gl-area"
                 ref={glAreaRef}
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
-                useEs
+                allowedApis={Gdk.GLAPI.GLES}
                 onRender={handleRender}
                 onResize={handleResize}
                 onUnrealize={handleUnrealize}

--- a/examples/gtk-demo/src/use-context-menu-gesture.ts
+++ b/examples/gtk-demo/src/use-context-menu-gesture.ts
@@ -16,23 +16,23 @@ function useContextMenuGesture(options: ContextMenuGestureOptions): ContextMenuG
     const ref = useRef<Gtk.GestureClick | null>(null);
     const { onContextMenu } = options;
 
-    const onPressed = (_nPress: number, x: number, y: number) => {
+    const notifyWhenEventMatches = (x: number, y: number, isMatching: (event: Gdk.Event) => boolean) => {
         const event = ref.current?.getCurrentEvent();
 
-        if (event?.triggersContextMenu()) {
+        if (event && isMatching(event)) {
             onContextMenu(x, y);
         }
     };
 
-    const onReleased = (_nPress: number, x: number, y: number) => {
-        const event = ref.current?.getCurrentEvent();
+    const onPressed = (_nPress: number, x: number, y: number) => {
+        notifyWhenEventMatches(x, y, (event) => event.triggersContextMenu());
+    };
 
-        if (event?.getEventType() === Gdk.EventType.TOUCH_END) {
-            onContextMenu(x, y);
-        }
+    const onReleased = (_nPress: number, x: number, y: number) => {
+        notifyWhenEventMatches(x, y, (event) => event.getEventType() === Gdk.EventType.TOUCH_END);
     };
 
     return { ref, onPressed, onReleased };
 }
 
-export { type ContextMenuGesture, type ContextMenuGestureOptions, useContextMenuGesture };
+export { useContextMenuGesture };

--- a/examples/gtk-demo/tsconfig.app.json
+++ b/examples/gtk-demo/tsconfig.app.json
@@ -3,6 +3,9 @@
     "files": ["${configDir}/node_modules/.gtkx/env.d.ts"],
     "references": [
       {
+        "path": "../../packages/utils/tsconfig.lib.json"
+      },
+      {
         "path": "../../packages/react/tsconfig.lib.json"
       },
       {

--- a/knip.json
+++ b/knip.json
@@ -14,9 +14,6 @@
         "^@gtkx/jsx(/.*)?$"
     ],
     "ignoreIssues": {
-        "packages/utils/src/process/index.ts": [
-            "exports"
-        ],
         "**/gtkx.config.ts": [
             "exports"
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@gtkx/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
+      '@gtkx/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       react:
         specifier: 'catalog:'
         version: 19.2.8


### PR DESCRIPTION
Deduplicates the gtk-demo sources and takes the deprecated widgets out of them.

- The demos share their repeated helpers instead of copying them.
- Demos built on widgets GTK or Adwaita deprecated are rewritten on the replacements, so the example application no longer teaches an API on its way out.

The targeted `@typescript-eslint/no-deprecated` disables these sources have carried since part 4 are removed here along with the usages that needed them.

Part 12 of the v1.0.0 release stack. Merge in order.

### Areas touched

- `examples/gtk-demo` (26)
