### PR TITLE
Update the gtk-demo suites for mapped queries

### DIFF
--- a/examples/gtk-demo/tests/app-interactions.test.tsx
+++ b/examples/gtk-demo/tests/app-interactions.test.tsx
@@ -1,23 +1,12 @@
 import * as Gdk from "@gtkx/gi/gdk";
 import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
-import { GtkApplication } from "@gtkx/jsx/gtk";
-import { rootElement } from "@gtkx/react";
-import { act, render, screen, userEvent, waitFor } from "@gtkx/testing";
+import { act, screen, userEvent, waitFor } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
 import { path as logoResourcePath } from "#data/icons/org.gtk.Demo4.svg";
-import { Demo } from "../src/app.js";
-import { createApplicationIdFactory } from "./test-utils.js";
+import { createAppRenderer } from "./render-app.js";
 
-const nextApplicationId = createApplicationIdFactory("org.gtkx.gtkdemoint");
-
-const renderDemo = () =>
-    render(
-        <GtkApplication applicationId={nextApplicationId()} flags={Gio.ApplicationFlags.NON_UNIQUE}>
-            <Demo />
-        </GtkApplication>,
-        { container: rootElement },
-    );
+const renderDemo = createAppRenderer("org.gtkx.gtkdemoint");
 
 const selectFirstDemoWithComponent = async (): Promise<void> => {
     const sidebar = await screen.findByName("sidebar-list", { as: Gtk.ListView });
@@ -36,6 +25,21 @@ const selectFirstDemoWithComponent = async (): Promise<void> => {
     }
 
     expect(selectedIndex, "no demo with a runnable component found in the sidebar").not.toBeNull();
+};
+
+const renderMainWindowBody = async (): Promise<Gtk.Widget> => {
+    await renderDemo();
+
+    return await screen.findByName("main-window-body");
+};
+
+const findNotebook = async (): Promise<Gtk.Notebook> => await screen.findByName("notebook", { as: Gtk.Notebook });
+
+const expectDialogShown = async (): Promise<void> => {
+    await waitFor(async () => {
+        const dialogs = await screen.findAllByRole(Gtk.AccessibleRole.DIALOG);
+        expect(dialogs.length).toBeGreaterThan(0);
+    });
 };
 
 const openMenuItem = async (name: string): Promise<void> => {
@@ -85,11 +89,7 @@ describe("App about menu", () => {
     it("renders the about dialog after the About menu entry is activated", async () => {
         await renderDemo();
         await openMenuItem("About GTK Demo");
-
-        await waitFor(async () => {
-            const dialogs = await screen.findAllByRole(Gtk.AccessibleRole.DIALOG);
-            expect(dialogs.length).toBeGreaterThan(0);
-        });
+        await expectDialogShown();
     });
 
     it("bundles the application icon into the GResource so AdwAboutDialog can resolve it", async () => {
@@ -103,8 +103,9 @@ describe("App about menu", () => {
 describe("App notebook", () => {
     it("renders the Info and Source tabs", async () => {
         await renderDemo();
-        const infoTab = await screen.findByRole(Gtk.AccessibleRole.TAB, { name: "Info" });
-        const sourceTab = await screen.findByRole(Gtk.AccessibleRole.TAB, { name: "Source" });
+        const tabs = await screen.findAllByRole(Gtk.AccessibleRole.TAB);
+        const [infoTab, sourceTab] = tabs;
+        expect(tabs).toHaveLength(2);
         expect(infoTab).toBeInstanceOf(Gtk.Widget);
         expect(sourceTab).toBeInstanceOf(Gtk.Widget);
         expect(sourceTab).not.toBe(infoTab);
@@ -112,7 +113,7 @@ describe("App notebook", () => {
 
     it("advances the page when the notebook page is set", async () => {
         await renderDemo();
-        const notebook = await screen.findByName("notebook", { as: Gtk.Notebook });
+        const notebook = await findNotebook();
         expect(notebook).toHaveObjectProperty("page", 0);
 
         await act(() => {
@@ -129,12 +130,7 @@ describe("App keyboard shortcuts dialog", () => {
     it("opens the keyboard shortcuts dialog when the menu entry is activated", async () => {
         await renderDemo();
         await openMenuItem("Keyboard Shortcuts");
-
-        await waitFor(async () => {
-            const dialogs = await screen.findAllByRole(Gtk.AccessibleRole.DIALOG);
-            expect(dialogs.length).toBeGreaterThan(0);
-        });
-
+        await expectDialogShown();
         const shortcutLabels = await screen.findAllByText("Search demos");
         expect(shortcutLabels.length).toBeGreaterThan(0);
     });
@@ -159,8 +155,7 @@ describe("App inspector activation", () => {
 
 describe("App global shortcuts", () => {
     it("toggles the search bar when Ctrl+F is pressed", async () => {
-        await renderDemo();
-        const body = await screen.findByName("main-window-body");
+        const body = await renderMainWindowBody();
         const searchBar = await screen.findByName("sidebar-search-bar", { as: Gtk.SearchBar });
         expect(searchBar).toHaveObjectProperty("searchModeEnabled", false);
         await userEvent.keyboard(body, "{Control>}f{/Control}");
@@ -174,8 +169,7 @@ describe("App global shortcuts", () => {
         const debugSpy = vi.spyOn(Gtk.Window, "setInteractiveDebugging").mockImplementation((): void => undefined);
 
         try {
-            await renderDemo();
-            const body = await screen.findByName("main-window-body");
+            const body = await renderMainWindowBody();
             await userEvent.keyboard(body, "{Control>}{Shift>}i{/Shift}{/Control}");
 
             await waitFor(() => {
@@ -187,9 +181,8 @@ describe("App global shortcuts", () => {
     });
 
     it("advances the notebook page when Ctrl+Page_Down is pressed", async () => {
-        await renderDemo();
-        const body = await screen.findByName("main-window-body");
-        const notebook = await screen.findByName("notebook", { as: Gtk.Notebook });
+        const body = await renderMainWindowBody();
+        const notebook = await findNotebook();
         expect(notebook).toHaveObjectProperty("page", 0);
         await userEvent.keyboard(body, "{Control>}{PageDown}{/Control}");
 
@@ -199,9 +192,8 @@ describe("App global shortcuts", () => {
     });
 
     it("returns to the previous notebook page when Ctrl+Page_Up is pressed", async () => {
-        await renderDemo();
-        const body = await screen.findByName("main-window-body");
-        const notebook = await screen.findByName("notebook", { as: Gtk.Notebook });
+        const body = await renderMainWindowBody();
+        const notebook = await findNotebook();
         await userEvent.keyboard(body, "{Control>}{PageDown}{/Control}");
 
         await waitFor(() => {
@@ -212,20 +204,6 @@ describe("App global shortcuts", () => {
 
         await waitFor(() => {
             expect(notebook).toHaveObjectProperty("page", 0);
-        });
-    });
-});
-
-describe("App opens demos with custom titlebars and dialog-only demos", () => {
-    it("renders Run-enabled demo entries from the sidebar (covers DemoWindow titlebar/provider paths)", async () => {
-        await renderDemo();
-        await selectFirstDemoWithComponent();
-        const run = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Run", as: Gtk.Button });
-        await userEvent.click(run);
-
-        await waitFor(async () => {
-            const windows = await screen.findAllByRole(Gtk.AccessibleRole.WINDOW);
-            expect(windows.length).toBeGreaterThan(1);
         });
     });
 });

--- a/examples/gtk-demo/tests/app.test.tsx
+++ b/examples/gtk-demo/tests/app.test.tsx
@@ -1,21 +1,9 @@
-import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
-import { GtkApplication } from "@gtkx/jsx/gtk";
-import { rootElement } from "@gtkx/react";
-import { render, screen } from "@gtkx/testing";
+import { screen } from "@gtkx/testing";
 import { describe, expect, it } from "vitest";
-import { Demo } from "../src/app.js";
-import { createApplicationIdFactory } from "./test-utils.js";
+import { createAppRenderer } from "./render-app.js";
 
-const nextApplicationId = createApplicationIdFactory("org.gtkx.gtkdemoapp");
-
-const renderDemo = () =>
-    render(
-        <GtkApplication applicationId={nextApplicationId()} flags={Gio.ApplicationFlags.NON_UNIQUE}>
-            <Demo />
-        </GtkApplication>,
-        { container: rootElement },
-    );
+const renderDemo = createAppRenderer("org.gtkx.gtkdemoapp");
 
 describe("App", () => {
     it("renders the main window titled 'GTK Demo'", async () => {

--- a/examples/gtk-demo/tests/components/sidebar.test.tsx
+++ b/examples/gtk-demo/tests/components/sidebar.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import * as Gtk from "@gtkx/gi/gtk";
-import { render, renderHook, screen } from "@gtkx/testing";
+import { render, renderHook, screen, within } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
 import type { Demo } from "../../src/demos/types.js";
 import { Sidebar } from "../../src/components/sidebar.js";
@@ -33,21 +33,19 @@ const standaloneDemo: Demo = {
 
 const noop = vi.fn();
 
-const ContextProbeWrapper = ({ children }: { children: ReactNode }) => (
-    <DemoProvider demos={[intro, buttonDemo, expanderDemo]}>
-        <Sidebar isSearchActive={false} onSearchChanged={noop} />
+const drawSidebar = (demos: Demo[], isSearchActive = false, children?: ReactNode): ReactNode => (
+    <DemoProvider demos={demos}>
+        <Sidebar isSearchActive={isSearchActive} onSearchChanged={noop} />
         {children}
     </DemoProvider>
 );
 
+const ContextProbeWrapper = ({ children }: { children: ReactNode }) =>
+    drawSidebar([intro, buttonDemo, expanderDemo], false, children);
+
 describe("Sidebar", () => {
     it("renders the Buttons category node grouping its two child demos", async () => {
-        await render(
-            <DemoProvider demos={[intro, buttonDemo, expanderDemo, standaloneDemo]}>
-                <Sidebar isSearchActive={false} onSearchChanged={noop} />
-            </DemoProvider>,
-        );
-
+        await render(drawSidebar([intro, buttonDemo, expanderDemo, standaloneDemo]));
         const category = await screen.findByText("Buttons");
         const first = await screen.findByText("Button");
         const second = await screen.findByText("Expander");
@@ -56,24 +54,14 @@ describe("Sidebar", () => {
     });
 
     it("renders top-level demos by their display title", async () => {
-        await render(
-            <DemoProvider demos={[intro, standaloneDemo]}>
-                <Sidebar isSearchActive={false} onSearchChanged={noop} />
-            </DemoProvider>,
-        );
-
+        await render(drawSidebar([intro, standaloneDemo]));
         const standalone = await screen.findByText("Standalone");
         const introEntry = await screen.findByText("GTK Demo");
         expect(standalone).not.toBe(introEntry);
     });
 
     it("opens the sidebar search bar when search mode is enabled", async () => {
-        await render(
-            <DemoProvider demos={[intro, buttonDemo, expanderDemo]}>
-                <Sidebar isSearchActive={true} onSearchChanged={noop} />
-            </DemoProvider>,
-        );
-
+        await render(drawSidebar([intro, buttonDemo, expanderDemo], true));
         const searchBar = await screen.findByName("sidebar-search-bar", { as: Gtk.SearchBar });
         expect(searchBar).toHaveObjectProperty("searchModeEnabled", true);
         await screen.findByText("Buttons");
@@ -82,5 +70,22 @@ describe("Sidebar", () => {
     it("exposes the current demo via the context", async () => {
         const { result } = await renderHook(() => useDemo(), { wrapper: ContextProbeWrapper });
         expect(result.current.currentDemo?.id).toBe("intro");
+    });
+});
+
+describe("Sidebar accessibility", () => {
+    it("names every expander in the tree and describes the ones that expand", async () => {
+        await render(drawSidebar([intro, buttonDemo, expanderDemo]));
+        const list = await screen.findByName("sidebar-list", { as: Gtk.ListView });
+        const expanders = within(list).getAllByRole(Gtk.AccessibleRole.BUTTON);
+        expect(expanders.length).toBeGreaterThan(0);
+
+        for (const expander of expanders) {
+            expect(expander).toHaveAccessibleName();
+        }
+
+        expect(within(list).getByRole(Gtk.AccessibleRole.BUTTON, { name: "Buttons" })).toHaveAccessibleDescription(
+            "Collapse",
+        );
     });
 });

--- a/examples/gtk-demo/tests/demos/advanced/font-features.test.tsx
+++ b/examples/gtk-demo/tests/demos/advanced/font-features.test.tsx
@@ -17,12 +17,55 @@ const expandFeatures = async (): Promise<void> => {
     await userEvent.click(expander);
 };
 
-const activateKerningFeature = async (): Promise<Gtk.Label> => {
+const renderExpandedFeatures = async (): Promise<void> => {
     await renderDemo(fontFeaturesDemo);
     await expandFeatures();
-    const kerning = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Kerning" });
+};
+
+const findFeatureCheck = async (name: string): Promise<Gtk.Widget> =>
+    await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name });
+
+const findSettingsLabel = async (): Promise<Gtk.Label> => await screen.findByName("settings", { as: Gtk.Label });
+
+const commitEntryValue = async (name: string, value: string): Promise<Gtk.Entry> => {
+    await renderDemo(fontFeaturesDemo);
+    const entry = await screen.findByName(name, { as: Gtk.Entry });
+    await userEvent.clear(entry);
+    await userEvent.type(entry, value);
+    await userEvent.keyboard(entry, "{Enter}");
+
+    return entry;
+};
+
+const renderColorButtons = async (): Promise<{ fg: Gtk.ColorDialogButton; bg: Gtk.ColorDialogButton }> => {
+    await renderDemo(fontFeaturesDemo);
+    const fg = await screen.findByName("foreground-color", { as: Gtk.ColorDialogButton });
+    const bg = await screen.findByName("background-color", { as: Gtk.ColorDialogButton });
+
+    return { fg, bg };
+};
+
+const renderViewToggles = async (): Promise<{ plain: Gtk.ToggleButton; waterfall: Gtk.ToggleButton }> => {
+    await renderDemo(fontFeaturesDemo);
+    const plain = await screen.findByName("plain_toggle", { as: Gtk.ToggleButton });
+    const waterfall = await screen.findByName("waterfall_toggle", { as: Gtk.ToggleButton });
+
+    return { plain, waterfall };
+};
+
+const enterEditMode = async (): Promise<Gtk.Stack> => {
+    await renderDemo(fontFeaturesDemo);
+    const editToggle = await screen.findByName("edit_toggle", { as: Gtk.ToggleButton });
+    await userEvent.click(editToggle);
+
+    return await screen.findByName("stack", { as: Gtk.Stack });
+};
+
+const activateKerningFeature = async (): Promise<Gtk.Label> => {
+    await renderExpandedFeatures();
+    const kerning = await findFeatureCheck("Kerning");
     await userEvent.click(kerning);
-    const settings = await screen.findByName("settings", { as: Gtk.Label });
+    const settings = await findSettingsLabel();
 
     await waitFor(() => {
         expect(settings).toHaveTextContent("kern=1");
@@ -45,9 +88,8 @@ describe("fontFeaturesDemo metadata", () => {
 
 describe("fontFeaturesDemo rendering", () => {
     it("expands the OpenType Features to reveal feature checkboxes", async () => {
-        await renderDemo(fontFeaturesDemo);
-        await expandFeatures();
-        const kerning = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Kerning" });
+        await renderExpandedFeatures();
+        const kerning = await findFeatureCheck("Kerning");
         expect(kerning).not.toBeChecked();
     });
 
@@ -66,42 +108,34 @@ describe("fontFeaturesDemo rendering", () => {
 
     it("renders the settings label empty initially", async () => {
         await renderDemo(fontFeaturesDemo);
-        const settings = await screen.findByName("settings", { as: Gtk.Label });
+        const settings = await findSettingsLabel();
         expect(settings).not.toHaveTextContent();
     });
 });
 
 describe("fontFeaturesDemo view mode buttons", () => {
     it("renders Plain and Waterfall toggle buttons with Plain active by default", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const plain = await screen.findByName("plain_toggle", { as: Gtk.ToggleButton });
-        const waterfall = await screen.findByName("waterfall_toggle", { as: Gtk.ToggleButton });
+        const { plain, waterfall } = await renderViewToggles();
         expect(plain).toBePressed();
         expect(waterfall).not.toBePressed();
     });
 
     it("switches to waterfall mode and renders multiple sized labels", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const waterfall = await screen.findByName("waterfall_toggle", { as: Gtk.ToggleButton });
+        const { waterfall } = await renderViewToggles();
         await userEvent.click(waterfall);
         const waterfallLabels = await screen.findAllByName("waterfall-label");
         expect(waterfallLabels).toHaveLength(15);
     });
 
     it("switches back to plain mode", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const plain = await screen.findByName("plain_toggle", { as: Gtk.ToggleButton });
-        const waterfall = await screen.findByName("waterfall_toggle", { as: Gtk.ToggleButton });
+        const { plain, waterfall } = await renderViewToggles();
         await userEvent.click(waterfall);
         await userEvent.click(plain);
         expect(plain).toBePressed();
     });
 
     it("switches to edit mode and shows the TextView in the stack", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const editBtn = await screen.findByName("edit_toggle", { as: Gtk.ToggleButton });
-        await userEvent.click(editBtn);
-        const stack = await screen.findByName("stack", { as: Gtk.Stack });
+        const stack = await enterEditMode();
         expect(stack).toHaveObjectProperty("visibleChildName", "entry");
     });
 });
@@ -137,7 +171,7 @@ describe("fontFeaturesDemo feature toggling", () => {
 
     it("cycles Kerning from active to explicitly-disabled on the second click (kern=0)", async () => {
         const settings = await activateKerningFeature();
-        const kerning = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Kerning" });
+        const kerning = await findFeatureCheck("Kerning");
         await userEvent.click(kerning);
 
         await waitFor(() => {
@@ -146,11 +180,10 @@ describe("fontFeaturesDemo feature toggling", () => {
     });
 
     it("selects a non-default radio value to enable a feature", async () => {
-        await renderDemo(fontFeaturesDemo);
-        await expandFeatures();
-        const liningFigures = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Lining Figures" });
+        await renderExpandedFeatures();
+        const liningFigures = await findFeatureCheck("Lining Figures");
         await userEvent.click(liningFigures);
-        const settings = await screen.findByName("settings", { as: Gtk.Label });
+        const settings = await findSettingsLabel();
 
         await waitFor(() => {
             expect(settings).toHaveTextContent("lnum=1");
@@ -179,20 +212,12 @@ describe("fontFeaturesDemo titlebar", () => {
 
 describe("fontFeaturesDemo size entry", () => {
     it("accepts a valid size entry value", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const sizeEntry = await screen.findByName("size_entry", { as: Gtk.Entry });
-        await userEvent.clear(sizeEntry);
-        await userEvent.type(sizeEntry, "24");
-        await userEvent.keyboard(sizeEntry, "{Enter}");
+        const sizeEntry = await commitEntryValue("size_entry", "24");
         expect(sizeEntry).toHaveDisplayValue("24");
     });
 
     it("ignores out-of-range size values without crashing the preview", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const sizeEntry = await screen.findByName("size_entry", { as: Gtk.Entry });
-        await userEvent.clear(sizeEntry);
-        await userEvent.type(sizeEntry, "9999");
-        await userEvent.keyboard(sizeEntry, "{Enter}");
+        await commitEntryValue("size_entry", "9999");
         const sliders = await screen.findAllByRole(Gtk.AccessibleRole.SLIDER);
         const sizeSlider = sliders[0] as Gtk.Scale;
         expect(sizeSlider.getValue()).toBe(14);
@@ -201,31 +226,19 @@ describe("fontFeaturesDemo size entry", () => {
 
 describe("fontFeaturesDemo letterspacing entry", () => {
     it("accepts a valid letterspacing entry", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const letterspacingEntry = await screen.findByName("letterspacing_entry", { as: Gtk.Entry });
-        await userEvent.clear(letterspacingEntry);
-        await userEvent.type(letterspacingEntry, "512");
-        await userEvent.keyboard(letterspacingEntry, "{Enter}");
+        const letterspacingEntry = await commitEntryValue("letterspacing_entry", "512");
         expect(letterspacingEntry).toHaveDisplayValue("512");
     });
 });
 
 describe("fontFeaturesDemo line-height entry", () => {
     it("accepts a valid line-height entry", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const lineHeightEntry = await screen.findByName("line_height_entry", { as: Gtk.Entry });
-        await userEvent.clear(lineHeightEntry);
-        await userEvent.type(lineHeightEntry, "1.5");
-        await userEvent.keyboard(lineHeightEntry, "{Enter}");
+        const lineHeightEntry = await commitEntryValue("line_height_entry", "1.5");
         expect(lineHeightEntry).toHaveDisplayValue("1.5");
     });
 
     it("ignores invalid line-height values", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const lineHeightEntry = await screen.findByName("line_height_entry", { as: Gtk.Entry });
-        await userEvent.clear(lineHeightEntry);
-        await userEvent.type(lineHeightEntry, "0.1");
-        await userEvent.keyboard(lineHeightEntry, "{Enter}");
+        await commitEntryValue("line_height_entry", "0.1");
         const sliders = await screen.findAllByRole(Gtk.AccessibleRole.SLIDER);
         const lineHeightSlider = sliders[2] as Gtk.Scale;
         expect(lineHeightSlider.getValue()).toBe(1);
@@ -234,9 +247,7 @@ describe("fontFeaturesDemo line-height entry", () => {
 
 describe("fontFeaturesDemo color swap", () => {
     it("swaps the default foreground and background colors on click", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const fg = await screen.findByName("foreground-color", { as: Gtk.ColorDialogButton });
-        const bg = await screen.findByName("background-color", { as: Gtk.ColorDialogButton });
+        const { fg, bg } = await renderColorButtons();
         expect(isRgbaEqual(fg, 0, 0, 0)).toBe(true);
         expect(isRgbaEqual(bg, 1, 1, 1)).toBe(true);
         const swap = await screen.findByName("swap-colors", { as: Gtk.Button });
@@ -250,9 +261,7 @@ describe("fontFeaturesDemo color swap", () => {
     });
 
     it("applies a foreground color change and carries it to the background on swap", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const fg = await screen.findByName("foreground-color", { as: Gtk.ColorDialogButton });
-        const bg = await screen.findByName("background-color", { as: Gtk.ColorDialogButton });
+        const { fg, bg } = await renderColorButtons();
         const red = new Gdk.RGBA();
         red.red = 1;
         red.green = 0;
@@ -316,10 +325,7 @@ describe("fontFeaturesDemo sliders", () => {
 
 describe("fontFeaturesDemo edit mode Escape", () => {
     it("reverts edits and returns to plain view when Escape is pressed", async () => {
-        await renderDemo(fontFeaturesDemo);
-        const editBtn = await screen.findByName("edit_toggle", { as: Gtk.ToggleButton });
-        await userEvent.click(editBtn);
-        const stack = await screen.findByName("stack", { as: Gtk.Stack });
+        const stack = await enterEditMode();
         expect(stack).toHaveObjectProperty("visibleChildName", "entry");
         const textView = await screen.findByName("edit_textview", { as: Gtk.TextView });
         textView.grabFocus();

--- a/examples/gtk-demo/tests/demos/advanced/fontrendering.test.tsx
+++ b/examples/gtk-demo/tests/demos/advanced/fontrendering.test.tsx
@@ -5,28 +5,36 @@ import { describe, expect, it } from "vitest";
 import { fontRenderingDemo } from "../../../src/demos/advanced/fontrendering.js";
 import { renderDemo } from "../../test-utils.js";
 
-async function activateGridMode(): Promise<Gtk.ToggleButton> {
-    const gridToggle = await screen.findByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, {
-        name: "Grid",
-        as: Gtk.ToggleButton,
-    });
+async function findModeToggle(name: string): Promise<Gtk.ToggleButton> {
+    return await screen.findByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, { name, as: Gtk.ToggleButton });
+}
 
+async function findOverlayCheck(name: string): Promise<Gtk.CheckButton> {
+    return await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name, as: Gtk.CheckButton });
+}
+
+async function renderDrawingArea(): Promise<Gtk.DrawingArea> {
+    await renderDemo(fontRenderingDemo);
+
+    return await screen.findByName("image", { as: Gtk.DrawingArea });
+}
+
+async function renderEntry(): Promise<Gtk.Entry> {
+    await renderDemo(fontRenderingDemo);
+
+    return await screen.findByName("entry", { as: Gtk.Entry });
+}
+
+async function activateGridMode(): Promise<Gtk.ToggleButton> {
+    const gridToggle = await findModeToggle("Grid");
     await userEvent.click(gridToggle);
 
     return gridToggle;
 }
 
 async function toggleExtentsAndGridOverlays(): Promise<{ extents: Gtk.CheckButton; grid: Gtk.CheckButton }> {
-    const extents = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-        name: "Show _Extents",
-        as: Gtk.CheckButton,
-    });
-
-    const grid = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-        name: "Show _Grid",
-        as: Gtk.CheckButton,
-    });
-
+    const extents = await findOverlayCheck("Show Extents");
+    const grid = await findOverlayCheck("Show Grid");
     await userEvent.click(extents);
     await userEvent.click(grid);
 
@@ -64,17 +72,8 @@ describe("fontRenderingDemo titlebar wiring", () => {
 describe("fontRenderingDemo header toggles", () => {
     it("starts in text mode with the Text toggle active", async () => {
         await renderDemo(fontRenderingDemo);
-
-        const textToggle = await screen.findByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, {
-            name: "Text",
-            as: Gtk.ToggleButton,
-        });
-
-        const gridToggle = await screen.findByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, {
-            name: "Grid",
-            as: Gtk.ToggleButton,
-        });
-
+        const textToggle = await findModeToggle("Text");
+        const gridToggle = await findModeToggle("Grid");
         expect(textToggle).toBePressed();
         expect(gridToggle).not.toBePressed();
     });
@@ -89,12 +88,7 @@ describe("fontRenderingDemo header toggles", () => {
         await renderDemo(fontRenderingDemo);
         const gridToggle = await activateGridMode();
         expect(gridToggle).toBePressed();
-
-        const textToggle = await screen.findByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, {
-            name: "Text",
-            as: Gtk.ToggleButton,
-        });
-
+        const textToggle = await findModeToggle("Text");
         await userEvent.click(textToggle);
         expect(textToggle).toBePressed();
         expect(gridToggle).not.toBePressed();
@@ -104,46 +98,23 @@ describe("fontRenderingDemo header toggles", () => {
 describe("fontRenderingDemo overlay checks", () => {
     it("renders pixel and outline overlay checkboxes with correct defaults", async () => {
         await renderDemo(fontRenderingDemo);
-
-        const showPixels = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Show _Pixels",
-            as: Gtk.CheckButton,
-        });
-
-        const showOutline = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Show _Outline",
-            as: Gtk.CheckButton,
-        });
-
+        const showPixels = await findOverlayCheck("Show Pixels");
+        const showOutline = await findOverlayCheck("Show Outline");
         expect(showPixels).toBeChecked();
         expect(showOutline).not.toBeChecked();
     });
 
     it("toggles the show-pixels overlay state", async () => {
         await renderDemo(fontRenderingDemo);
-
-        const showPixels = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Show _Pixels",
-            as: Gtk.CheckButton,
-        });
-
+        const showPixels = await findOverlayCheck("Show Pixels");
         await userEvent.click(showPixels);
         expect(showPixels).not.toBeChecked();
     });
 
     it("toggles antialias and hint-metrics checks", async () => {
         await renderDemo(fontRenderingDemo);
-
-        const antialias = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "_Antialias",
-            as: Gtk.CheckButton,
-        });
-
-        const hintMetrics = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Hint _Metrics",
-            as: Gtk.CheckButton,
-        });
-
+        const antialias = await findOverlayCheck("Antialias");
+        const hintMetrics = await findOverlayCheck("Hint Metrics");
         expect(antialias).toBeChecked();
         expect(hintMetrics).not.toBeChecked();
         await userEvent.click(antialias);
@@ -172,9 +143,8 @@ describe("fontRenderingDemo zoom buttons", () => {
     });
 
     it("grows the drawing-area content width when zooming in", async () => {
-        await renderDemo(fontRenderingDemo);
+        const drawingArea = await renderDrawingArea();
         const zoomIn = await screen.findByName("up_button", { as: Gtk.Button });
-        const drawingArea = await screen.findByName("image", { as: Gtk.DrawingArea });
         const before = drawingArea.getContentWidth();
         await fireEvent(zoomIn, "clicked");
 
@@ -184,9 +154,8 @@ describe("fontRenderingDemo zoom buttons", () => {
     });
 
     it("shrinks the drawing-area content width when zooming out", async () => {
-        await renderDemo(fontRenderingDemo);
+        const drawingArea = await renderDrawingArea();
         const zoomOut = await screen.findByName("down_button", { as: Gtk.Button });
-        const drawingArea = await screen.findByName("image", { as: Gtk.DrawingArea });
         const before = drawingArea.getContentWidth();
         await fireEvent(zoomOut, "clicked");
 
@@ -198,15 +167,13 @@ describe("fontRenderingDemo zoom buttons", () => {
 
 describe("fontRenderingDemo text input", () => {
     it("renders an entry holding the default text", async () => {
-        await renderDemo(fontRenderingDemo);
-        const entry = await screen.findByName("entry", { as: Gtk.Entry });
+        const entry = await renderEntry();
         expect(entry).toBeInstanceOf(Gtk.Entry);
         expect(entry).toHaveDisplayValue("Fonts render");
     });
 
     it("updates the text state when the entry changes", async () => {
-        await renderDemo(fontRenderingDemo);
-        const entry = await screen.findByName("entry", { as: Gtk.Entry });
+        const entry = await renderEntry();
         await userEvent.clear(entry);
         await userEvent.type(entry, "Hello");
         expect(entry).toHaveDisplayValue("Hello");
@@ -234,8 +201,7 @@ describe("fontRenderingDemo drawing area", () => {
 
 describe("fontRenderingDemo font selection", () => {
     it("re-measures the content size when a larger font is selected", async () => {
-        await renderDemo(fontRenderingDemo);
-        const drawingArea = await screen.findByName("image", { as: Gtk.DrawingArea });
+        const drawingArea = await renderDrawingArea();
         const before = drawingArea.getContentHeight();
         const fontButton = await screen.findByName("font-button", { as: Gtk.FontDialogButton });
 
@@ -292,8 +258,7 @@ describe("fontRenderingDemo zoom limits", () => {
 
 describe("fontRenderingDemo keyboard zoom shortcuts", () => {
     it("zooms in via the Ctrl+plus shortcut", async () => {
-        await renderDemo(fontRenderingDemo);
-        const drawingArea = await screen.findByName("image", { as: Gtk.DrawingArea });
+        const drawingArea = await renderDrawingArea();
         const before = drawingArea.getContentWidth();
         drawingArea.grabFocus();
         await userEvent.keyboard(drawingArea, "{Control>}+{/Control}");
@@ -304,8 +269,7 @@ describe("fontRenderingDemo keyboard zoom shortcuts", () => {
     });
 
     it("zooms out via the Ctrl+minus shortcut", async () => {
-        await renderDemo(fontRenderingDemo);
-        const drawingArea = await screen.findByName("image", { as: Gtk.DrawingArea });
+        const drawingArea = await renderDrawingArea();
         const before = drawingArea.getContentWidth();
         drawingArea.grabFocus();
         await userEvent.keyboard(drawingArea, "{Control>}-{/Control}");
@@ -319,12 +283,7 @@ describe("fontRenderingDemo keyboard zoom shortcuts", () => {
 describe("fontRenderingDemo overlay animation", () => {
     it("checks the Show Outline overlay when toggled on", async () => {
         const result = await renderDemo(fontRenderingDemo);
-
-        const showOutline = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Show _Outline",
-            as: Gtk.CheckButton,
-        });
-
+        const showOutline = await findOverlayCheck("Show Outline");
         await userEvent.click(showOutline);
         expect(showOutline).toBeChecked();
         await result.unmount();
@@ -332,12 +291,7 @@ describe("fontRenderingDemo overlay animation", () => {
 
     it("unchecks the Show Pixels overlay when toggled off", async () => {
         const result = await renderDemo(fontRenderingDemo);
-
-        const showPixels = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Show _Pixels",
-            as: Gtk.CheckButton,
-        });
-
+        const showPixels = await findOverlayCheck("Show Pixels");
         await userEvent.click(showPixels);
         expect(showPixels).not.toBeChecked();
         await result.unmount();
@@ -346,8 +300,7 @@ describe("fontRenderingDemo overlay animation", () => {
 
 describe("fontRenderingDemo paint callback", () => {
     it("has a non-zero measured content size in text mode", async () => {
-        await renderDemo(fontRenderingDemo);
-        const drawingArea = await screen.findByName("image", { as: Gtk.DrawingArea });
+        const drawingArea = await renderDrawingArea();
 
         await act(() => {
             drawingArea.queueDraw();
@@ -358,8 +311,7 @@ describe("fontRenderingDemo paint callback", () => {
     });
 
     it("re-measures to a different content size after switching to grid mode", async () => {
-        await renderDemo(fontRenderingDemo);
-        const drawingArea = await screen.findByName("image", { as: Gtk.DrawingArea });
+        const drawingArea = await renderDrawingArea();
         const textSize: [number, number] = [drawingArea.getContentWidth(), drawingArea.getContentHeight()];
         await activateGridMode();
 
@@ -388,8 +340,7 @@ describe("fontRenderingDemo paint callback", () => {
 
 describe("fontRenderingDemo text entry", () => {
     it("clears the entry and accepts empty text via the change handler", async () => {
-        await renderDemo(fontRenderingDemo);
-        const entry = await screen.findByName("entry", { as: Gtk.Entry });
+        const entry = await renderEntry();
         await userEvent.clear(entry);
         expect(entry).toHaveDisplayValue("");
     });

--- a/examples/gtk-demo/tests/demos/advanced/markup.test.tsx
+++ b/examples/gtk-demo/tests/demos/advanced/markup.test.tsx
@@ -4,6 +4,17 @@ import { describe, expect, it } from "vitest";
 import { markupDemo } from "../../../src/demos/advanced/markup.js";
 import { readBufferText, renderDemo } from "../../test-utils.js";
 
+const clickSourceToggle = async (): Promise<Gtk.CheckButton> => {
+    const sourceToggle = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
+        name: "Source",
+        as: Gtk.CheckButton,
+    });
+
+    await userEvent.click(sourceToggle);
+
+    return sourceToggle;
+};
+
 describe("markupDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(markupDemo.id).toBe("markup");
@@ -33,6 +44,7 @@ describe("markupDemo initial state", () => {
 
     it("populates the source text view buffer with the raw markup content", async () => {
         await renderDemo(markupDemo);
+        await clickSourceToggle();
         const source = await screen.findByName("source-view", { as: Gtk.TextView });
         expect(source).toHaveDisplayValue(/Text sizes:/);
         expect(source).toHaveDisplayValue(/<span size="xx-small">/);
@@ -51,31 +63,19 @@ describe("markupDemo initial state", () => {
 describe("markupDemo toggle interaction", () => {
     it("switches to the source page when the Source toggle is activated", async () => {
         await renderDemo(markupDemo);
-
-        const sourceToggle = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Source",
-            as: Gtk.CheckButton,
-        });
-
-        await userEvent.click(sourceToggle);
+        await clickSourceToggle();
         const stack = await screen.findByName("markup-stack", { as: Gtk.Stack });
         expect(stack).toHaveObjectProperty("visibleChildName", "source");
     });
 
     it("re-applies the markup when toggling Source back off after editing", async () => {
         await renderDemo(markupDemo);
-
-        const sourceToggle = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "Source",
-            as: Gtk.CheckButton,
-        });
-
-        await userEvent.click(sourceToggle);
+        const sourceToggle = await clickSourceToggle();
         const source = await screen.findByName("source-view", { as: Gtk.TextView });
-        const formatted = await screen.findByName("formatted-view", { as: Gtk.TextView });
         await userEvent.clear(source);
         await userEvent.type(source, "Hello <b>World</b>");
         await userEvent.click(sourceToggle);
+        const formatted = await screen.findByName("formatted-view", { as: Gtk.TextView });
         const stack = await screen.findByName("markup-stack", { as: Gtk.Stack });
         expect(stack).toHaveObjectProperty("visibleChildName", "formatted");
         expect(formatted).toHaveDisplayValue(/Hello/);

--- a/examples/gtk-demo/tests/demos/benchmark/themes.test.tsx
+++ b/examples/gtk-demo/tests/demos/benchmark/themes.test.tsx
@@ -16,11 +16,23 @@ const THEME_TITLES = ["Adwaita", "Adwaita (dark)", "HighContrast", "HighContrast
 const FPS_SETTLE_MS = 1200;
 const FPS_PATTERN = /^\d+\.\d{2} fps$/;
 
-const activateCycleAndAwaitAlert = async (): Promise<CycleContext> => {
+const renderThemesHeader = async (): Promise<Gtk.HeaderBar> => {
     await renderDemo(themesDemo);
-    const header = await screen.findByName("themes-header", { as: Gtk.HeaderBar });
+
+    return await screen.findByName("themes-header", { as: Gtk.HeaderBar });
+};
+
+const getCycleToggle = (header: Gtk.HeaderBar): Gtk.ToggleButton =>
+    within(header).getByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, { name: "Cycle", as: Gtk.ToggleButton });
+
+const respondToWarning = async (alert: Adw.AlertDialog, response: string): Promise<void> => {
+    await userEvent.click(within(alert).getByRole(Gtk.AccessibleRole.BUTTON, { name: response }));
+};
+
+const activateCycleAndAwaitAlert = async (): Promise<CycleContext> => {
+    const header = await renderThemesHeader();
     const window = await screen.findByRole(Gtk.AccessibleRole.WINDOW, { as: Gtk.Window });
-    const cycle = within(header).getByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, { name: "Cycle", as: Gtk.ToggleButton });
+    const cycle = getCycleToggle(header);
     await userEvent.click(cycle);
     const alert = await screen.findByName("warning-dialog", { as: Adw.AlertDialog });
 
@@ -55,15 +67,8 @@ describe("themesDemo", () => {
     });
 
     it("renders the cycle toggle inside the titlebar and the linked body buttons", async () => {
-        await renderDemo(themesDemo);
-        const header = await screen.findByName("themes-header", { as: Gtk.HeaderBar });
-
-        const cycle = within(header).getByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, {
-            name: "Cycle",
-            as: Gtk.ToggleButton,
-        });
-
-        expect(cycle).not.toBePressed();
+        const header = await renderThemesHeader();
+        expect(getCycleToggle(header)).not.toBePressed();
 
         const firstLinked = await screen.findByRole(Gtk.AccessibleRole.BUTTON, {
             name: "Hi, I am a button",
@@ -106,7 +111,7 @@ describe("themesDemo cycling lifecycle", () => {
         const { cycle, alert, header, window } = await activateCycleAndAwaitAlert();
         expect(window).toHaveObjectProperty("title", null);
         expect(queryFpsLabel(header)).toBeNull();
-        await userEvent.click(within(alert).getByRole(Gtk.AccessibleRole.BUTTON, { name: "_OK" }));
+        await respondToWarning(alert, "OK");
 
         await waitFor(() => {
             expect(screen.queryByName("warning-dialog")).toBeNull();
@@ -123,7 +128,7 @@ describe("themesDemo cycling lifecycle", () => {
 
     it("does not start cycling when the warning is cancelled", async () => {
         const { alert, header, window } = await activateCycleAndAwaitAlert();
-        await userEvent.click(within(alert).getByRole(Gtk.AccessibleRole.BUTTON, { name: "_Cancel" }));
+        await respondToWarning(alert, "Cancel");
 
         await waitFor(() => {
             expect(screen.queryByName("warning-dialog")).toBeNull();
@@ -136,7 +141,7 @@ describe("themesDemo cycling lifecycle", () => {
 
     it("stops cycling, clears the fps readout, and unpresses the toggle when unchecked", async () => {
         const { cycle, alert, header } = await activateCycleAndAwaitAlert();
-        await userEvent.click(within(alert).getByRole(Gtk.AccessibleRole.BUTTON, { name: "_OK" }));
+        await respondToWarning(alert, "OK");
 
         await waitFor(() => {
             expect(cycle).toBePressed();

--- a/examples/gtk-demo/tests/demos/buttons/expander.test.tsx
+++ b/examples/gtk-demo/tests/demos/buttons/expander.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, it } from "vitest";
 import { expanderDemo } from "../../../src/demos/buttons/expander.js";
 import { renderDemo } from "../../test-utils.js";
 
+const renderExpander = async (): Promise<Gtk.Expander> => {
+    await renderDemo(expanderDemo);
+
+    return await screen.findByName("expander", { as: Gtk.Expander });
+};
+
 describe("expanderDemo", () => {
     it("exposes the expected metadata", () => {
         expect(expanderDemo.id).toBe("expander");
@@ -20,25 +26,23 @@ describe("expanderDemo", () => {
 
         const expander = await screen.findByName("expander", { as: Gtk.Expander });
         expect(screen.getByRole(Gtk.AccessibleRole.BUTTON, { name: "Details:", expanded: false })).toBe(expander);
-        expect(expander).not.toBeExpanded();
+        expect(expander).toHaveAccessibleState(Gtk.AccessibleState.EXPANDED, false);
     });
 
     it("flips its own expanded state to true when clicked", async () => {
-        await renderDemo(expanderDemo);
-        const expander = await screen.findByName("expander", { as: Gtk.Expander });
-        expect(expander).not.toBeExpanded();
+        const expander = await renderExpander();
+        expect(expander).toHaveAccessibleState(Gtk.AccessibleState.EXPANDED, false);
         await userEvent.click(expander);
 
         await waitFor(() => {
-            expect(expander).toBeExpanded();
+            expect(expander).toHaveAccessibleState(Gtk.AccessibleState.EXPANDED, true);
         });
 
         expect(screen.getByRole(Gtk.AccessibleRole.BUTTON, { name: "Details:", expanded: true })).toBe(expander);
     });
 
     it("encloses a non-editable, word-wrapped TextView seeded with the details paragraph", async () => {
-        await renderDemo(expanderDemo);
-        const expander = await screen.findByName("expander", { as: Gtk.Expander });
+        const expander = await renderExpander();
         await userEvent.click(expander);
         const textView = await within(expander).findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
         expect(textView).toBeInstanceOf(Gtk.TextView);

--- a/examples/gtk-demo/tests/demos/buttons/spinbutton.test.tsx
+++ b/examples/gtk-demo/tests/demos/buttons/spinbutton.test.tsx
@@ -19,10 +19,20 @@ const REJECTED_TIME_TEXTS = [
     { label: "with non-numeric components", text: "aa:bb" },
 ];
 
+const renderSpinButton = async (name: string): Promise<Gtk.SpinButton> => {
+    await renderDemo(spinbuttonDemo);
+
+    return await screen.findByName(name, { as: Gtk.SpinButton });
+};
+
+const commitText = async (spinButton: Gtk.SpinButton, text: string): Promise<void> => {
+    await userEvent.clear(spinButton);
+    await userEvent.type(spinButton, text);
+    await userEvent.keyboard(spinButton, "{Enter}");
+};
+
 const establishTimeValue = async (timeButton: Gtk.SpinButton): Promise<void> => {
-    await userEvent.clear(timeButton);
-    await userEvent.type(timeButton, "12:30");
-    await userEvent.keyboard(timeButton, "{Enter}");
+    await commitText(timeButton, "12:30");
 
     await waitFor(() => {
         expect(timeButton).toHaveObjectProperty("value", 750);
@@ -53,66 +63,46 @@ describe("spinbuttonDemo", () => {
 
 describe("spinbuttonDemo custom output formatting", () => {
     it("formats hex output for a non-zero value", async () => {
-        await renderDemo(spinbuttonDemo);
-        const hexButton = await screen.findByName("hex_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "0xAB");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        const hexButton = await renderSpinButton("hex_spin");
+        await commitText(hexButton, "0xAB");
         expect(await screen.findByDisplayValue("0xAB")).toBeTruthy();
     });
 
     it("formats hex output as 0x00 when the value is essentially zero", async () => {
-        await renderDemo(spinbuttonDemo);
-        const hexButton = await screen.findByName("hex_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "0");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        const hexButton = await renderSpinButton("hex_spin");
+        await commitText(hexButton, "0");
         expect(await screen.findByDisplayValue("0x00")).toBeTruthy();
     });
 
     it("formats time output as HH:MM for a non-zero value", async () => {
-        await renderDemo(spinbuttonDemo);
-        const timeButton = await screen.findByName("time_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(timeButton);
-        await userEvent.type(timeButton, "02:30");
-        await userEvent.keyboard(timeButton, "{Enter}");
+        const timeButton = await renderSpinButton("time_spin");
+        await commitText(timeButton, "02:30");
         expect(await screen.findByDisplayValue("02:30")).toBeTruthy();
     });
 
     it("formats month output for the corresponding month index", async () => {
-        await renderDemo(spinbuttonDemo);
-        const monthButton = await screen.findByName("month_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(monthButton);
-        await userEvent.type(monthButton, "July");
-        await userEvent.keyboard(monthButton, "{Enter}");
+        const monthButton = await renderSpinButton("month_spin");
+        await commitText(monthButton, "July");
         expect(await screen.findByDisplayValue("July")).toBeTruthy();
     });
 });
 
 describe("spinbuttonDemo custom input parsing", () => {
     it("parses hexadecimal text via the hex input handler when the user types and commits", async () => {
-        await renderDemo(spinbuttonDemo);
-        const hexButton = await screen.findByName("hex_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "0xff");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        const hexButton = await renderSpinButton("hex_spin");
+        await commitText(hexButton, "0xff");
         expect(screen.getByRole(Gtk.AccessibleRole.SPIN_BUTTON, { value: { now: 0xFF } })).toBeTruthy();
     });
 
     it("clamps a signed hexadecimal value to the adjustment lower bound via the '-' sign branch", async () => {
-        await renderDemo(spinbuttonDemo);
-        const hexButton = await screen.findByName("hex_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "0x20");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        const hexButton = await renderSpinButton("hex_spin");
+        await commitText(hexButton, "0x20");
 
         await waitFor(() => {
             expect(hexButton).toHaveObjectProperty("value", 0x20);
         });
 
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "-0x10");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        await commitText(hexButton, "-0x10");
 
         await waitFor(() => {
             expect(hexButton).toHaveObjectProperty("value", 0);
@@ -122,19 +112,14 @@ describe("spinbuttonDemo custom input parsing", () => {
     });
 
     it("rejects text that does not match the hex regex instead of committing it verbatim", async () => {
-        await renderDemo(spinbuttonDemo);
-        const hexButton = await screen.findByName("hex_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "0x05");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        const hexButton = await renderSpinButton("hex_spin");
+        await commitText(hexButton, "0x05");
 
         await waitFor(() => {
             expect(hexButton).toHaveObjectProperty("value", 5);
         });
 
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "not-a-number");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        await commitText(hexButton, "not-a-number");
 
         await waitFor(() => {
             expect(hexButton.getText()).toMatch(/^0x[0-9A-Fa-f]{2}$/);
@@ -146,21 +131,15 @@ describe("spinbuttonDemo custom input parsing", () => {
 
 describe("spinbuttonDemo time input parsing", () => {
     it("parses HH:MM time strings via the time input handler", async () => {
-        await renderDemo(spinbuttonDemo);
-        const timeButton = await screen.findByName("time_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(timeButton);
-        await userEvent.type(timeButton, "12:30");
-        await userEvent.keyboard(timeButton, "{Enter}");
+        const timeButton = await renderSpinButton("time_spin");
+        await commitText(timeButton, "12:30");
         expect(screen.getByRole(Gtk.AccessibleRole.SPIN_BUTTON, { value: { now: 750 } })).toBeTruthy();
     });
 
     it.each(REJECTED_TIME_TEXTS)("rejects time strings $label and keeps the previous value", async ({ text }) => {
-        await renderDemo(spinbuttonDemo);
-        const timeButton = await screen.findByName("time_spin", { as: Gtk.SpinButton });
+        const timeButton = await renderSpinButton("time_spin");
         await establishTimeValue(timeButton);
-        await userEvent.clear(timeButton);
-        await userEvent.type(timeButton, text);
-        await userEvent.keyboard(timeButton, "{Enter}");
+        await commitText(timeButton, text);
 
         await waitFor(() => {
             expect(timeButton.getText()).toMatch(TIME_DISPLAY_PATTERN);
@@ -172,11 +151,8 @@ describe("spinbuttonDemo time input parsing", () => {
 
 describe("spinbuttonDemo month input parsing", () => {
     it("parses month names by prefix-matching the user input via the month input handler", async () => {
-        await renderDemo(spinbuttonDemo);
-        const monthButton = await screen.findByName("month_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(monthButton);
-        await userEvent.type(monthButton, "apr");
-        await userEvent.keyboard(monthButton, "{Enter}");
+        const monthButton = await renderSpinButton("month_spin");
+        await commitText(monthButton, "apr");
 
         await waitFor(() => {
             expect(monthButton).toHaveObjectProperty("value", 4);
@@ -186,37 +162,28 @@ describe("spinbuttonDemo month input parsing", () => {
     });
 
     it("rejects month text that matches no known month prefix and keeps the previous value", async () => {
-        await renderDemo(spinbuttonDemo);
-        const monthButton = await screen.findByName("month_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(monthButton);
-        await userEvent.type(monthButton, "apr");
-        await userEvent.keyboard(monthButton, "{Enter}");
+        const monthButton = await renderSpinButton("month_spin");
+        await commitText(monthButton, "apr");
 
         await waitFor(() => {
             expect(monthButton).toHaveObjectProperty("value", 4);
         });
 
-        await userEvent.clear(monthButton);
-        await userEvent.type(monthButton, "xyz");
-        await userEvent.keyboard(monthButton, "{Enter}");
+        await commitText(monthButton, "xyz");
         expect(monthButton).toHaveObjectProperty("value", 4);
     });
 });
 
 describe("spinbuttonDemo numeric input", () => {
     it("updates the numeric spin value and its mirrored label when the user types a number", async () => {
-        await renderDemo(spinbuttonDemo);
-        const numericButton = await screen.findByName("basic_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(numericButton);
-        await userEvent.type(numericButton, "12.5");
-        await userEvent.keyboard(numericButton, "{Enter}");
+        const numericButton = await renderSpinButton("basic_spin");
+        await commitText(numericButton, "12.5");
         expect(screen.getByRole(Gtk.AccessibleRole.SPIN_BUTTON, { value: { now: 12.5 } })).toBe(numericButton);
         expect(await screen.findByText("12.5")).toBeInstanceOf(Gtk.Label);
     });
 
     it("steps the numeric value up by its 0.5 step increment when ArrowUp is pressed", async () => {
-        await renderDemo(spinbuttonDemo);
-        const numericButton = await screen.findByName("basic_spin", { as: Gtk.SpinButton });
+        const numericButton = await renderSpinButton("basic_spin");
         numericButton.grabFocus();
         await userEvent.keyboard(numericButton, "{ArrowUp}");
 
@@ -230,11 +197,8 @@ describe("spinbuttonDemo numeric input", () => {
 
 describe("spinbuttonDemo mirrored value labels", () => {
     it("mirrors the parsed hex value into the third-column label", async () => {
-        await renderDemo(spinbuttonDemo);
-        const hexButton = await screen.findByName("hex_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(hexButton);
-        await userEvent.type(hexButton, "0xff");
-        await userEvent.keyboard(hexButton, "{Enter}");
+        const hexButton = await renderSpinButton("hex_spin");
+        await commitText(hexButton, "0xff");
 
         await waitFor(() => {
             expect(hexButton).toHaveObjectProperty("value", 255);
@@ -244,18 +208,14 @@ describe("spinbuttonDemo mirrored value labels", () => {
     });
 
     it("mirrors the parsed time value (minutes since midnight) into the third-column label", async () => {
-        await renderDemo(spinbuttonDemo);
-        const timeButton = await screen.findByName("time_spin", { as: Gtk.SpinButton });
+        const timeButton = await renderSpinButton("time_spin");
         await establishTimeValue(timeButton);
         expect(await screen.findByText("750")).toBeInstanceOf(Gtk.Label);
     });
 
     it("mirrors the parsed month index into the third-column label", async () => {
-        await renderDemo(spinbuttonDemo);
-        const monthButton = await screen.findByName("month_spin", { as: Gtk.SpinButton });
-        await userEvent.clear(monthButton);
-        await userEvent.type(monthButton, "July");
-        await userEvent.keyboard(monthButton, "{Enter}");
+        const monthButton = await renderSpinButton("month_spin");
+        await commitText(monthButton, "July");
 
         await waitFor(() => {
             expect(monthButton).toHaveObjectProperty("value", 7);
@@ -267,8 +227,7 @@ describe("spinbuttonDemo mirrored value labels", () => {
 
 describe("spinbuttonDemo wrap behavior", () => {
     it("wraps the hex value to the upper bound when stepped down past zero", async () => {
-        await renderDemo(spinbuttonDemo);
-        const hexButton = await screen.findByName("hex_spin", { as: Gtk.SpinButton });
+        const hexButton = await renderSpinButton("hex_spin");
         expect(hexButton).toHaveObjectProperty("value", 0);
         hexButton.grabFocus();
         await userEvent.keyboard(hexButton, "{ArrowDown}");

--- a/examples/gtk-demo/tests/demos/buttons/spinner.test.tsx
+++ b/examples/gtk-demo/tests/demos/buttons/spinner.test.tsx
@@ -4,6 +4,25 @@ import { describe, expect, it } from "vitest";
 import { spinnerDemo } from "../../../src/demos/buttons/spinner.js";
 import { renderDemo } from "../../test-utils.js";
 
+const renderSpinners = async (): Promise<Gtk.Spinner[]> => {
+    await renderDemo(spinnerDemo);
+
+    return await screen.findAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
+};
+
+const findEntries = async (): Promise<Gtk.Entry[]> =>
+    await screen.findAllByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
+
+const findButton = async (name: string): Promise<Gtk.Button> =>
+    await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name, as: Gtk.Button });
+
+const expectSpinning = async (areSpinning: boolean): Promise<void> => {
+    await waitFor(() => {
+        const spinners = screen.queryAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
+        expect(spinners.every((s) => s.getSpinning() === areSpinning)).toBe(true);
+    });
+};
+
 describe("spinnerDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(spinnerDemo.id).toBe("spinner");
@@ -17,22 +36,20 @@ describe("spinnerDemo metadata", () => {
 
 describe("spinnerDemo rendering", () => {
     it("renders two GtkSpinners both initially spinning", async () => {
-        await renderDemo(spinnerDemo);
-        const spinners = await screen.findAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
+        const spinners = await renderSpinners();
         expect(spinners).toHaveLength(2);
         expect(spinners.every((s) => s.getSpinning())).toBe(true);
     });
 
     it("renders two text entries — one in the sensitive row and one in the insensitive row", async () => {
         await renderDemo(spinnerDemo);
-        const entries = await screen.findAllByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
+        const entries = await findEntries();
         expect(entries).toHaveLength(2);
     });
 
     it("renders the second row insensitive so its spinner and entry are effectively disabled", async () => {
-        await renderDemo(spinnerDemo);
-        const spinners = await screen.findAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
-        const entries = await screen.findAllByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
+        const spinners = await renderSpinners();
+        const entries = await findEntries();
         expect(spinners[0]).toBeEnabled();
         expect(entries[0]).toBeEnabled();
         expect(spinners[1]).toBeDisabled();
@@ -41,7 +58,7 @@ describe("spinnerDemo rendering", () => {
 
     it("accepts typed text in the sensitive-row entry", async () => {
         await renderDemo(spinnerDemo);
-        const entries = await screen.findAllByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
+        const entries = await findEntries();
         const sensitiveEntry = entries[0] as Gtk.Entry;
         await userEvent.type(sensitiveEntry, "hello");
         expect(sensitiveEntry).toHaveDisplayValue("hello");
@@ -49,8 +66,8 @@ describe("spinnerDemo rendering", () => {
 
     it("renders Play and Stop buttons accessible by their labels", async () => {
         await renderDemo(spinnerDemo);
-        const play = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Play" });
-        const stop = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Stop" });
+        const play = await findButton("Play");
+        const stop = await findButton("Stop");
         expect(play).toHaveAccessibleName("Play");
         expect(stop).toHaveAccessibleName("Stop");
     });
@@ -59,40 +76,26 @@ describe("spinnerDemo rendering", () => {
 describe("spinnerDemo Stop / Play toggling", () => {
     it("stops the spinners when the Stop button is clicked", async () => {
         await renderDemo(spinnerDemo);
-        const stop = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Stop", as: Gtk.Button });
+        const stop = await findButton("Stop");
         await userEvent.click(stop);
-
-        await waitFor(() => {
-            const spinners = screen.queryAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
-            expect(spinners.every((s) => !s.getSpinning())).toBe(true);
-        });
+        await expectSpinning(false);
     });
 
     it("restarts the spinners when the Play button is clicked after Stop", async () => {
         await renderDemo(spinnerDemo);
-        const stop = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Stop", as: Gtk.Button });
-        const play = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Play", as: Gtk.Button });
+        const stop = await findButton("Stop");
+        const play = await findButton("Play");
         await userEvent.click(stop);
-
-        await waitFor(() => {
-            const spinners = screen.queryAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
-            expect(spinners.every((s) => !s.getSpinning())).toBe(true);
-        });
-
+        await expectSpinning(false);
         await userEvent.click(play);
-
-        await waitFor(() => {
-            const spinners = screen.queryAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
-            expect(spinners.every((s) => s.getSpinning())).toBe(true);
-        });
+        await expectSpinning(true);
     });
 
     it("keeps both spinner instances flipping together across Stop and Play", async () => {
-        await renderDemo(spinnerDemo);
-        const spinners = await screen.findAllByRole(Gtk.AccessibleRole.PROGRESS_BAR, { as: Gtk.Spinner });
+        const spinners = await renderSpinners();
         expect(spinners.every((s) => s.getSpinning())).toBe(true);
-        const stop = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Stop", as: Gtk.Button });
-        const play = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Play", as: Gtk.Button });
+        const stop = await findButton("Stop");
+        const play = await findButton("Play");
         await userEvent.click(stop);
 
         await waitFor(() => {

--- a/examples/gtk-demo/tests/demos/constraints/constraint-helpers.ts
+++ b/examples/gtk-demo/tests/demos/constraints/constraint-helpers.ts
@@ -1,11 +1,8 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { screen } from "@gtkx/testing";
+import type { ChildButtons } from "../../../src/demos/constraints/child-buttons.js";
 
-type ChildButtons = {
-    button1: Gtk.Button;
-    button2: Gtk.Button;
-    button3: Gtk.Button;
-};
+type ConstraintObserver = ReturnType<Gtk.ConstraintLayout["observeConstraints"]>;
 
 const CHILD_BUTTON_LABELS = ["Child 1", "Child 2", "Child 3"];
 
@@ -31,25 +28,33 @@ const findContainerLayout = async (): Promise<{ box: Gtk.Box; layout: Gtk.Constr
     return { box, layout: box.getLayoutManager() as Gtk.ConstraintLayout };
 };
 
-const collectConstraints = (layout: Gtk.ConstraintLayout): Gtk.Constraint[] => {
-    const observer = layout.observeConstraints();
-    const constraints: Gtk.Constraint[] = [];
+const isConstraint = (item: unknown): item is Gtk.Constraint => item instanceof Gtk.Constraint;
+const isGuide = (item: unknown): item is Gtk.ConstraintGuide => item instanceof Gtk.ConstraintGuide;
 
-    for (let i = 0; i < observer.getNItems(); i++) {
-        const item = observer.getItem(i);
+const collectListItems = <T>(model: ConstraintObserver, isMatch: (item: unknown) => item is T): T[] => {
+    const items: T[] = [];
 
-        if (item instanceof Gtk.Constraint) {
-            constraints.push(item);
+    for (let i = 0; i < model.getNItems(); i++) {
+        const item = model.getItem(i);
+
+        if (isMatch(item)) {
+            items.push(item);
         }
     }
 
-    return constraints;
+    return items;
 };
+
+const collectConstraints = (layout: Gtk.ConstraintLayout): Gtk.Constraint[] =>
+    collectListItems(layout.observeConstraints(), isConstraint);
+
+const collectGuides = (layout: Gtk.ConstraintLayout): Gtk.ConstraintGuide[] =>
+    collectListItems(layout.observeGuides(), isGuide);
 
 export {
     CHILD_BUTTON_LABELS,
-    type ChildButtons,
     collectConstraints,
+    collectGuides,
     findChildButtons,
     findContainerLayout,
     findLabelledChildButtons,

--- a/examples/gtk-demo/tests/demos/constraints/constraints-interactive.test.tsx
+++ b/examples/gtk-demo/tests/demos/constraints/constraints-interactive.test.tsx
@@ -65,7 +65,9 @@ describe("constraintsInteractiveDemo dragging", () => {
         await waitFor(() => {
             const dividerLeft = findDividerLeftConstant(layout);
             expect(dividerLeft).not.toBeNull();
-            expect(button1.getAllocatedWidth()).toBe((dividerLeft as number) - 8);
+            const [wasComputed, bounds] = button1.computeBounds(box);
+            expect(wasComputed).toBe(true);
+            expect(bounds.getWidth()).toBe((dividerLeft as number) - 8);
         });
     });
 });

--- a/examples/gtk-demo/tests/demos/constraints/constraints-vfl.test.tsx
+++ b/examples/gtk-demo/tests/demos/constraints/constraints-vfl.test.tsx
@@ -1,11 +1,11 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { screen } from "@gtkx/testing";
 import { describe, expect, it } from "vitest";
+import type { ChildButtons } from "../../../src/demos/constraints/child-buttons.js";
 import { constraintsVflDemo } from "../../../src/demos/constraints/constraints-vfl.js";
 import { renderDemo } from "../../test-utils.js";
 import {
     CHILD_BUTTON_LABELS,
-    type ChildButtons,
     collectConstraints,
     findChildButtons,
     findLabelledChildButtons,

--- a/examples/gtk-demo/tests/demos/constraints/constraints.test.tsx
+++ b/examples/gtk-demo/tests/demos/constraints/constraints.test.tsx
@@ -3,13 +3,14 @@ import { screen, waitFor } from "@gtkx/testing";
 import { describe, expect, it } from "vitest";
 import { constraintsDemo } from "../../../src/demos/constraints/constraints.js";
 import { renderDemo } from "../../test-utils.js";
-import { collectConstraints, findChildButtons } from "./constraint-helpers.js";
+import { collectConstraints, collectGuides, findChildButtons } from "./constraint-helpers.js";
 
 type AllocatedLayout = {
     button1: Gtk.Button;
     button2: Gtk.Button;
     button3: Gtk.Button;
     container: Gtk.Box;
+    containerWidth: number;
 };
 
 const getGridLayout = async (): Promise<Gtk.ConstraintLayout> => {
@@ -18,21 +19,6 @@ const getGridLayout = async (): Promise<Gtk.ConstraintLayout> => {
     expect(layout).toBeInstanceOf(Gtk.ConstraintLayout);
 
     return layout as Gtk.ConstraintLayout;
-};
-
-const collectGuides = (layout: Gtk.ConstraintLayout): Gtk.ConstraintGuide[] => {
-    const observer = layout.observeGuides();
-    const guides: Gtk.ConstraintGuide[] = [];
-
-    for (let i = 0; i < observer.getNItems(); i++) {
-        const item = observer.getItem(i);
-
-        if (item instanceof Gtk.ConstraintGuide) {
-            guides.push(item);
-        }
-    }
-
-    return guides;
 };
 
 const boundsIn = (widget: Gtk.Widget, container: Gtk.Widget) => {
@@ -60,10 +46,21 @@ const renderAndAllocate = async (): Promise<AllocatedLayout> => {
     const container = await screen.findByName("container", { as: Gtk.Box });
 
     await waitFor(() => {
-        expect(button3.getAllocatedWidth()).toBeGreaterThan(0);
+        expect(button3.getWidth()).toBeGreaterThan(0);
     });
 
-    return { button1, button2, button3, container };
+    return { button1, button2, button3, container, containerWidth: container.getWidth() };
+};
+
+const renderAndMeasure = async () => {
+    const layout = await renderAndAllocate();
+
+    return {
+        b1: boundsIn(layout.button1, layout.container),
+        b2: boundsIn(layout.button2, layout.container),
+        b3: boundsIn(layout.button3, layout.container),
+        containerWidth: layout.containerWidth,
+    };
 };
 
 describe("constraintsDemo metadata", () => {
@@ -130,12 +127,8 @@ describe("constraintsDemo layout", () => {
 
 describe("constraintsDemo geometry", () => {
     it("resolves the constraints into the intended allocations", async () => {
-        const { button1, button2, button3, container } = await renderAndAllocate();
-        const containerWidth = container.getAllocatedWidth();
-        const b1 = boundsIn(button1, container);
-        const b2 = boundsIn(button2, container);
-        const b3 = boundsIn(button3, container);
-        expect(button1.getAllocatedWidth()).toBe(button2.getAllocatedWidth());
+        const { b1, b2, b3, containerWidth } = await renderAndMeasure();
+        expect(b1.getWidth()).toBe(b2.getWidth());
         expect(b1.getX()).toBe(8);
         expect(b2.getX() + b2.getWidth()).toBe(containerWidth - 8);
         expect(b2.getX()).toBeGreaterThan(b1.getX() + b1.getWidth());
@@ -145,10 +138,9 @@ describe("constraintsDemo geometry", () => {
     });
 
     it("recomputes the layout when the window is resized", async () => {
-        const { button1, button2, button3, container } = await renderAndAllocate();
-        const initialContainerWidth = container.getAllocatedWidth();
-        const initialButton1Width = button1.getAllocatedWidth();
-        const widerWidth = initialContainerWidth + 240;
+        const { button1, button2, button3, container, containerWidth } = await renderAndAllocate();
+        const widerWidth = containerWidth + 240;
+        const initialButton1Width = boundsIn(button1, container).getWidth();
         const root = container.getRoot();
 
         if (!(root instanceof Gtk.Window)) {
@@ -158,12 +150,12 @@ describe("constraintsDemo geometry", () => {
         root.setDefaultSize(widerWidth, 400);
 
         await waitFor(() => {
-            expect(container.getAllocatedWidth()).toBe(widerWidth);
+            expect(container.getWidth()).toBe(widerWidth);
         });
 
-        expect(button3.getAllocatedWidth()).toBe(widerWidth - 16);
-        expect(button1.getAllocatedWidth()).toBeGreaterThan(initialButton1Width);
-        expect(button1.getAllocatedWidth()).toBe(button2.getAllocatedWidth());
+        expect(boundsIn(button3, container).getWidth()).toBe(widerWidth - 16);
+        expect(boundsIn(button1, container).getWidth()).toBeGreaterThan(initialButton1Width);
+        expect(boundsIn(button1, container).getWidth()).toBe(boundsIn(button2, container).getWidth());
     });
 });
 

--- a/examples/gtk-demo/tests/demos/css/css-accordion.test.tsx
+++ b/examples/gtk-demo/tests/demos/css/css-accordion.test.tsx
@@ -46,6 +46,7 @@ describe("cssAccordionDemo", () => {
 
 describe("cssAccordionDemo styling and interaction", () => {
     it("registers a CssProvider on the default display at application priority", async () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const addSpy = vi.spyOn(Gtk.StyleContext, "addProviderForDisplay");
 
         try {

--- a/examples/gtk-demo/tests/demos/css/css-basics.test.tsx
+++ b/examples/gtk-demo/tests/demos/css/css-basics.test.tsx
@@ -4,6 +4,17 @@ import { describe, expect, it } from "vitest";
 import { cssBasicsDemo } from "../../../src/demos/css/css-basics.js";
 import { hasBufferTag, renderDemo } from "../../test-utils.js";
 
+const renderTextView = async (): Promise<Gtk.TextView> => {
+    await renderDemo(cssBasicsDemo);
+
+    return await screen.findByName("text-view", { as: Gtk.TextView });
+};
+
+const replaceCss = async (textView: Gtk.TextView, css: string): Promise<void> => {
+    await userEvent.clear(textView);
+    await userEvent.type(textView, css);
+};
+
 describe("cssBasicsDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(cssBasicsDemo.id).toBe("css-basics");
@@ -20,8 +31,7 @@ describe("cssBasicsDemo metadata", () => {
 
 describe("cssBasicsDemo rendering", () => {
     it("renders a text view inside a scrolled window with the default CSS preloaded", async () => {
-        await renderDemo(cssBasicsDemo);
-        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
+        const textView = await renderTextView();
         await screen.findByName("scrolled");
         expect(textView).toHaveDisplayValue(/Set a very futuristic style by default/);
         expect(textView).toHaveDisplayValue(/window\.demo/);
@@ -38,18 +48,14 @@ describe("cssBasicsDemo rendering", () => {
 
 describe("cssBasicsDemo behavior", () => {
     it("propagates edited buffer text back into the text view", async () => {
-        await renderDemo(cssBasicsDemo);
-        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-        await userEvent.clear(textView);
-        await userEvent.type(textView, "/* edited */\nwindow { color: red; }\n");
+        const textView = await renderTextView();
+        await replaceCss(textView, "/* edited */\nwindow { color: red; }\n");
         expect(textView).toHaveDisplayValue("/* edited */\nwindow { color: red; }\n");
     });
 
     it("marks invalid CSS by adding an error tag to the buffer", async () => {
-        await renderDemo(cssBasicsDemo);
-        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-        await userEvent.clear(textView);
-        await userEvent.type(textView, "window { color: this-is-not-a-valid-color; }");
+        const textView = await renderTextView();
+        await replaceCss(textView, "window { color: this-is-not-a-valid-color; }");
 
         await waitFor(() => {
             expect(hasBufferTag(textView, "error")).toBe(true);
@@ -59,10 +65,8 @@ describe("cssBasicsDemo behavior", () => {
     });
 
     it("marks warning-level CSS with the warning tag rather than the error tag", async () => {
-        await renderDemo(cssBasicsDemo);
-        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-        await userEvent.clear(textView);
-        await userEvent.type(textView, "window { color: green }");
+        const textView = await renderTextView();
+        await replaceCss(textView, "window { color: green }");
 
         await waitFor(() => {
             expect(hasBufferTag(textView, "warning")).toBe(true);
@@ -72,17 +76,14 @@ describe("cssBasicsDemo behavior", () => {
     });
 
     it("clears a previously applied error tag once the CSS becomes valid again", async () => {
-        await renderDemo(cssBasicsDemo);
-        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-        await userEvent.clear(textView);
-        await userEvent.type(textView, "window { color: this-is-not-a-valid-color; }");
+        const textView = await renderTextView();
+        await replaceCss(textView, "window { color: this-is-not-a-valid-color; }");
 
         await waitFor(() => {
             expect(hasBufferTag(textView, "error")).toBe(true);
         });
 
-        await userEvent.clear(textView);
-        await userEvent.type(textView, "window { color: red; }");
+        await replaceCss(textView, "window { color: red; }");
 
         await waitFor(() => {
             expect(hasBufferTag(textView, "error")).toBe(false);

--- a/examples/gtk-demo/tests/demos/css/css-blendmodes.test.tsx
+++ b/examples/gtk-demo/tests/demos/css/css-blendmodes.test.tsx
@@ -64,7 +64,7 @@ describe("cssBlendmodesDemo behavior", () => {
     it("selects the Normal row by default once the listbox is mounted", async () => {
         await renderDemo(cssBlendmodesDemo);
         const row = await screen.findByRole(Gtk.AccessibleRole.LIST_ITEM, { name: "Normal", selected: true });
-        expect(row).toBeSelected();
+        expect(row).toHaveAccessibleState(Gtk.AccessibleState.SELECTED, true);
     });
 
     it("regenerates the root grid blend-mode css class when a blend row is activated", async () => {

--- a/examples/gtk-demo/tests/demos/css/css-multiplebgs.test.tsx
+++ b/examples/gtk-demo/tests/demos/css/css-multiplebgs.test.tsx
@@ -2,7 +2,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { screen, userEvent, waitFor } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
 import { cssMultiplebgsDemo } from "../../../src/demos/css/css-multiplebgs.js";
-import { hasBufferTag, renderDemo } from "../../test-utils.js";
+import { expectCssReloadedOnEdit, hasBufferTag, renderDemo } from "../../test-utils.js";
 
 describe("cssMultiplebgsDemo", () => {
     it("exposes the expected metadata", () => {
@@ -50,6 +50,7 @@ describe("cssMultiplebgsDemo", () => {
 describe("cssMultiplebgsDemo css provider", () => {
     it("loads the default CSS into a CssProvider added to the display on mount", async () => {
         const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const addSpy = vi.spyOn(Gtk.StyleContext, "addProviderForDisplay");
 
         try {
@@ -68,25 +69,11 @@ describe("cssMultiplebgsDemo css provider", () => {
     });
 
     it("re-applies the CssProvider when the user edits the buffer", async () => {
-        const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
-
-        try {
-            await renderDemo(cssMultiplebgsDemo);
-            const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-            loadSpy.mockClear();
-            await userEvent.clear(textView);
-            await userEvent.type(textView, "#canvas { background-color: magenta; }");
-
-            await waitFor(() => {
-                const userLoad = loadSpy.mock.calls.find(
-                    ([css]) => typeof css === "string" && css.includes("background-color: magenta"),
-                );
-
-                expect(userLoad, "expected the buffer edit to be loaded into a CssProvider").toBeDefined();
-            });
-        } finally {
-            loadSpy.mockRestore();
-        }
+        await expectCssReloadedOnEdit(
+            cssMultiplebgsDemo,
+            "#canvas { background-color: magenta; }",
+            "background-color: magenta",
+        );
     });
 
     it("marks invalid CSS by adding an error tag to the buffer", async () => {

--- a/examples/gtk-demo/tests/demos/css/css-pixbufs.test.tsx
+++ b/examples/gtk-demo/tests/demos/css/css-pixbufs.test.tsx
@@ -1,8 +1,8 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { screen, userEvent, waitFor } from "@gtkx/testing";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { cssPixbufsDemo } from "../../../src/demos/css/css-pixbufs.js";
-import { hasBufferTag, renderDemo } from "../../test-utils.js";
+import { expectCssReloadedOnEdit, findCssLoadedOnMount, hasBufferTag, renderDemo } from "../../test-utils.js";
 
 describe("cssPixbufsDemo", () => {
     it("exposes the expected metadata", () => {
@@ -44,41 +44,16 @@ describe("cssPixbufsDemo", () => {
 
 describe("cssPixbufsDemo css provider", () => {
     it("loads the default keyframe CSS into a CssProvider when the editor mounts", async () => {
-        const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
-
-        try {
-            await renderDemo(cssPixbufsDemo);
-
-            const defaultLoad = loadSpy.mock.calls.find(
-                ([css]) => typeof css === "string" && css.includes("@keyframes move-the-image"),
-            );
-
-            expect(defaultLoad, "expected the default pixbufs CSS to be loaded via loadFromString").toBeDefined();
-        } finally {
-            loadSpy.mockRestore();
-        }
+        const loaded = await findCssLoadedOnMount(cssPixbufsDemo, "@keyframes move-the-image");
+        expect(loaded, "expected the default pixbufs CSS to be loaded via loadFromString").toBeDefined();
     });
 
     it("re-applies the CssProvider when the user edits the buffer", async () => {
-        const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
-
-        try {
-            await renderDemo(cssPixbufsDemo);
-            const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-            loadSpy.mockClear();
-            await userEvent.clear(textView);
-            await userEvent.type(textView, "window { background-color: cyan; }");
-
-            await waitFor(() => {
-                const userLoad = loadSpy.mock.calls.find(
-                    ([css]) => typeof css === "string" && css.includes("background-color: cyan"),
-                );
-
-                expect(userLoad, "expected the buffer edit to be loaded into a CssProvider").toBeDefined();
-            });
-        } finally {
-            loadSpy.mockRestore();
-        }
+        await expectCssReloadedOnEdit(
+            cssPixbufsDemo,
+            "window { background-color: cyan; }",
+            "background-color: cyan",
+        );
     });
 
     it("marks invalid CSS with an error tag and clears it once the CSS is valid again", async () => {

--- a/examples/gtk-demo/tests/demos/css/css-shadows.test.tsx
+++ b/examples/gtk-demo/tests/demos/css/css-shadows.test.tsx
@@ -1,21 +1,8 @@
 import * as Gtk from "@gtkx/gi/gtk";
 import { screen, userEvent, waitFor } from "@gtkx/testing";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { cssShadowsDemo } from "../../../src/demos/css/css-shadows.js";
-import { renderDemo } from "../../test-utils.js";
-
-const hasTagToggle = (view: Gtk.TextView, tagName: string): boolean => {
-    const buffer = view.getBuffer();
-    const tag = buffer.getTagTable().lookup(tagName);
-
-    if (!tag) {
-        return false;
-    }
-
-    const iter = buffer.getStartIter();
-
-    return iter.forwardToTagToggle(tag);
-};
+import { expectCssReloadedOnEdit, findCssLoadedOnMount, hasBufferTag, renderDemo } from "../../test-utils.js";
 
 describe("cssShadowsDemo metadata", () => {
     it("exposes the expected metadata", () => {
@@ -59,41 +46,16 @@ describe("cssShadowsDemo behavior", () => {
     });
 
     it("loads the default CSS into a CssProvider when the editor mounts", async () => {
-        const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
-
-        try {
-            await renderDemo(cssShadowsDemo);
-
-            const defaultLoad = loadSpy.mock.calls.find(
-                ([css]) => typeof css === "string" && css.includes("text-shadow"),
-            );
-
-            expect(defaultLoad, "expected the default shadows CSS to be loaded via loadFromString").toBeDefined();
-        } finally {
-            loadSpy.mockRestore();
-        }
+        const loaded = await findCssLoadedOnMount(cssShadowsDemo, "text-shadow");
+        expect(loaded, "expected the default shadows CSS to be loaded via loadFromString").toBeDefined();
     });
 
     it("re-applies the CssProvider when the user edits the buffer", async () => {
-        const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
-
-        try {
-            await renderDemo(cssShadowsDemo);
-            const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-            loadSpy.mockClear();
-            await userEvent.clear(textView);
-            await userEvent.type(textView, "button { box-shadow: 0 0 10px red; }");
-
-            await waitFor(() => {
-                const userLoad = loadSpy.mock.calls.find(
-                    ([css]) => typeof css === "string" && css.includes("box-shadow: 0 0 10px red"),
-                );
-
-                expect(userLoad, "expected the buffer edit to be loaded into a CssProvider").toBeDefined();
-            });
-        } finally {
-            loadSpy.mockRestore();
-        }
+        await expectCssReloadedOnEdit(
+            cssShadowsDemo,
+            "button { box-shadow: 0 0 10px red; }",
+            "box-shadow: 0 0 10px red",
+        );
     });
 });
 
@@ -104,13 +66,13 @@ describe("cssShadowsDemo error tagging", () => {
         await userEvent.clear(textView);
 
         await waitFor(() => {
-            expect(hasTagToggle(textView, "error")).toBe(false);
+            expect(hasBufferTag(textView, "error")).toBe(false);
         });
 
         await userEvent.type(textView, "button { nonsense-prop: 5px; }");
 
         await waitFor(() => {
-            expect(hasTagToggle(textView, "error")).toBe(true);
+            expect(hasBufferTag(textView, "error")).toBe(true);
         });
     });
 
@@ -121,14 +83,14 @@ describe("cssShadowsDemo error tagging", () => {
         await userEvent.type(textView, "button { nonsense-prop: 5px; }");
 
         await waitFor(() => {
-            expect(hasTagToggle(textView, "error")).toBe(true);
+            expect(hasBufferTag(textView, "error")).toBe(true);
         });
 
         await userEvent.clear(textView);
         await userEvent.type(textView, "button { color: red; }");
 
         await waitFor(() => {
-            expect(hasTagToggle(textView, "error")).toBe(false);
+            expect(hasBufferTag(textView, "error")).toBe(false);
         });
     });
 });

--- a/examples/gtk-demo/tests/demos/css/errorstates.test.tsx
+++ b/examples/gtk-demo/tests/demos/css/errorstates.test.tsx
@@ -1,6 +1,6 @@
 import * as Adw from "@gtkx/gi/adw";
 import * as Gtk from "@gtkx/gi/gtk";
-import { getWidgetErrorMessage, getWidgetInvalidState, screen, userEvent } from "@gtkx/testing";
+import { screen, userEvent } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
 import { errorstatesDemo } from "../../../src/demos/css/errorstates.js";
 import { renderDemo } from "../../test-utils.js";
@@ -12,12 +12,29 @@ type DetailEntries = {
 
 const renderAndFlagMoreDetails = async (): Promise<DetailEntries> => {
     await renderDemo(errorstatesDemo);
-    const detailsEntry = await screen.findByLabelText("_Details", { as: Gtk.Entry });
-    const moreDetailsEntry = screen.getByLabelText("More D_etails", { as: Gtk.Entry });
+    const detailsEntry = await screen.findByLabelText("Details", { as: Gtk.Entry });
+    const moreDetailsEntry = screen.getByLabelText("More Details", { as: Gtk.Entry });
     await userEvent.type(moreDetailsEntry, "filled in");
 
     return { detailsEntry, moreDetailsEntry };
 };
+
+const renderSwitch = async (): Promise<Gtk.Switch> => {
+    await renderDemo(errorstatesDemo);
+
+    return await screen.findByRole(Gtk.AccessibleRole.SWITCH, { as: Gtk.Switch });
+};
+
+const renderScaleAndSwitch = async (): Promise<{ scale: Gtk.Scale; sw: Gtk.Switch }> => {
+    await renderDemo(errorstatesDemo);
+    const scale = await screen.findByRole(Gtk.AccessibleRole.SLIDER, { as: Gtk.Scale });
+    const sw = await screen.findByRole(Gtk.AccessibleRole.SWITCH, { as: Gtk.Switch });
+
+    return { scale, sw };
+};
+
+const findLevelErrorLabel = async (): Promise<Gtk.Label> =>
+    await screen.findByRole(Gtk.AccessibleRole.LABEL, { name: "Level too low", as: Gtk.Label });
 
 describe("errorstatesDemo metadata", () => {
     it("exposes the expected metadata", () => {
@@ -46,7 +63,7 @@ describe("errorstatesDemo entries", () => {
         const { moreDetailsEntry } = await renderAndFlagMoreDetails();
         expect(moreDetailsEntry).toHaveClass("error");
         expect(moreDetailsEntry).toHaveObjectProperty("tooltipText", "Must have details first");
-        expect(getWidgetInvalidState(moreDetailsEntry)).toBe(Gtk.AccessibleInvalidState.TRUE);
+        expect(moreDetailsEntry).toBeInvalid();
     });
 
     it("clears the more-details error once the details entry receives input", async () => {
@@ -55,58 +72,42 @@ describe("errorstatesDemo entries", () => {
         await userEvent.type(detailsEntry, "ok");
         expect(moreDetailsEntry).not.toHaveClass("error");
         expect(moreDetailsEntry).toHaveObjectProperty("tooltipText", null);
-        expect(getWidgetInvalidState(moreDetailsEntry)).toBe(Gtk.AccessibleInvalidState.FALSE);
+        expect(moreDetailsEntry).toBeValid();
     });
 });
 
 describe("errorstatesDemo switch and scale", () => {
     it("shows the level-too-low error label and flags the switch invalid when activated with a low level", async () => {
-        await renderDemo(errorstatesDemo);
-        const sw = await screen.findByRole(Gtk.AccessibleRole.SWITCH, { as: Gtk.Switch });
-        expect(getWidgetInvalidState(sw)).toBe(Gtk.AccessibleInvalidState.FALSE);
+        const sw = await renderSwitch();
+        expect(sw).toBeValid();
         await userEvent.click(sw);
-
-        const errorLabel = await screen.findByRole(Gtk.AccessibleRole.LABEL, {
-            name: "Level too low",
-            as: Gtk.Label,
-        });
-
+        const errorLabel = await findLevelErrorLabel();
         expect(errorLabel).toHaveClass("error");
-        expect(getWidgetInvalidState(sw)).toBe(Gtk.AccessibleInvalidState.TRUE);
-        expect(getWidgetErrorMessage(sw)).toEqual([errorLabel]);
+        expect(sw).toBeInvalid();
+        expect(sw).toHaveAccessibleErrorMessage("Level too low");
     });
 
     it("activates the switch through the Control+M keyboard shortcut", async () => {
-        await renderDemo(errorstatesDemo);
-        const sw = await screen.findByRole(Gtk.AccessibleRole.SWITCH, { as: Gtk.Switch });
+        const sw = await renderSwitch();
         sw.grabFocus();
         await userEvent.keyboard(sw, "{Control>}m{/Control}");
         expect(sw).toHaveObjectProperty("active", true);
-
-        const errorLabel = await screen.findByRole(Gtk.AccessibleRole.LABEL, {
-            name: "Level too low",
-            as: Gtk.Label,
-        });
-
+        const errorLabel = await findLevelErrorLabel();
         expect(errorLabel).toHaveClass("error");
-        expect(getWidgetInvalidState(sw)).toBe(Gtk.AccessibleInvalidState.TRUE);
+        expect(sw).toBeInvalid();
     });
 
     it("does not show the error label when the switch is activated with a high level", async () => {
-        await renderDemo(errorstatesDemo);
-        const scale = await screen.findByRole(Gtk.AccessibleRole.SLIDER, { as: Gtk.Scale });
-        const sw = await screen.findByRole(Gtk.AccessibleRole.SWITCH, { as: Gtk.Switch });
+        const { scale, sw } = await renderScaleAndSwitch();
         await userEvent.slide(scale, 80);
         await userEvent.click(sw);
         expect(sw).toHaveObjectProperty("state", true);
         expect(screen.queryByRole(Gtk.AccessibleRole.LABEL, { name: "Level too low" })).toBeNull();
-        expect(getWidgetInvalidState(sw)).toBe(Gtk.AccessibleInvalidState.FALSE);
+        expect(sw).toBeValid();
     });
 
     it("flips the switch state automatically when the level crosses 50 with the switch already active", async () => {
-        await renderDemo(errorstatesDemo);
-        const scale = await screen.findByRole(Gtk.AccessibleRole.SLIDER, { as: Gtk.Scale });
-        const sw = await screen.findByRole(Gtk.AccessibleRole.SWITCH, { as: Gtk.Switch });
+        const { scale, sw } = await renderScaleAndSwitch();
         await userEvent.click(sw);
         await userEvent.slide(scale, 80);
         expect(sw).toHaveObjectProperty("state", true);

--- a/examples/gtk-demo/tests/demos/dialogs/dialog.test.tsx
+++ b/examples/gtk-demo/tests/demos/dialogs/dialog.test.tsx
@@ -12,8 +12,19 @@ const openDialog = async (buttonName: string, dialogName: string): Promise<Adw.A
     return screen.findByName(dialogName, { as: Adw.AlertDialog });
 };
 
-const openMessageDialog = (): Promise<Adw.AlertDialog> => openDialog("_Message Dialog", "message-dialog");
-const openInteractiveDialog = (): Promise<Adw.AlertDialog> => openDialog("_Interactive Dialog", "interactive-dialog");
+const openMessageDialog = (): Promise<Adw.AlertDialog> => openDialog("Message Dialog", "message-dialog");
+const openInteractiveDialog = (): Promise<Adw.AlertDialog> => openDialog("Interactive Dialog", "interactive-dialog");
+
+const expectDialogClosed = async (dialogName: string): Promise<void> => {
+    await waitFor(() => {
+        expect(screen.queryByName(dialogName)).toBeNull();
+    });
+};
+
+const clickMessageDialogResponse = async (response: RegExp): Promise<void> => {
+    const dialog = await openMessageDialog();
+    await userEvent.click(within(dialog).getByRole(Gtk.AccessibleRole.BUTTON, { name: response }));
+};
 
 describe("dialogDemo metadata", () => {
     it("exposes the expected metadata", () => {
@@ -28,8 +39,8 @@ describe("dialogDemo metadata", () => {
 
     it("renders the Message Dialog button, the Interactive Dialog button and two empty entries", async () => {
         await renderDemo(dialogDemo);
-        await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Message Dialog" });
-        await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Interactive Dialog" });
+        await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Message Dialog" });
+        await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Interactive Dialog" });
         expect(await screen.findByName("demo-entry-1")).toHaveDisplayValue("");
         expect(await screen.findByName("demo-entry-2")).toHaveDisplayValue("");
     });
@@ -50,7 +61,7 @@ describe("dialogDemo message dialog", () => {
         await renderDemo(dialogDemo);
 
         const messageButton = await screen.findByRole(Gtk.AccessibleRole.BUTTON, {
-            name: "_Message Dialog",
+            name: "Message Dialog",
             as: Gtk.Button,
         });
 
@@ -58,11 +69,7 @@ describe("dialogDemo message dialog", () => {
         const firstDialog = await screen.findByName("message-dialog", { as: Adw.AlertDialog });
         await within(firstDialog).findByText("Has been shown once");
         await userEvent.click(within(firstDialog).getByRole(Gtk.AccessibleRole.BUTTON, { name: /OK/ }));
-
-        await waitFor(() => {
-            expect(screen.queryByName("message-dialog")).toBeNull();
-        });
-
+        await expectDialogClosed("message-dialog");
         await userEvent.click(messageButton);
         const secondDialog = await screen.findByName("message-dialog", { as: Adw.AlertDialog });
         await within(secondDialog).findByText("Has been shown 2 times");
@@ -70,22 +77,14 @@ describe("dialogDemo message dialog", () => {
 
     it("dismisses the message dialog after emitting the response signal", async () => {
         await renderDemo(dialogDemo);
-        const dialog = await openMessageDialog();
-        await userEvent.click(within(dialog).getByRole(Gtk.AccessibleRole.BUTTON, { name: /OK/ }));
-
-        await waitFor(() => {
-            expect(screen.queryByName("message-dialog")).toBeNull();
-        });
+        await clickMessageDialogResponse(/OK/);
+        await expectDialogClosed("message-dialog");
     });
 
     it("dismisses the message dialog via the Cancel/closeResponse button", async () => {
         await renderDemo(dialogDemo);
-        const dialog = await openMessageDialog();
-        await userEvent.click(within(dialog).getByRole(Gtk.AccessibleRole.BUTTON, { name: /Cancel/ }));
-
-        await waitFor(() => {
-            expect(screen.queryByName("message-dialog")).toBeNull();
-        });
+        await clickMessageDialogResponse(/Cancel/);
+        await expectDialogClosed("message-dialog");
     });
 });
 
@@ -132,11 +131,7 @@ describe("dialogDemo interactive dialog entries", () => {
         await userEvent.type(dialogEntry1, "-edited");
         expect(dialogEntry1).toHaveDisplayValue("orig-edited");
         await userEvent.click(within(interactive).getByRole(Gtk.AccessibleRole.BUTTON, { name: /Cancel/ }));
-
-        await waitFor(() => {
-            expect(screen.queryByName("interactive-dialog")).toBeNull();
-        });
-
+        await expectDialogClosed("interactive-dialog");
         expect(await screen.findByName("demo-entry-1", { as: Gtk.Entry })).toHaveDisplayValue("orig");
     });
 
@@ -148,11 +143,7 @@ describe("dialogDemo interactive dialog entries", () => {
         await userEvent.type(dialogEntry1, "alpha");
         await userEvent.type(dialogEntry2, "beta");
         await userEvent.click(within(interactive).getByRole(Gtk.AccessibleRole.BUTTON, { name: /OK/ }));
-
-        await waitFor(() => {
-            expect(screen.queryByName("interactive-dialog")).toBeNull();
-        });
-
+        await expectDialogClosed("interactive-dialog");
         const demoEntry1 = await screen.findByName("demo-entry-1", { as: Gtk.Entry });
         const demoEntry2 = await screen.findByName("demo-entry-2", { as: Gtk.Entry });
         expect(screen.getByDisplayValue("alpha")).toBe(demoEntry1);

--- a/examples/gtk-demo/tests/demos/dialogs/pickers.test.tsx
+++ b/examples/gtk-demo/tests/demos/dialogs/pickers.test.tsx
@@ -26,6 +26,19 @@ const PDF_PATH = join(TMP_DIR, "doc.pdf");
 const dismissedError = (): GError =>
     GError.newLiteral(quarkFromString("gtk-dialog-error-quark"), Gtk.DialogError.DISMISSED, "Dismissed by user");
 
+const renderSelectFileButton = async (): Promise<Gtk.Button> => {
+    await renderDemo(pickersDemo);
+
+    return await screen.findByName("select-file-button", { as: Gtk.Button });
+};
+
+const dropFileOnSelectButton = async (path: string): Promise<Gtk.Button> => {
+    const selectFile = await renderSelectFileButton();
+    await userEvent.drop(selectFile, makeFileValue(path));
+
+    return selectFile;
+};
+
 writeFileSync(PDF_PATH, MIN_PDF);
 
 afterAll(() => {
@@ -55,16 +68,16 @@ describe("pickersDemo rendering", () => {
     it("renders the 'None' file label and the www.gtk.org URI launcher button", async () => {
         await renderDemo(pickersDemo);
         expect(await screen.findByText("None")).toHaveTextContent("None");
-        const uriButton = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Open www.gtk.org" });
+        const uriButton = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "URI:" });
         expect(uriButton).toHaveTextContent("www.gtk.org");
     });
 
     it("renders the labelled rows for color, font, file and URI via mnemonic labels", async () => {
         await renderDemo(pickersDemo);
-        expect(await screen.findByLabelText("_Color:")).toBeInstanceOf(Gtk.ColorDialogButton);
-        expect(await screen.findByLabelText("_Font:")).toBeInstanceOf(Gtk.FontDialogButton);
-        expect(await screen.findByLabelText("_File:")).toBeInstanceOf(Gtk.Button);
-        expect(await screen.findByLabelText("_URI:")).toBeInstanceOf(Gtk.Button);
+        expect(await screen.findByLabelText("Color:")).toBeInstanceOf(Gtk.ColorDialogButton);
+        expect(await screen.findByLabelText("Font:")).toBeInstanceOf(Gtk.FontDialogButton);
+        expect(await screen.findByLabelText("File:")).toBeInstanceOf(Gtk.Button);
+        expect(await screen.findByLabelText("URI:")).toBeInstanceOf(Gtk.Button);
     });
 });
 
@@ -90,8 +103,7 @@ describe("pickersDemo handlers", () => {
         const errorSpy = vi.spyOn(console, "error");
 
         try {
-            await renderDemo(pickersDemo);
-            const selectFile = await screen.findByName("select-file-button", { as: Gtk.Button });
+            const selectFile = await renderSelectFileButton();
             await userEvent.click(selectFile);
 
             await waitFor(() => {
@@ -113,7 +125,7 @@ describe("pickersDemo handlers", () => {
             await renderDemo(pickersDemo);
 
             const uri = await screen.findByRole(Gtk.AccessibleRole.BUTTON, {
-                name: "Open www.gtk.org",
+                name: "URI:",
                 as: Gtk.Button,
             });
 
@@ -133,9 +145,7 @@ describe("pickersDemo handlers", () => {
 
 describe("pickersDemo drop target", () => {
     it("accepts a GFile dropped on the select-file button and updates the displayed filename", async () => {
-        await renderDemo(pickersDemo);
-        const selectFile = await screen.findByName("select-file-button", { as: Gtk.Button });
-        await userEvent.drop(selectFile, makeFileValue("/tmp"));
+        await dropFileOnSelectButton("/tmp");
 
         await waitFor(() => {
             expect(screen.getByText("tmp")).toHaveTextContent("tmp");
@@ -145,17 +155,14 @@ describe("pickersDemo drop target", () => {
     });
 
     it("returns false from the drop handler when a non-file value is dropped on the select-file button", async () => {
-        await renderDemo(pickersDemo);
-        const selectFile = await screen.findByName("select-file-button", { as: Gtk.Button });
+        const selectFile = await renderSelectFileButton();
         await userEvent.drop(selectFile, makeStringValue("not a file"));
         await screen.findByText("None");
         expect(screen.queryByText("not a file")).toBeNull();
     });
 
     it("enables the Open File and Open in Folder buttons but keeps Print disabled for a non-PDF file", async () => {
-        await renderDemo(pickersDemo);
-        const selectFile = await screen.findByName("select-file-button", { as: Gtk.Button });
-        await userEvent.drop(selectFile, makeFileValue("/tmp"));
+        await dropFileOnSelectButton("/tmp");
         const openFileBtn = await screen.findByName("open-file-button", { as: Gtk.Button });
         const openFolderBtn = await screen.findByName("open-folder-button", { as: Gtk.Button });
         const printBtn = await screen.findByName("print-button", { as: Gtk.Button });
@@ -174,9 +181,7 @@ describe("pickersDemo file-dependent handlers", () => {
         const launchSpy = vi.spyOn(Gtk.FileLauncher.prototype, "launch").mockResolvedValue(true);
 
         try {
-            await renderDemo(pickersDemo);
-            const selectFile = await screen.findByName("select-file-button", { as: Gtk.Button });
-            await userEvent.drop(selectFile, makeFileValue(PDF_PATH));
+            await dropFileOnSelectButton(PDF_PATH);
             const openFile = await screen.findByName("open-file-button", { as: Gtk.Button });
 
             await waitFor(() => {
@@ -197,9 +202,7 @@ describe("pickersDemo file-dependent handlers", () => {
         const folderSpy = vi.spyOn(Gtk.FileLauncher.prototype, "openContainingFolder").mockResolvedValue(true);
 
         try {
-            await renderDemo(pickersDemo);
-            const selectFile = await screen.findByName("select-file-button", { as: Gtk.Button });
-            await userEvent.drop(selectFile, makeFileValue(PDF_PATH));
+            await dropFileOnSelectButton(PDF_PATH);
             const openFolder = await screen.findByName("open-folder-button", { as: Gtk.Button });
 
             await waitFor(() => {
@@ -220,9 +223,7 @@ describe("pickersDemo file-dependent handlers", () => {
 describe("pickersDemo printing", () => {
     it("enables the Print button and runs handlePrintFile after dropping a PDF GFile", async () => {
         const printFileSpy = vi.spyOn(Gtk.PrintDialog.prototype, "printFile").mockResolvedValue(true);
-        await renderDemo(pickersDemo);
-        const selectFile = await screen.findByName("select-file-button", { as: Gtk.Button });
-        await userEvent.drop(selectFile, makeFileValue(PDF_PATH));
+        await dropFileOnSelectButton(PDF_PATH);
         const printBtn = await screen.findByName("print-button", { as: Gtk.Button });
 
         await waitFor(() => {

--- a/examples/gtk-demo/tests/demos/drawing/drawingarea.test.tsx
+++ b/examples/gtk-demo/tests/demos/drawing/drawingarea.test.tsx
@@ -4,6 +4,14 @@ import { describe, expect, it, vi } from "vitest";
 import { drawingAreaDemo } from "../../../src/demos/drawing/drawingarea.js";
 import { renderDemo } from "../../test-utils.js";
 
+const renderFrames = async (): Promise<{ knockoutFrame: Gtk.Frame; scribbleFrame: Gtk.Frame }> => {
+    await renderDemo(drawingAreaDemo);
+    const knockoutFrame = await screen.findByName("knockout-frame", { as: Gtk.Frame });
+    const scribbleFrame = await screen.findByName("scribble-frame", { as: Gtk.Frame });
+
+    return { knockoutFrame, scribbleFrame };
+};
+
 describe("drawingAreaDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(drawingAreaDemo.id).toBe("drawingarea");
@@ -43,9 +51,7 @@ describe("drawingAreaDemo rendering", () => {
     });
 
     it("renders two GtkDrawingArea widgets each sized 100x100", async () => {
-        await renderDemo(drawingAreaDemo);
-        const knockoutFrame = await screen.findByName("knockout-frame", { as: Gtk.Frame });
-        const scribbleFrame = await screen.findByName("scribble-frame", { as: Gtk.Frame });
+        const { knockoutFrame, scribbleFrame } = await renderFrames();
 
         for (const frame of [knockoutFrame, scribbleFrame]) {
             const area = within(frame).getByRole(Gtk.AccessibleRole.IMG, { as: Gtk.DrawingArea });
@@ -55,9 +61,7 @@ describe("drawingAreaDemo rendering", () => {
     });
 
     it("wraps each drawing area in a vertical-expanding frame", async () => {
-        await renderDemo(drawingAreaDemo);
-        const knockoutFrame = await screen.findByName("knockout-frame", { as: Gtk.Frame });
-        const scribbleFrame = await screen.findByName("scribble-frame", { as: Gtk.Frame });
+        const { knockoutFrame, scribbleFrame } = await renderFrames();
 
         for (const frame of [knockoutFrame, scribbleFrame]) {
             expect(frame).toHaveObjectProperty("vexpand", true);

--- a/examples/gtk-demo/tests/demos/drawing/images.test.tsx
+++ b/examples/gtk-demo/tests/demos/drawing/images.test.tsx
@@ -57,7 +57,7 @@ describe("imagesDemo toggle", () => {
         await renderDemo(imagesDemo);
 
         const toggle = await screen.findByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, {
-            name: "_Insensitive",
+            name: "Insensitive",
             as: Gtk.ToggleButton,
         });
 
@@ -68,7 +68,7 @@ describe("imagesDemo toggle", () => {
         await renderDemo(imagesDemo);
 
         const toggle = await screen.findByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, {
-            name: "_Insensitive",
+            name: "Insensitive",
             as: Gtk.ToggleButton,
         });
 

--- a/examples/gtk-demo/tests/demos/drawing/paintable-svg.test.tsx
+++ b/examples/gtk-demo/tests/demos/drawing/paintable-svg.test.tsx
@@ -6,6 +6,8 @@ import nodeEditorSvgUri from "#data/demos/drawing/org.gtk.gtk4.NodeEditor.Devel.
 import { paintableSvgDemo } from "../../../src/demos/drawing/paintable-svg.js";
 import { findOpenButton, renderDemo } from "../../test-utils.js";
 
+type PictureState = { picture: Gtk.Picture; initial: ReturnType<Gtk.Picture["getPaintable"]> };
+
 const renderAndFindPicture = async (): Promise<Gtk.Picture> => {
     await renderDemo(paintableSvgDemo);
 
@@ -20,6 +22,15 @@ const renderAndFindSvgPicture = async (): Promise<{ picture: Gtk.Picture; svg: G
     });
 
     return { picture, svg: picture.getPaintable() as Gtk.Svg };
+};
+
+const openPictureFileDialog = async (): Promise<PictureState> => {
+    const { picture } = await renderAndFindSvgPicture();
+    const initial = picture.getPaintable();
+    const openButton = await findOpenButton();
+    await userEvent.click(openButton);
+
+    return { picture, initial };
 };
 
 describe("paintableSvgDemo metadata", () => {
@@ -54,7 +65,7 @@ describe("paintableSvgDemo rendering", () => {
     it("packs the open button into a HeaderBar titlebar", async () => {
         await renderDemo(paintableSvgDemo);
         const headerBar = await screen.findByName("paintable-svg-header", { as: Gtk.HeaderBar });
-        const openButton = within(headerBar).getByRole(Gtk.AccessibleRole.BUTTON, { name: "_Open", as: Gtk.Button });
+        const openButton = within(headerBar).getByRole(Gtk.AccessibleRole.BUTTON, { name: "Open", as: Gtk.Button });
         expect(openButton).toBeInstanceOf(Gtk.Button);
     });
 
@@ -72,10 +83,7 @@ describe("paintableSvgDemo open dialog", () => {
         openSpy.mockResolvedValue(Gio.File.newForUri(nodeEditorSvgUri));
 
         try {
-            const { picture } = await renderAndFindSvgPicture();
-            const initial = picture.getPaintable();
-            const openButton = await findOpenButton();
-            await userEvent.click(openButton);
+            const { picture, initial } = await openPictureFileDialog();
 
             await waitFor(() => {
                 expect(openSpy).toHaveBeenCalled();
@@ -95,10 +103,7 @@ describe("paintableSvgDemo open dialog", () => {
         openSpy.mockRejectedValue(new Error("dismissed"));
 
         try {
-            const { picture } = await renderAndFindSvgPicture();
-            const initial = picture.getPaintable();
-            const openButton = await findOpenButton();
-            await userEvent.click(openButton);
+            const { picture, initial } = await openPictureFileDialog();
 
             await waitFor(() => {
                 expect(errorSpy).toHaveBeenCalledWith("dismissed");

--- a/examples/gtk-demo/tests/demos/games/listview-minesweeper.test.tsx
+++ b/examples/gtk-demo/tests/demos/games/listview-minesweeper.test.tsx
@@ -2,35 +2,15 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { fireEvent, screen, userEvent, waitFor } from "@gtkx/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listviewMinesweeperDemo } from "../../../src/demos/games/listview-minesweeper.js";
-import { renderDemo } from "../../test-utils.js";
+import { collectWidgets, renderDemo } from "../../test-utils.js";
 
 const MINE = "\u{1F4A3}";
 
-const collectLabels = (widget: Gtk.Widget, out: Gtk.Label[] = []): Gtk.Label[] => {
-    for (let child = widget.getFirstChild(); child; child = child.getNextSibling()) {
-        if (child instanceof Gtk.Label) {
-            out.push(child);
-        }
+const cellTexts = (gridView: Gtk.Widget): string[] =>
+    collectWidgets(gridView, Gtk.Label).map((label) => label.getLabel());
 
-        collectLabels(child, out);
-    }
-
-    return out;
-};
-
-const collectImages = (widget: Gtk.Widget, out: Gtk.Image[] = []): Gtk.Image[] => {
-    for (let child = widget.getFirstChild(); child; child = child.getNextSibling()) {
-        if (child instanceof Gtk.Image) {
-            out.push(child);
-        }
-
-        collectImages(child, out);
-    }
-
-    return out;
-};
-
-const cellTexts = (gridView: Gtk.Widget): string[] => collectLabels(gridView).map((label) => label.getLabel());
+const hasTrophy = (header: Gtk.Widget): boolean =>
+    collectWidgets(header, Gtk.Image).some((image) => image.getIconName() === "trophy-gold");
 
 const mockMinesAt = (indices: number[]): void => {
     const values = indices.map((index) => Math.floor(((index + 0.5) / 64) * 2 ** 32));
@@ -45,6 +25,12 @@ const mockMinesAt = (indices: number[]): void => {
 
         return buffer;
     });
+};
+
+const renderGridView = async (): Promise<Gtk.GridView> => {
+    await renderDemo(listviewMinesweeperDemo);
+
+    return await screen.findByName("grid-view", { as: Gtk.GridView });
 };
 
 beforeEach(() => {
@@ -81,14 +67,13 @@ describe("listviewMinesweeperDemo rendering", () => {
     it("starts with no trophy in the header (title widget is null while playing)", async () => {
         await renderDemo(listviewMinesweeperDemo);
         const header = await screen.findByName("minesweeper-header");
-        expect(collectImages(header).some((image) => image.getIconName() === "trophy-gold")).toBe(false);
+        expect(hasTrophy(header)).toBe(false);
     });
 });
 
 describe("listviewMinesweeperDemo gameplay", () => {
     it("reveals the focused cell on a single-press activation (keyboard Enter)", async () => {
-        await renderDemo(listviewMinesweeperDemo);
-        const gridView = await screen.findByName("grid-view", { as: Gtk.GridView });
+        const gridView = await renderGridView();
         gridView.grabFocus();
         await userEvent.keyboard(gridView, "{Enter}");
 
@@ -100,8 +85,7 @@ describe("listviewMinesweeperDemo gameplay", () => {
     });
 
     it("restores the revealed cell to '?' after pressing New Game", async () => {
-        await renderDemo(listviewMinesweeperDemo);
-        const gridView = await screen.findByName("grid-view", { as: Gtk.GridView });
+        const gridView = await renderGridView();
         await fireEvent(gridView, "activate", 0);
 
         await waitFor(() => {
@@ -122,8 +106,7 @@ describe("listviewMinesweeperDemo gameplay", () => {
 describe("listviewMinesweeperDemo outcomes", () => {
     it("loses when a mine is activated and locks the board against further reveals", async () => {
         mockMinesAt([0, 10, 11, 12, 13, 14, 15, 16, 17, 18]);
-        await renderDemo(listviewMinesweeperDemo);
-        const gridView = await screen.findByName("grid-view", { as: Gtk.GridView });
+        const gridView = await renderGridView();
         await fireEvent(gridView, "activate", 0);
 
         await waitFor(() => {
@@ -139,8 +122,7 @@ describe("listviewMinesweeperDemo outcomes", () => {
 
     it("wins when every safe cell is revealed and swaps in the trophy title widget", async () => {
         mockMinesAt([54, 55, 56, 57, 58, 59, 60, 61, 62, 63]);
-        await renderDemo(listviewMinesweeperDemo);
-        const gridView = await screen.findByName("grid-view", { as: Gtk.GridView });
+        const gridView = await renderGridView();
         const header = await screen.findByName("minesweeper-header");
 
         for (let position = 0; position < 54; position++) {
@@ -148,7 +130,7 @@ describe("listviewMinesweeperDemo outcomes", () => {
         }
 
         await waitFor(() => {
-            expect(collectImages(header).some((image) => image.getIconName() === "trophy-gold")).toBe(true);
+            expect(hasTrophy(header)).toBe(true);
         });
 
         const texts = cellTexts(gridView);

--- a/examples/gtk-demo/tests/demos/gestures/clipboard.test.tsx
+++ b/examples/gtk-demo/tests/demos/gestures/clipboard.test.tsx
@@ -7,17 +7,24 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { clipboardDemo } from "../../../src/demos/gestures/clipboard.js";
-import { makeFileValue, makeIntValue, makeRgbaValue, makeStringValue, renderDemo } from "../../test-utils.js";
+import { makeFileValue, makeIntValue, makeRgba, makeRgbaValue, makeStringValue, renderDemo } from "../../test-utils.js";
+
+type SourceType = "Text" | "Color" | "Image" | "File" | "Folder";
 
 const TEMP_DIR = tmpdir();
 
 const findButtonByLabel = async (label: string): Promise<Gtk.Button> =>
     screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: label, as: Gtk.Button });
 
-const switchSourceType = async (type: "Text" | "Color" | "Image" | "File" | "Folder"): Promise<void> => {
+const switchSourceType = async (type: SourceType): Promise<void> => {
     const dropdown = await screen.findByName("source-type", { as: Gtk.DropDown });
     const items = ["Text", "Color", "Image", "File", "Folder"];
     await userEvent.selectOptions(dropdown, items.indexOf(type));
+};
+
+const renderSourceType = async (type: SourceType): Promise<void> => {
+    await renderDemo(clipboardDemo);
+    await switchSourceType(type);
 };
 
 const getDefaultClipboard = (): Gdk.Clipboard => {
@@ -67,22 +74,30 @@ const populateClipboardFile = async (): Promise<void> => {
 };
 
 const copyImageSource = async (): Promise<void> => {
-    await renderDemo(clipboardDemo);
-    await switchSourceType("Image");
-    const copyButton = await findButtonByLabel("_Copy");
+    await renderSourceType("Image");
+    const copyButton = await findButtonByLabel("Copy");
     await userEvent.click(copyButton);
 };
 
 const getPasteStack = async (): Promise<Gtk.Stack> => await screen.findByName("paste-stack", { as: Gtk.Stack });
 
-const buildRgba = (r: number, g: number, b: number, a: number): Gdk.RGBA => {
-    const rgba = new Gdk.RGBA();
-    rgba.red = r;
-    rgba.green = g;
-    rgba.blue = b;
-    rgba.alpha = a;
+const expectClipboardHolds = async (gtype: ReturnType<typeof GObject.typeFromName>): Promise<void> => {
+    await waitFor(() => {
+        expect(getDefaultClipboard().getFormats().containGtype(gtype)).toBe(true);
+    });
+};
 
-    return rgba;
+const dropOnPasteBox = async (value: GObject.Value): Promise<Gtk.Label> => {
+    const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
+    await userEvent.drop(pasteBox, value);
+
+    return await screen.findByName("paste-type-label", { as: Gtk.Label });
+};
+
+const expectPasteTypeLabel = async (label: Gtk.Label, type: string): Promise<void> => {
+    await waitFor(() => {
+        expect(label).toHaveTextContent(type);
+    });
 };
 
 const makePaintableValue = (): GObject.Value => {
@@ -95,7 +110,7 @@ const makePaintableValue = (): GObject.Value => {
 };
 
 const pasteAndAssertType = async (assertType: (label: Gtk.Label) => void): Promise<void> => {
-    const pasteButton = await findButtonByLabel("_Paste");
+    const pasteButton = await findButtonByLabel("Paste");
 
     await waitFor(() => {
         expect(pasteButton).toBeEnabled();
@@ -135,14 +150,27 @@ const clickSourceButtonAfterDialog = async (
     kind: "File" | "Folder",
     label: "File Drag Source" | "Folder Drag Source",
 ): Promise<void> => {
-    await renderDemo(clipboardDemo);
-    await switchSourceType(kind);
+    await renderSourceType(kind);
     const sourceButton = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: label, as: Gtk.Button });
 
     await act(async () => {
         await userEvent.click(sourceButton);
         await Promise.resolve();
     });
+};
+
+const expectCopyEnabledAfterDialog = async (
+    kind: "File" | "Folder",
+    label: "File Drag Source" | "Folder Drag Source",
+): Promise<Gtk.Button> => {
+    await clickSourceButtonAfterDialog(kind, label);
+    const copyButton = await findButtonByLabel("Copy");
+
+    await waitFor(() => {
+        expect(copyButton).toBeEnabled();
+    });
+
+    return copyButton;
 };
 
 describe("clipboardDemo metadata", () => {
@@ -169,15 +197,14 @@ describe("clipboardDemo rendering", () => {
             );
 
             expect(await screen.findByDisplayValue("Copy this!")).toHaveDisplayValue("Copy this!");
-            const copyButton = await findButtonByLabel("_Copy");
+            const copyButton = await findButtonByLabel("Copy");
             expect(copyButton).toBeEnabled();
-            await findButtonByLabel("_Paste");
+            await findButtonByLabel("Paste");
         },
     );
 
     it("renders three image toggle buttons with the rose toggle active by default", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Image");
+        await renderSourceType("Image");
         const rose = await screen.findByName("image_rose", { as: Gtk.ToggleButton });
         const floppy = await screen.findByName("image_floppy", { as: Gtk.ToggleButton });
         const logo = await screen.findByName("image_logo", { as: Gtk.ToggleButton });
@@ -187,7 +214,7 @@ describe("clipboardDemo rendering", () => {
     });
 
     it("includes a GtkColorDialogButton for the Color source page", async () => {
-        await renderDemo(clipboardDemo);
+        await renderSourceType("Color");
         const colorButton = await screen.findByName("color-button");
         expect(colorButton).toBeInstanceOf(Gtk.ColorDialogButton);
     });
@@ -211,7 +238,7 @@ describe("clipboardDemo entry interactions", () => {
     it("disables the copy button when the text source is cleared", async () => {
         await renderDemo(clipboardDemo);
         const entry = await screen.findByName("source-entry", { as: Gtk.Entry });
-        const copyButton = await findButtonByLabel("_Copy");
+        const copyButton = await findButtonByLabel("Copy");
         expect(copyButton).toBeEnabled();
         await userEvent.clear(entry);
 
@@ -223,7 +250,7 @@ describe("clipboardDemo entry interactions", () => {
     it("re-enables the copy button when the user types text after clearing the source", async () => {
         await renderDemo(clipboardDemo);
         const entry = await screen.findByName("source-entry", { as: Gtk.Entry });
-        const copyButton = await findButtonByLabel("_Copy");
+        const copyButton = await findButtonByLabel("Copy");
         await userEvent.clear(entry);
 
         await waitFor(() => {
@@ -240,8 +267,7 @@ describe("clipboardDemo entry interactions", () => {
 
 describe("clipboardDemo source type switching", () => {
     it("switches the source stack to the Color page when Color is selected", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Color");
+        await renderSourceType("Color");
         const stack = await screen.findByName("source-stack", { as: Gtk.Stack });
 
         await waitFor(() => {
@@ -250,8 +276,7 @@ describe("clipboardDemo source type switching", () => {
     });
 
     it("switches the source stack to the Image page when Image is selected", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Image");
+        await renderSourceType("Image");
         const stack = await screen.findByName("source-stack", { as: Gtk.Stack });
 
         await waitFor(() => {
@@ -262,15 +287,14 @@ describe("clipboardDemo source type switching", () => {
     it(
         "switches the source stack to the File page when File is selected and disables Copy until a file is chosen",
         async () => {
-            await renderDemo(clipboardDemo);
-            await switchSourceType("File");
+            await renderSourceType("File");
             const stack = await screen.findByName("source-stack", { as: Gtk.Stack });
 
             await waitFor(() => {
                 expect(stack).toHaveObjectProperty("visibleChildName", "File");
             });
 
-            const copyButton = await findButtonByLabel("_Copy");
+            const copyButton = await findButtonByLabel("Copy");
 
             await waitFor(() => {
                 expect(copyButton).toBeDisabled();
@@ -282,15 +306,14 @@ describe("clipboardDemo source type switching", () => {
         "switches the source stack to the Folder page when Folder is selected " +
         "and disables Copy until a folder is chosen",
         async () => {
-            await renderDemo(clipboardDemo);
-            await switchSourceType("Folder");
+            await renderSourceType("Folder");
             const stack = await screen.findByName("source-stack", { as: Gtk.Stack });
 
             await waitFor(() => {
                 expect(stack).toHaveObjectProperty("visibleChildName", "Folder");
             });
 
-            const copyButton = await findButtonByLabel("_Copy");
+            const copyButton = await findButtonByLabel("Copy");
 
             await waitFor(() => {
                 expect(copyButton).toBeDisabled();
@@ -301,8 +324,7 @@ describe("clipboardDemo source type switching", () => {
 
 describe("clipboardDemo image source", () => {
     it("activates the floppy buddy image toggle when clicked and deselects the default rose toggle", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Image");
+        await renderSourceType("Image");
         const rose = await screen.findByName("image_rose", { as: Gtk.ToggleButton });
         const floppy = await screen.findByName("image_floppy", { as: Gtk.ToggleButton });
         expect(rose).toBePressed();
@@ -315,8 +337,7 @@ describe("clipboardDemo image source", () => {
     });
 
     it("activates the logo image toggle when clicked", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Image");
+        await renderSourceType("Image");
         const logo = await screen.findByName("image_logo", { as: Gtk.ToggleButton });
         await userEvent.click(logo);
 
@@ -328,23 +349,18 @@ describe("clipboardDemo image source", () => {
 
 describe("clipboardDemo color source", () => {
     it("copies the color chosen through the color button after onNotifyRgba updates the source color", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Color");
+        await renderSourceType("Color");
         const colorButton = await screen.findByName("color-button", { as: Gtk.ColorDialogButton });
-        const chosen = buildRgba(0.2, 0.4, 0.6, 1);
+        const chosen = makeRgba(0.2, 0.4, 0.6, 1);
 
         await act(() => {
             colorButton.setRgba(chosen);
         });
 
-        const copyButton = await findButtonByLabel("_Copy");
+        const copyButton = await findButtonByLabel("Copy");
         await userEvent.click(copyButton);
         const rgbaType = GObject.typeFromName("GdkRGBA");
-
-        await waitFor(() => {
-            expect(getDefaultClipboard().getFormats().containGtype(rgbaType)).toBe(true);
-        });
-
+        await expectClipboardHolds(rgbaType);
         const value = await getDefaultClipboard().readValueAsync(rgbaType, 0, null);
         const rgba = value.getBoxed<Gdk.RGBA>();
         expect(rgba.red).toBeCloseTo(0.2, 2);
@@ -356,31 +372,21 @@ describe("clipboardDemo color source", () => {
 describe("clipboardDemo Copy button populates the clipboard", () => {
     it("copies a string when Copy is clicked with text selected", async () => {
         await renderDemo(clipboardDemo);
-        const copyButton = await findButtonByLabel("_Copy");
+        const copyButton = await findButtonByLabel("Copy");
         await userEvent.click(copyButton);
-
-        await waitFor(() => {
-            expect(getDefaultClipboard().getFormats().containGtype(GObject.TYPE_STRING)).toBe(true);
-        });
+        await expectClipboardHolds(GObject.TYPE_STRING);
     });
 
     it("copies an RGBA color when Copy is clicked with Color source selected", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Color");
-        const copyButton = await findButtonByLabel("_Copy");
+        await renderSourceType("Color");
+        const copyButton = await findButtonByLabel("Copy");
         await userEvent.click(copyButton);
-
-        await waitFor(() => {
-            expect(getDefaultClipboard().getFormats().containGtype(GObject.typeFromName("GdkRGBA"))).toBe(true);
-        });
+        await expectClipboardHolds(GObject.typeFromName("GdkRGBA"));
     });
 
     it("copies a paintable when Copy is clicked with Image source selected", async () => {
         await copyImageSource();
-
-        await waitFor(() => {
-            expect(getDefaultClipboard().getFormats().containGtype(GObject.typeFromName("GdkPaintable"))).toBe(true);
-        });
+        await expectClipboardHolds(GObject.typeFromName("GdkPaintable"));
     });
 });
 
@@ -439,35 +445,20 @@ describe("clipboardDemo Paste button updates pasted content", () => {
 describe("clipboardDemo paste-box drop handler", () => {
     it("updates the pasted content label to 'Text' when a string is dropped", async () => {
         await renderDemo(clipboardDemo);
-        const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
-        await userEvent.drop(pasteBox, makeStringValue("dropped text"));
-        const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-        await waitFor(() => {
-            expect(label).toHaveTextContent("Text");
-        });
+        const label = await dropOnPasteBox(makeStringValue("dropped text"));
+        await expectPasteTypeLabel(label, "Text");
     });
 
     it("updates the pasted content label to 'Color' when an RGBA is dropped", async () => {
         await renderDemo(clipboardDemo);
-        const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
-        await userEvent.drop(pasteBox, makeRgbaValue(0.5, 0.2, 0.8, 1));
-        const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-        await waitFor(() => {
-            expect(label).toHaveTextContent("Color");
-        });
+        const label = await dropOnPasteBox(makeRgbaValue(0.5, 0.2, 0.8, 1));
+        await expectPasteTypeLabel(label, "Color");
     });
 
     it("updates the pasted content label to 'File' when a GFile is dropped", async () => {
         await renderDemo(clipboardDemo);
-        const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
-        await userEvent.drop(pasteBox, makeFileValue("/tmp"));
-        const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-        await waitFor(() => {
-            expect(label).toHaveTextContent("File");
-        });
+        const label = await dropOnPasteBox(makeFileValue("/tmp"));
+        await expectPasteTypeLabel(label, "File");
     });
 });
 
@@ -478,37 +469,24 @@ describe("clipboardDemo drag sources", () => {
         const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
         await userEvent.dragAndDrop(entry, pasteBox, makeStringValue("Copy this!"));
         const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-        await waitFor(() => {
-            expect(label).toHaveTextContent("Text");
-        });
+        await expectPasteTypeLabel(label, "Text");
     });
 
     it("registers a drag source on the color button by exposing its color via userEvent", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Color");
+        await renderSourceType("Color");
         const colorButton = await screen.findByName("color-button", { as: Gtk.ColorDialogButton });
         const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
         await userEvent.dragAndDrop(colorButton, pasteBox, makeRgbaValue(0.5, 0.5, 0.5, 1));
         const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-        await waitFor(() => {
-            expect(label).toHaveTextContent("Color");
-        });
+        await expectPasteTypeLabel(label, "Color");
     });
 });
 
 describe("clipboardDemo paste content rendering", () => {
     it("switches the paste stack to the Color swatch page after a Color is dropped on the paste box", async () => {
         await renderDemo(clipboardDemo);
-        const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
-        await userEvent.drop(pasteBox, makeRgbaValue(0.9, 0.1, 0.5, 1));
-        const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-        await waitFor(() => {
-            expect(label).toHaveTextContent("Color");
-        });
-
+        const label = await dropOnPasteBox(makeRgbaValue(0.9, 0.1, 0.5, 1));
+        await expectPasteTypeLabel(label, "Color");
         const pasteStack = await getPasteStack();
 
         await waitFor(() => {
@@ -529,14 +507,8 @@ describe("clipboardDemo paste content rendering", () => {
         "renders the pasted image on the paste-stack Image page when a paintable is dropped on the paste box",
         async () => {
             await renderDemo(clipboardDemo);
-            const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
-            await userEvent.drop(pasteBox, makePaintableValue());
-            const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-            await waitFor(() => {
-                expect(label).toHaveTextContent("Image");
-            });
-
+            const label = await dropOnPasteBox(makePaintableValue());
+            await expectPasteTypeLabel(label, "Image");
             const pasteStack = await getPasteStack();
 
             await waitFor(() => {
@@ -549,8 +521,7 @@ describe("clipboardDemo paste content rendering", () => {
 
 describe("clipboardDemo invalid image path", () => {
     it("logs the texture error when copying an image source whose resource fails to load", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Image");
+        await renderSourceType("Image");
         const errorSpy = vi.spyOn(console, "error").mockImplementation((): void => undefined);
 
         const textureSpy = vi.spyOn(Gdk.Texture, "newFromResource").mockImplementation(() => {
@@ -558,7 +529,7 @@ describe("clipboardDemo invalid image path", () => {
         });
 
         try {
-            const copyButton = await findButtonByLabel("_Copy");
+            const copyButton = await findButtonByLabel("Copy");
             await userEvent.click(copyButton);
 
             await waitFor(() => {
@@ -573,10 +544,7 @@ describe("clipboardDemo invalid image path", () => {
 
 describe("clipboardDemo paste after copy round-trip", () => {
     it("shows pasted Image when the clipboard holds a paintable copied from the demo", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Image");
-        const copyButton = await findButtonByLabel("_Copy");
-        await userEvent.click(copyButton);
+        await copyImageSource();
 
         await pasteAndAssertType((label) => {
             expect(label).toHaveTextContent("Image");
@@ -587,23 +555,13 @@ describe("clipboardDemo paste after copy round-trip", () => {
 describe("clipboardDemo file source selection", () => {
     it("opens a Gtk.FileDialog and updates the source file when the File button is clicked", async () => {
         await runWithFileDialog("open", Gio.File.newForPath(join(TEMP_DIR, "fake-file.txt")), async () => {
-            await clickSourceButtonAfterDialog("File", "File Drag Source");
-            const copyButton = await findButtonByLabel("_Copy");
-
-            await waitFor(() => {
-                expect(copyButton).toBeEnabled();
-            });
+            await expectCopyEnabledAfterDialog("File", "File Drag Source");
         });
     });
 
     it("opens a Gtk.FileDialog folder picker when the Folder button is clicked", async () => {
         await runWithFileDialog("selectFolder", Gio.File.newForPath("/tmp"), async () => {
-            await clickSourceButtonAfterDialog("Folder", "Folder Drag Source");
-            const copyButton = await findButtonByLabel("_Copy");
-
-            await waitFor(() => {
-                expect(copyButton).toBeEnabled();
-            });
+            await expectCopyEnabledAfterDialog("Folder", "Folder Drag Source");
         });
     });
 
@@ -627,43 +585,24 @@ describe("clipboardDemo file source selection", () => {
 describe("clipboardDemo file source copying", () => {
     it("copies a file to the clipboard after the file dialog selects a file", async () => {
         await runWithFileDialog("open", Gio.File.newForPath(join(TEMP_DIR, "some-file.txt")), async () => {
-            await clickSourceButtonAfterDialog("File", "File Drag Source");
-            const copyButton = await findButtonByLabel("_Copy");
-
-            await waitFor(() => {
-                expect(copyButton).toBeEnabled();
-            });
-
+            const copyButton = await expectCopyEnabledAfterDialog("File", "File Drag Source");
             await userEvent.click(copyButton);
-
-            await waitFor(() => {
-                expect(getDefaultClipboard().getFormats().containGtype(GObject.typeFromName("GFile"))).toBe(true);
-            });
+            await expectClipboardHolds(GObject.typeFromName("GFile"));
         });
     });
 
     it("copies a folder GFile to the clipboard after the folder dialog selects a folder", async () => {
         await runWithFileDialog("selectFolder", Gio.File.newForPath("/tmp"), async () => {
-            await clickSourceButtonAfterDialog("Folder", "Folder Drag Source");
-            const copyButton = await findButtonByLabel("_Copy");
-
-            await waitFor(() => {
-                expect(copyButton).toBeEnabled();
-            });
-
+            const copyButton = await expectCopyEnabledAfterDialog("Folder", "Folder Drag Source");
             await userEvent.click(copyButton);
-
-            await waitFor(() => {
-                expect(getDefaultClipboard().getFormats().containGtype(GObject.typeFromName("GFile"))).toBe(true);
-            });
+            await expectClipboardHolds(GObject.typeFromName("GFile"));
         });
     });
 });
 
 describe("clipboardDemo image and file drag sources", () => {
     it("exposes a paintable content provider from the floppy image toggle drag source", async () => {
-        await renderDemo(clipboardDemo);
-        await switchSourceType("Image");
+        await renderSourceType("Image");
         const floppy = await screen.findByName("image_floppy", { as: Gtk.ToggleButton });
         await userEvent.click(floppy);
 
@@ -699,20 +638,13 @@ describe("clipboardDemo image and file drag sources", () => {
 describe("clipboardDemo paste-box drop with object types", () => {
     it("updates the pasted content label to 'File' when a GFile object is dropped via the OBJECT branch", async () => {
         await renderDemo(clipboardDemo);
-        const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
-        await userEvent.drop(pasteBox, makeFileValue("/etc"));
-        const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
-
-        await waitFor(() => {
-            expect(label).toHaveTextContent("File");
-        });
+        const label = await dropOnPasteBox(makeFileValue("/etc"));
+        await expectPasteTypeLabel(label, "File");
     });
 
     it("returns false from the drop handler when the dropped value is unrecognized", async () => {
         await renderDemo(clipboardDemo);
-        const pasteBox = await screen.findByName("paste-box", { as: Gtk.Box });
-        await userEvent.drop(pasteBox, makeIntValue(42));
-        const label = await screen.findByName("paste-type-label", { as: Gtk.Label });
+        const label = await dropOnPasteBox(makeIntValue(42));
         expect(label).not.toHaveTextContent();
     });
 });

--- a/examples/gtk-demo/tests/demos/gestures/cursors.test.tsx
+++ b/examples/gtk-demo/tests/demos/gestures/cursors.test.tsx
@@ -3,21 +3,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { screen } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
 import { cursorsDemo } from "../../../src/demos/gestures/cursors.js";
-import { renderDemo } from "../../test-utils.js";
-
-const collectFrames = (widget: Gtk.Widget | null, frames: Gtk.Frame[]): void => {
-    if (!widget) {
-        return;
-    }
-
-    if (widget instanceof Gtk.Frame) {
-        frames.push(widget);
-    }
-
-    for (let child = widget.getFirstChild(); child; child = child.getNextSibling()) {
-        collectFrames(child, frames);
-    }
-};
+import { collectWidgets, renderDemo } from "../../test-utils.js";
 
 const rowFramesFor = async (name: string): Promise<Gtk.Frame[]> => {
     const label = await screen.findByText(name);
@@ -27,10 +13,7 @@ const rowFramesFor = async (name: string): Promise<Gtk.Frame[]> => {
         row = row.getParent();
     }
 
-    const frames: Gtk.Frame[] = [];
-    collectFrames(row, frames);
-
-    return frames;
+    return row ? collectWidgets(row, Gtk.Frame) : [];
 };
 
 const getSelectionModes = (listBoxes: Gtk.Widget[]): Gtk.SelectionMode[] =>
@@ -142,6 +125,7 @@ describe("cursorsDemo previews", () => {
 
 describe("cursorsDemo css registration", () => {
     it("adds exactly one cursors CssProvider at user priority for the default display", async () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const addSpy = vi.spyOn(Gtk.StyleContext, "addProviderForDisplay");
 
         try {

--- a/examples/gtk-demo/tests/demos/gestures/dnd.test.tsx
+++ b/examples/gtk-demo/tests/demos/gestures/dnd.test.tsx
@@ -6,6 +6,8 @@ import { describe, expect, it, vi } from "vitest";
 import { dndDemo } from "../../../src/demos/gestures/dnd.js";
 import { makeRgbaValue, makeStringValue, renderDemo } from "../../test-utils.js";
 
+type ChildTransform = ReturnType<Gtk.Fixed["getChildTransform"]>;
+
 const findCanvas = async (): Promise<Gtk.Fixed> => screen.findByName("canvas", { as: Gtk.Fixed });
 const findItemLabel = async (id: string): Promise<Gtk.Label> => screen.findByName(`item${id}`, { as: Gtk.Label });
 
@@ -58,20 +60,40 @@ const clickEnabledMenuButton = async (name: string): Promise<void> => {
     await userEvent.click(button);
 };
 
-const beginDragRevealingTrash = async (item: Gtk.Label, trash: Gtk.Box): Promise<Gtk.DragSource | null> => {
+const renderCanvasItem = async (): Promise<{ canvas: Gtk.Fixed; item1: Gtk.Label }> => {
+    await renderDemo(dndDemo);
+    const canvas = await findCanvas();
+    const item1 = await findItemLabel("1");
+
+    return { canvas, item1 };
+};
+
+const findTrashZone = async (): Promise<Gtk.Box> => screen.findByName("trash-zone", { as: Gtk.Box });
+
+const renderItemWithTrashHidden = async (): Promise<Gtk.Label> => {
+    await renderDemo(dndDemo);
+    const item1 = await findItemLabel("1");
+    expect(screen.queryByName("trash-zone")).toBeNull();
+
+    return item1;
+};
+
+const expectTransformChanged = async (canvas: Gtk.Fixed, item: Gtk.Label, before: ChildTransform): Promise<void> => {
+    await waitFor(() => {
+        const after = canvas.getChildTransform(item);
+        expect(after?.equal(before)).toBe(false);
+    });
+};
+
+const beginItemDrag = async (item: Gtk.Label): Promise<Gtk.DragSource> => {
     const dragSource = queryController(item, Gtk.DragSource);
-    expect(dragSource).toBeInstanceOf(Gtk.DragSource);
 
     if (!dragSource) {
-        return null;
+        throw new TypeError("expected a Gtk.DragSource on the item");
     }
 
     await act(() => {
         dragSource.emit("drag-begin", null);
-    });
-
-    await waitFor(() => {
-        expect(trash).toBeVisible();
     });
 
     return dragSource;
@@ -111,19 +133,20 @@ describe("dndDemo initial canvas", () => {
         }
     });
 
-    it("attaches a hidden context-menu popover at startup", async () => {
+    it("shows no context-menu popover until a context-menu press opens one", async () => {
         await renderDemo(dndDemo);
+        expect(screen.queryByName("context-menu")).toBeNull();
+        const canvas = await findCanvas();
+        await triggerContextMenu(canvas, 50, 50);
         const popover = await screen.findByName("context-menu", { as: Gtk.Popover });
         expect(popover).toBeInstanceOf(Gtk.Popover);
-        expect(popover).not.toBeVisible();
+        expect(popover).toBeVisible();
     });
 });
 
 describe("dndDemo canvas drop", () => {
     it("moves an item to the dropped location when its id is dropped on the canvas", async () => {
-        await renderDemo(dndDemo);
-        const canvas = await findCanvas();
-        const item1 = await findItemLabel("1");
+        const { canvas, item1 } = await renderCanvasItem();
         const [beforeX, beforeY] = canvas.getChildPosition(item1);
         await userEvent.drop(canvas, makeStringValue("1"), { x: 250, y: 250 });
 
@@ -184,22 +207,14 @@ describe("dndDemo inline editing", () => {
 
 describe("dndDemo item rotation", () => {
     it("changes the item transform while the rotate gesture reports an angle delta", async () => {
-        await renderDemo(dndDemo);
-        const canvas = await findCanvas();
-        const item1 = await findItemLabel("1");
+        const { canvas, item1 } = await renderCanvasItem();
         const before = canvas.getChildTransform(item1);
         await userEvent.rotate(item1, 0.5, 0.5);
-
-        await waitFor(() => {
-            const after = canvas.getChildTransform(item1);
-            expect(after?.equal(before)).toBe(false);
-        });
+        await expectTransformChanged(canvas, item1, before);
     });
 
     it("commits the rotation to the item transform when the rotate gesture ends", async () => {
-        await renderDemo(dndDemo);
-        const canvas = await findCanvas();
-        const item1 = await findItemLabel("1");
+        const { canvas, item1 } = await renderCanvasItem();
         const rotate = queryController(item1, Gtk.GestureRotate);
         expect(rotate).toBeInstanceOf(Gtk.GestureRotate);
 
@@ -214,10 +229,7 @@ describe("dndDemo item rotation", () => {
             rotate.emit("end", null);
         });
 
-        await waitFor(() => {
-            const after = canvas.getChildTransform(item1);
-            expect(after?.equal(before)).toBe(false);
-        });
+        await expectTransformChanged(canvas, item1, before);
     });
 
     it("rotates the item when the inline editor scale value changes", async () => {
@@ -331,22 +343,15 @@ describe("dndDemo non-context-menu click is ignored", () => {
             spy.mockRestore();
         }
 
-        const popover = await screen.findByName("context-menu", { as: Gtk.Popover });
-        expect(popover).not.toBeVisible();
+        expect(screen.queryByName("context-menu")).toBeNull();
     });
 });
 
 describe("dndDemo item drag-source side effects", () => {
     it("dims the item and reveals the trash zone on drag-begin, then restores them on drag-end", async () => {
-        await renderDemo(dndDemo);
-        const item1 = await findItemLabel("1");
-        const trash = await screen.findByName("trash-zone", { as: Gtk.Box });
-        expect(trash).not.toBeVisible();
-        const dragSource = await beginDragRevealingTrash(item1, trash);
-
-        if (!dragSource) {
-            return;
-        }
+        const item1 = await renderItemWithTrashHidden();
+        const dragSource = await beginItemDrag(item1);
+        expect(await findTrashZone()).toBeVisible();
 
         await waitFor(() => {
             expect(item1.getOpacity()).toBeCloseTo(0.3, 2);
@@ -358,7 +363,7 @@ describe("dndDemo item drag-source side effects", () => {
 
         await waitFor(() => {
             expect(item1.getOpacity()).toBeCloseTo(1, 2);
-            expect(trash).not.toBeVisible();
+            expect(screen.queryByName("trash-zone")).toBeNull();
         });
     });
 
@@ -388,14 +393,9 @@ describe("dndDemo item drag-source side effects", () => {
 
 describe("dndDemo trash zone", () => {
     it("deletes an item when its id is dropped on the trash zone", async () => {
-        await renderDemo(dndDemo);
-        const item1 = await findItemLabel("1");
-        const trash = await screen.findByName("trash-zone", { as: Gtk.Box });
-
-        if (!(await beginDragRevealingTrash(item1, trash))) {
-            return;
-        }
-
+        const item1 = await renderItemWithTrashHidden();
+        await beginItemDrag(item1);
+        const trash = await findTrashZone();
         await userEvent.drop(trash, makeStringValue("1"));
 
         await waitFor(() => {
@@ -406,8 +406,9 @@ describe("dndDemo trash zone", () => {
     });
 
     it("highlights the trash zone with a background class on drop-target enter and clears it on leave", async () => {
-        await renderDemo(dndDemo);
-        const trash = await screen.findByName("trash-zone", { as: Gtk.Box });
+        const item1 = await renderItemWithTrashHidden();
+        await beginItemDrag(item1);
+        const trash = await findTrashZone();
         const dropTarget = queryController(trash, Gtk.DropTarget);
         expect(dropTarget).toBeInstanceOf(Gtk.DropTarget);
 

--- a/examples/gtk-demo/tests/demos/gestures/gestures.test.tsx
+++ b/examples/gtk-demo/tests/demos/gestures/gestures.test.tsx
@@ -17,6 +17,14 @@ const findThreeFingerSwipe = (widget: Gtk.Widget): Gtk.GestureSwipe => {
     return swipe;
 };
 
+const expectRedrawOnGesture = async (gesture: (area: Gtk.DrawingArea) => Promise<void>): Promise<void> => {
+    await renderDemo(gesturesDemo);
+    const drawingArea = await findDrawingArea();
+    const queueDraw = vi.spyOn(drawingArea, "queueDraw");
+    await gesture(drawingArea);
+    expect(queueDraw).toHaveBeenCalled();
+};
+
 const paintWindow = async (): Promise<string> => {
     const window = await screen.findByRole(Gtk.AccessibleRole.WINDOW, { as: Gtk.Window });
 
@@ -52,35 +60,27 @@ describe("gesturesDemo metadata", () => {
 
 describe("gesturesDemo redraw on gesture", () => {
     it("queues a redraw when a swipe gesture completes", async () => {
-        await renderDemo(gesturesDemo);
-        const drawingArea = await findDrawingArea();
-        const queueDraw = vi.spyOn(drawingArea, "queueDraw");
-        await userEvent.swipe(drawingArea, 100, 50);
-        expect(queueDraw).toHaveBeenCalled();
+        await expectRedrawOnGesture(async (area) => {
+            await userEvent.swipe(area, 100, 50);
+        });
     });
 
     it("queues a redraw when a rotate angle change is recognized", async () => {
-        await renderDemo(gesturesDemo);
-        const drawingArea = await findDrawingArea();
-        const queueDraw = vi.spyOn(drawingArea, "queueDraw");
-        await userEvent.rotate(drawingArea, 0.5, 0.1);
-        expect(queueDraw).toHaveBeenCalled();
+        await expectRedrawOnGesture(async (area) => {
+            await userEvent.rotate(area, 0.5, 0.1);
+        });
     });
 
     it("queues a redraw when a zoom scale change is recognized", async () => {
-        await renderDemo(gesturesDemo);
-        const drawingArea = await findDrawingArea();
-        const queueDraw = vi.spyOn(drawingArea, "queueDraw");
-        await userEvent.zoom(drawingArea, 1.2);
-        expect(queueDraw).toHaveBeenCalled();
+        await expectRedrawOnGesture(async (area) => {
+            await userEvent.zoom(area, 1.2);
+        });
     });
 
     it("queues a redraw when a long press is recognized", async () => {
-        await renderDemo(gesturesDemo);
-        const drawingArea = await findDrawingArea();
-        const queueDraw = vi.spyOn(drawingArea, "queueDraw");
-        await userEvent.longPress(drawingArea, 100, 100);
-        expect(queueDraw).toHaveBeenCalled();
+        await expectRedrawOnGesture(async (area) => {
+            await userEvent.longPress(area, 100, 100);
+        });
     });
 });
 

--- a/examples/gtk-demo/tests/demos/gestures/links.test.tsx
+++ b/examples/gtk-demo/tests/demos/gestures/links.test.tsx
@@ -7,6 +7,12 @@ import { describe, expect, it, vi } from "vitest";
 import { linksDemo } from "../../../src/demos/gestures/links.js";
 import { renderDemo } from "../../test-utils.js";
 
+const renderLinksLabel = async (): Promise<Gtk.Label> => {
+    await renderDemo(linksDemo);
+
+    return await screen.findByName("links-label", { as: Gtk.Label });
+};
+
 describe("linksDemo", () => {
     it("exposes the expected metadata", () => {
         expect(linksDemo.id).toBe("links");
@@ -19,8 +25,7 @@ describe("linksDemo", () => {
     });
 
     it("renders a markup-enabled label that wraps on word boundaries", async () => {
-        await renderDemo(linksDemo);
-        const label = await screen.findByName("links-label", { as: Gtk.Label });
+        const label = await renderLinksLabel();
         expect(label).toBeInstanceOf(Gtk.Label);
         expect(label).toHaveObjectProperty("useMarkup", true);
         expect(label).toHaveObjectProperty("wrap", true);
@@ -29,8 +34,7 @@ describe("linksDemo", () => {
     });
 
     it("exposes the keynav and external anchors as clickable hyperlinks in the markup", async () => {
-        await renderDemo(linksDemo);
-        const label = await screen.findByName("links-label", { as: Gtk.Label });
+        const label = await renderLinksLabel();
         const markup = label.getLabel();
         expect(markup).toMatch(/href="keynav"/);
         expect(markup).toMatch(/href="https:\/\/en\.wikipedia\.org\/wiki\/Text"/);
@@ -40,8 +44,7 @@ describe("linksDemo", () => {
 
 describe("linksDemo activate-link handler", () => {
     it("returns true and presents the keynav alert dialog when the 'keynav' link is activated", async () => {
-        await renderDemo(linksDemo);
-        const label = await screen.findByName("links-label", { as: Gtk.Label });
+        const label = await renderLinksLabel();
         const choose = vi.spyOn(Adw.AlertDialog.prototype, "choose").mockResolvedValue("ok");
         const setHeading = vi.spyOn(Adw.AlertDialog.prototype, "setHeading");
         const setBody = vi.spyOn(Adw.AlertDialog.prototype, "setBody");
@@ -61,8 +64,7 @@ describe("linksDemo activate-link handler", () => {
     });
 
     it("defers to default handling for a non-keynav link without presenting an alert dialog", async () => {
-        await renderDemo(linksDemo);
-        const label = await screen.findByName("links-label", { as: Gtk.Label });
+        const label = await renderLinksLabel();
         const choose = vi.spyOn(Adw.AlertDialog.prototype, "choose").mockResolvedValue("ok");
         let isReachedDefault = false;
 

--- a/examples/gtk-demo/tests/demos/gestures/shortcut-triggers.test.tsx
+++ b/examples/gtk-demo/tests/demos/gestures/shortcut-triggers.test.tsx
@@ -4,6 +4,19 @@ import { describe, expect, it, vi } from "vitest";
 import { shortcutTriggersDemo } from "../../../src/demos/gestures/shortcut-triggers.js";
 import { renderDemo } from "../../test-utils.js";
 
+const expectShortcutLog = async (labelName: string, keys: string, message: string): Promise<void> => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation((): void => undefined);
+
+    try {
+        await renderDemo(shortcutTriggersDemo);
+        const label = await screen.findByName(labelName, { as: Gtk.Label });
+        await userEvent.keyboard(label, keys);
+        expect(logSpy).toHaveBeenCalledWith(message);
+    } finally {
+        logSpy.mockRestore();
+    }
+};
+
 describe("shortcutTriggersDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(shortcutTriggersDemo.id).toBe("shortcut-triggers");
@@ -49,28 +62,10 @@ describe("shortcutTriggersDemo rendering", () => {
 
 describe("shortcutTriggersDemo activation handlers", () => {
     it("logs the Ctrl-G activation message when the Ctrl-G shortcut fires", async () => {
-        const logSpy = vi.spyOn(console, "log").mockImplementation((): void => undefined);
-
-        try {
-            await renderDemo(shortcutTriggersDemo);
-            const label = await screen.findByName("label-ctrl-g", { as: Gtk.Label });
-            await userEvent.keyboard(label, "{Control>}g{/Control}");
-            expect(logSpy).toHaveBeenCalledWith("activated Press Ctrl-G");
-        } finally {
-            logSpy.mockRestore();
-        }
+        await expectShortcutLog("label-ctrl-g", "{Control>}g{/Control}", "activated Press Ctrl-G");
     });
 
     it("logs the Press-X activation message when the X shortcut fires", async () => {
-        const logSpy = vi.spyOn(console, "log").mockImplementation((): void => undefined);
-
-        try {
-            await renderDemo(shortcutTriggersDemo);
-            const label = await screen.findByName("label-x", { as: Gtk.Label });
-            await userEvent.keyboard(label, "x");
-            expect(logSpy).toHaveBeenCalledWith("activated Press X");
-        } finally {
-            logSpy.mockRestore();
-        }
+        await expectShortcutLog("label-x", "x", "activated Press X");
     });
 });

--- a/examples/gtk-demo/tests/demos/input/entry-undo.test.tsx
+++ b/examples/gtk-demo/tests/demos/input/entry-undo.test.tsx
@@ -6,6 +6,14 @@ import { renderDemo } from "../../test-utils.js";
 
 const LABEL_TEXT = "Use Control+z or Control+Shift+z to undo or redo changes";
 
+const typeIntoEntry = async (text: string): Promise<Gtk.Entry> => {
+    await renderDemo(entryUndoDemo);
+    const entry = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
+    await userEvent.type(entry, text);
+
+    return entry;
+};
+
 describe("entryUndoDemo", () => {
     it("exposes the expected metadata", () => {
         expect(entryUndoDemo.id).toBe("entry-undo");
@@ -36,18 +44,14 @@ describe("entryUndoDemo", () => {
 
 describe("entryUndoDemo undo and redo", () => {
     it("undoes the typed text when Control+z is dispatched to the entry", async () => {
-        await renderDemo(entryUndoDemo);
-        const entry = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
-        await userEvent.type(entry, "hello");
+        const entry = await typeIntoEntry("hello");
         expect(screen.getByDisplayValue("hello")).toBe(entry);
         await userEvent.keyboard(entry, "{Control>}z{/Control}");
         expect(screen.queryByDisplayValue("hello")).toBeNull();
     });
 
     it("redoes the typed text when Control+Shift+z is dispatched after an undo", async () => {
-        await renderDemo(entryUndoDemo);
-        const entry = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
-        await userEvent.type(entry, "redo me");
+        const entry = await typeIntoEntry("redo me");
         expect(screen.getByDisplayValue("redo me")).toBe(entry);
         await userEvent.keyboard(entry, "{Control>}z{/Control}");
         expect(screen.queryByDisplayValue("redo me")).toBeNull();
@@ -56,9 +60,7 @@ describe("entryUndoDemo undo and redo", () => {
     });
 
     it("redoes the typed text with the Control+y accelerator after an undo", async () => {
-        await renderDemo(entryUndoDemo);
-        const entry = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
-        await userEvent.type(entry, "control y redo");
+        const entry = await typeIntoEntry("control y redo");
         expect(screen.getByDisplayValue("control y redo")).toBe(entry);
         await userEvent.keyboard(entry, "{Control>}z{/Control}");
         expect(screen.queryByDisplayValue("control y redo")).toBeNull();

--- a/examples/gtk-demo/tests/demos/input/hypertext.test.tsx
+++ b/examples/gtk-demo/tests/demos/input/hypertext.test.tsx
@@ -35,6 +35,23 @@ const windowCoordsAtOffset = (view: Gtk.TextView, offset: number): [number, numb
     return view.bufferToWindowCoords(Gtk.TextWindowType.WIDGET, rect.x + 1, rect.y + Math.trunc(rect.height / 2));
 };
 
+const renderTextView = async (): Promise<Gtk.TextView> => {
+    await renderDemo(hypertextDemo);
+
+    return await findTextView();
+};
+
+const placeCursorAtWord = async (view: Gtk.TextView, word: string): Promise<number> => {
+    const buffer = view.getBuffer();
+    const offset = readBufferText(view).indexOf(word);
+
+    await act(() => {
+        buffer.placeCursor(buffer.getIterAtOffset(offset));
+    });
+
+    return offset;
+};
+
 const clickOffset = async (view: Gtk.TextView, offset: number): Promise<void> => {
     const [x, y] = windowCoordsAtOffset(view, offset);
 
@@ -65,8 +82,7 @@ describe("hypertextDemo metadata", () => {
 
 describe("hypertextDemo rendering", () => {
     it("renders page 1 with the hypertext and tags introduction", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         expect(screen.getByDisplayValue(/simple /)).toBe(textView);
         expect(screen.getByDisplayValue(/hypertext/)).toBe(textView);
         expect(screen.getByDisplayValue(/can easily be realized with /)).toBe(textView);
@@ -74,8 +90,7 @@ describe("hypertextDemo rendering", () => {
     });
 
     it("embeds the ghost label, the level bar, and the emoji in page 1", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         const levelBar = await screen.findByRole(Gtk.AccessibleRole.METER, { as: Gtk.LevelBar });
         expect(levelBar).toHaveObjectProperty("value", 50);
         expect(levelBar).toHaveObjectProperty("minValue", 0);
@@ -87,45 +102,24 @@ describe("hypertextDemo rendering", () => {
 
 describe("hypertextDemo link navigation", () => {
     it("navigates to the tags definition page when Enter is pressed at the tags link", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
-        const buffer = textView.getBuffer();
-        const tagsOffset = readBufferText(textView).indexOf("tags");
+        const textView = await renderTextView();
+        const tagsOffset = await placeCursorAtWord(textView, "tags");
         expect(tagsOffset).toBeGreaterThan(0);
-
-        await act(() => {
-            buffer.placeCursor(buffer.getIterAtOffset(tagsOffset));
-        });
-
         await userEvent.keyboard(textView, "{Enter}");
         expect(await screen.findByDisplayValue(/attribute that can be applied to some range of text/)).toBe(textView);
     });
 
     it("navigates to the hypertext definition page when Enter is pressed at the hypertext link", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
-        const buffer = textView.getBuffer();
-        const linkOffset = readBufferText(textView).indexOf("hypertext");
+        const textView = await renderTextView();
+        const linkOffset = await placeCursorAtWord(textView, "hypertext");
         expect(linkOffset).toBeGreaterThan(0);
-
-        await act(() => {
-            buffer.placeCursor(buffer.getIterAtOffset(linkOffset));
-        });
-
         await userEvent.keyboard(textView, "{Enter}");
         expect(await screen.findByDisplayValue(/Machine-readable text that is not sequential/)).toBe(textView);
     });
 
     it("navigates via the numeric-keypad Enter key at a link", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
-        const buffer = textView.getBuffer();
-        const tagsOffset = readBufferText(textView).indexOf("tags");
-
-        await act(() => {
-            buffer.placeCursor(buffer.getIterAtOffset(tagsOffset));
-        });
-
+        const textView = await renderTextView();
+        await placeCursorAtWord(textView, "tags");
         await fireEvent(demoKeyController(textView), "key-pressed", Gdk.KEY_KP_Enter, 0, 0);
         expect(await screen.findByDisplayValue(/attribute that can be applied to some range of text/)).toBe(textView);
     });
@@ -133,24 +127,21 @@ describe("hypertextDemo link navigation", () => {
 
 describe("hypertextDemo click navigation", () => {
     it("follows the hypertext link to the definition page when clicked", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         const linkOffset = readBufferText(textView).indexOf("hypertext");
         await clickOffset(textView, linkOffset);
         expect(await screen.findByDisplayValue(/Machine-readable text that is not sequential/)).toBe(textView);
     });
 
     it("follows the tags link to the definition page when clicked", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         const linkOffset = readBufferText(textView).indexOf("tags");
         await clickOffset(textView, linkOffset);
         expect(await screen.findByDisplayValue(/attribute that can be applied to some range of text/)).toBe(textView);
     });
 
     it("returns to page 1 when the Go back link is clicked on a definition page", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         await clickOffset(textView, readBufferText(textView).indexOf("hypertext"));
         await screen.findByDisplayValue(/Machine-readable text that is not sequential/);
         await clickOffset(textView, readBufferText(textView).indexOf("Go back") + 1);
@@ -161,15 +152,8 @@ describe("hypertextDemo click navigation", () => {
 
 describe("hypertextDemo round trip", () => {
     it("navigates from page 2 (tags) back to page 1 via the Go back link", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
-        const buffer = textView.getBuffer();
-        const tagsOffset = readBufferText(textView).indexOf("tags");
-
-        await act(() => {
-            buffer.placeCursor(buffer.getIterAtOffset(tagsOffset));
-        });
-
+        const textView = await renderTextView();
+        await placeCursorAtWord(textView, "tags");
         await userEvent.keyboard(textView, "{Enter}");
         await screen.findByDisplayValue(/attribute that can be applied/);
         const pageTwo = readBufferText(textView);
@@ -188,8 +172,7 @@ describe("hypertextDemo round trip", () => {
 
 describe("hypertextDemo hover cursor", () => {
     it("swaps the text view cursor to a pointer over a link and back to text off it", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         const motion = demoMotionController(textView);
         const [linkX, linkY] = windowCoordsAtOffset(textView, readBufferText(textView).indexOf("tags"));
 
@@ -211,15 +194,8 @@ describe("hypertextDemo hover cursor", () => {
 describe("hypertextDemo speaker icon", () => {
     it("speaks the word when the speaker icon on a definition page is clicked", async () => {
         spawnMock.mockClear();
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
-        const buffer = textView.getBuffer();
-        const tagsOffset = readBufferText(textView).indexOf("tags");
-
-        await act(() => {
-            buffer.placeCursor(buffer.getIterAtOffset(tagsOffset));
-        });
-
+        const textView = await renderTextView();
+        await placeCursorAtWord(textView, "tags");
         await userEvent.keyboard(textView, "{Enter}");
         await screen.findByDisplayValue(/attribute that can be applied/);
         const speaker = await screen.findByRole(Gtk.AccessibleRole.IMG, { as: Gtk.Image });
@@ -234,16 +210,14 @@ describe("hypertextDemo speaker icon", () => {
 
 describe("hypertextDemo input edge cases", () => {
     it("ignores non-Enter key presses without changing the page", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         await userEvent.keyboard(textView, "a");
         expect(screen.getByDisplayValue(/Some text to show/)).toBe(textView);
         expect(screen.queryByDisplayValue(/attribute that can be applied/)).toBeNull();
     });
 
     it("does not navigate via Enter when the cursor is not on a link", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         const buffer = textView.getBuffer();
 
         await act(() => {
@@ -256,8 +230,7 @@ describe("hypertextDemo input edge cases", () => {
     });
 
     it("does not navigate when a click lands off any link", async () => {
-        await renderDemo(hypertextDemo);
-        const textView = await findTextView();
+        const textView = await renderTextView();
         await clickOffset(textView, 2);
         expect(screen.getByDisplayValue(/Some text to show/)).toBe(textView);
         expect(screen.queryByDisplayValue(/attribute that can be applied/)).toBeNull();

--- a/examples/gtk-demo/tests/demos/input/password-entry.test.tsx
+++ b/examples/gtk-demo/tests/demos/input/password-entry.test.tsx
@@ -2,7 +2,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { fireEvent, queryController, screen, userEvent, waitFor, within } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
 import { passwordEntryDemo } from "../../../src/demos/input/password-entry.js";
-import { renderDemo } from "../../test-utils.js";
+import { findWidget, renderDemo, type RenderDemoOptions } from "../../test-utils.js";
 
 const findPasswordFields = async (): Promise<{ password: Gtk.PasswordEntry; confirm: Gtk.PasswordEntry }> => {
     const password = await screen.findByName("password-entry", { as: Gtk.PasswordEntry });
@@ -12,38 +12,19 @@ const findPasswordFields = async (): Promise<{ password: Gtk.PasswordEntry; conf
 };
 
 const findDoneButton = async (): Promise<Gtk.Button> =>
-    screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Done", as: Gtk.Button });
+    screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Done", as: Gtk.Button });
 
-const findInnerText = (widget: Gtk.Widget): Gtk.Text | null => {
-    if (widget instanceof Gtk.Text) {
-        return widget;
-    }
+const isPeekImage = (widget: Gtk.Image): boolean => widget.getIconName() === "view-reveal-symbolic";
 
-    for (let child = widget.getFirstChild(); child; child = child.getNextSibling()) {
-        const found = findInnerText(child);
-
-        if (found) {
-            return found;
-        }
-    }
-
-    return null;
-};
-
-const findPeekImage = (widget: Gtk.Widget): Gtk.Image | null => {
-    if (widget instanceof Gtk.Image && widget.getIconName() === "view-reveal-symbolic") {
-        return widget;
-    }
-
-    for (let child = widget.getFirstChild(); child; child = child.getNextSibling()) {
-        const found = findPeekImage(child);
-
-        if (found) {
-            return found;
-        }
-    }
-
-    return null;
+const typePasswords = async (
+    password: string,
+    confirmation: string,
+    options: RenderDemoOptions = {},
+): Promise<void> => {
+    await renderDemo(passwordEntryDemo, options);
+    const fields = await findPasswordFields();
+    await userEvent.type(fields.password, password);
+    await userEvent.type(fields.confirm, confirmation);
 };
 
 describe("passwordEntryDemo metadata", () => {
@@ -70,8 +51,8 @@ describe("passwordEntryDemo form behavior", () => {
         await renderDemo(passwordEntryDemo);
         const { password } = await findPasswordFields();
         await userEvent.type(password, "s3cret");
-        const innerText = findInnerText(password);
-        const peek = findPeekImage(password);
+        const innerText = findWidget(password, Gtk.Text);
+        const peek = findWidget(password, Gtk.Image, isPeekImage);
         expect(innerText).not.toBeNull();
         expect(peek).not.toBeNull();
         const gesture = queryController(peek as Gtk.Image, Gtk.GestureClick);
@@ -85,10 +66,7 @@ describe("passwordEntryDemo form behavior", () => {
 
 describe("passwordEntryDemo done button", () => {
     it("enables the Done button when both password fields match", async () => {
-        await renderDemo(passwordEntryDemo);
-        const { password, confirm } = await findPasswordFields();
-        await userEvent.type(password, "hunter2");
-        await userEvent.type(confirm, "hunter2");
+        await typePasswords("hunter2", "hunter2");
 
         await waitFor(async () => {
             const button = await findDoneButton();
@@ -97,10 +75,7 @@ describe("passwordEntryDemo done button", () => {
     });
 
     it("keeps the Done button disabled when passwords differ", async () => {
-        await renderDemo(passwordEntryDemo);
-        const { password, confirm } = await findPasswordFields();
-        await userEvent.type(password, "hunter2");
-        await userEvent.type(confirm, "different");
+        await typePasswords("hunter2", "different");
 
         await waitFor(async () => {
             const button = await findDoneButton();
@@ -110,10 +85,7 @@ describe("passwordEntryDemo done button", () => {
 
     it("invokes onClose when the Done button is activated with matching passwords", async () => {
         const onClose = vi.fn();
-        await renderDemo(passwordEntryDemo, { onClose });
-        const { password, confirm } = await findPasswordFields();
-        await userEvent.type(password, "abc");
-        await userEvent.type(confirm, "abc");
+        await typePasswords("abc", "abc", { onClose });
 
         const button = await waitFor(async () => {
             const candidate = await findDoneButton();
@@ -135,7 +107,7 @@ describe("passwordEntryDemo window setup", () => {
         await renderDemo(passwordEntryDemo);
         const header = await screen.findByName("password-entry-header", { as: Gtk.HeaderBar });
         expect(header).toHaveObjectProperty("showTitleButtons", false);
-        const done = within(header).getByRole(Gtk.AccessibleRole.BUTTON, { name: "_Done" });
+        const done = within(header).getByRole(Gtk.AccessibleRole.BUTTON, { name: "Done" });
         expect(done).toBe(await findDoneButton());
     });
 });

--- a/examples/gtk-demo/tests/demos/input/search-entry.test.tsx
+++ b/examples/gtk-demo/tests/demos/input/search-entry.test.tsx
@@ -36,6 +36,8 @@ describe("searchEntryDemo rendering", () => {
         expect(screen.getByRole(Gtk.AccessibleRole.TOGGLE_BUTTON, { pressed: false })).toBe(toggle);
         const searchBar = await screen.findByRole(Gtk.AccessibleRole.SEARCH, { as: Gtk.SearchBar });
         expect(searchBar).toHaveObjectProperty("searchModeEnabled", false);
+        expect(screen.queryByRole(Gtk.AccessibleRole.SEARCH_BOX)).toBeNull();
+        await enableSearchMode();
         const searchEntry = await screen.findByRole(Gtk.AccessibleRole.SEARCH_BOX, { as: Gtk.SearchEntry });
         expect(searchEntry).toHaveObjectProperty("text", "");
         expect(await screen.findByText("Searching for:")).toHaveTextContent("Searching for:");

--- a/examples/gtk-demo/tests/demos/input/tabs.test.tsx
+++ b/examples/gtk-demo/tests/demos/input/tabs.test.tsx
@@ -5,6 +5,12 @@ import { describe, expect, it } from "vitest";
 import { tabsDemo } from "../../../src/demos/input/tabs.js";
 import { renderDemo } from "../../test-utils.js";
 
+const renderTextView = async (): Promise<Gtk.TextView> => {
+    await renderDemo(tabsDemo);
+
+    return await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+};
+
 describe("tabsDemo", () => {
     it("exposes the expected metadata", () => {
         expect(tabsDemo.id).toBe("tabs");
@@ -19,16 +25,14 @@ describe("tabsDemo", () => {
     });
 
     it("renders a GtkTextView populated with tab-separated rows", async () => {
-        await renderDemo(tabsDemo);
-        const textView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+        const textView = await renderTextView();
         expect(await screen.findByDisplayValue(/one\t2\.0\tthree/, { collapseWhitespace: false })).toBe(textView);
         expect(await screen.findByDisplayValue(/four\t5\.555\tsix/, { collapseWhitespace: false })).toBe(textView);
         expect(await screen.findByDisplayValue(/seven\t88\.88\tnine/, { collapseWhitespace: false })).toBe(textView);
     });
 
     it("configures three tabs with LEFT, DECIMAL, RIGHT alignments", async () => {
-        await renderDemo(tabsDemo);
-        const textView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+        const textView = await renderTextView();
         const tabs = textView.getTabs();
         expect(tabs).not.toBeNull();
         const tabArray = tabs as Pango.TabArray;
@@ -44,8 +48,7 @@ describe("tabsDemo", () => {
 
 describe("tabsDemo text view", () => {
     it("places the tabs at positions 0, 150 and 290 with '.' as the decimal point", async () => {
-        await renderDemo(tabsDemo);
-        const textView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+        const textView = await renderTextView();
         const tabs = textView.getTabs() as Pango.TabArray;
         const [, pos0] = tabs.getTab(0);
         const [, pos1] = tabs.getTab(1);
@@ -57,8 +60,7 @@ describe("tabsDemo text view", () => {
     });
 
     it("uses word wrap on the text view", async () => {
-        await renderDemo(tabsDemo);
-        const textView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+        const textView = await renderTextView();
         expect(textView).toHaveObjectProperty("wrapMode", Gtk.WrapMode.WORD);
     });
 

--- a/examples/gtk-demo/tests/demos/input/textundo.test.tsx
+++ b/examples/gtk-demo/tests/demos/input/textundo.test.tsx
@@ -10,9 +10,14 @@ type EditedTextView = {
     before: string;
 };
 
-const renderAndInsert = async (insertedText: string): Promise<EditedTextView> => {
+const renderTextView = async (): Promise<Gtk.TextView> => {
     await renderDemo(textundoDemo);
-    const textView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+
+    return await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+};
+
+const renderAndInsert = async (insertedText: string): Promise<EditedTextView> => {
+    const textView = await renderTextView();
     const buffer = textView.getBuffer();
     const before = readBufferText(textView);
     await userEvent.type(textView, insertedText);
@@ -34,8 +39,7 @@ describe("textundoDemo", () => {
     });
 
     it("renders a text view with the introductory content and word wrap", async () => {
-        await renderDemo(textundoDemo);
-        const textView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+        const textView = await renderTextView();
         const initial = readBufferText(textView);
         expect(initial).toContain("GtkTextView supports undo and redo");
         expect(initial).toContain("Control+z");

--- a/examples/gtk-demo/tests/demos/input/textview.test.tsx
+++ b/examples/gtk-demo/tests/demos/input/textview.test.tsx
@@ -81,6 +81,19 @@ const iterAtOffset = (buffer: Gtk.TextBuffer, offset: number): Gtk.TextIter => {
     return iter;
 };
 
+const renderPrimaryView = async (): Promise<Gtk.TextView> => {
+    await renderDemo(textviewDemo);
+    const [view1] = await findTextViews();
+
+    return view1;
+};
+
+const expectWindowCountAbove = async (count: number): Promise<void> => {
+    await waitFor(() => {
+        expect(screen.queryAllByRole(Gtk.AccessibleRole.WINDOW).length).toBeGreaterThan(count);
+    });
+};
+
 const openEasterEggFromClonedButton = async (): Promise<{
     result: RenderResult;
     beforeWindows: Gtk.Widget[];
@@ -91,11 +104,7 @@ const openEasterEggFromClonedButton = async (): Promise<{
     const cloned = buttons.at(-1) as Gtk.Button;
     const beforeWindows = screen.queryAllByRole(Gtk.AccessibleRole.WINDOW);
     await userEvent.click(cloned);
-
-    await waitFor(() => {
-        expect(screen.queryAllByRole(Gtk.AccessibleRole.WINDOW).length).toBeGreaterThan(beforeWindows.length);
-    });
-
+    await expectWindowCountAbove(beforeWindows.length);
     const after = screen.queryAllByRole(Gtk.AccessibleRole.WINDOW, { as: Gtk.Window });
     const newWindow = after.find((w) => !beforeWindows.includes(w));
 
@@ -129,8 +138,7 @@ describe("textviewDemo rendering", () => {
     });
 
     it("populates the shared buffer with section headings and international content", async () => {
-        await renderDemo(textviewDemo);
-        const [view1] = await findTextViews();
+        const view1 = await renderPrimaryView();
         const text = readBufferText(view1);
         expect(text).toContain("The text widget can display text with all kinds of nifty attributes");
         expect(text).toContain("Font styles.");
@@ -156,8 +164,7 @@ describe("textviewDemo rendering", () => {
 
 describe("textviewDemo formatting tags", () => {
     it("registers the demo's named formatting tags in the shared tag table", async () => {
-        await renderDemo(textviewDemo);
-        const [view1] = await findTextViews();
+        const view1 = await renderPrimaryView();
         const table = getBuffer(view1).getTagTable();
 
         for (const name of FORMATTING_TAGS) {
@@ -166,8 +173,7 @@ describe("textviewDemo formatting tags", () => {
     });
 
     it("applies the italic, bold and monospace tags to their respective text ranges", async () => {
-        await renderDemo(textviewDemo);
-        const [view1] = await findTextViews();
+        const view1 = await renderPrimaryView();
         const buffer = getBuffer(view1);
         const table = buffer.getTagTable();
 
@@ -186,8 +192,7 @@ describe("textviewDemo formatting tags", () => {
     });
 
     it("carries distinct per-tag wrap modes on the tagged wrapping sections", async () => {
-        await renderDemo(textviewDemo);
-        const [view1] = await findTextViews();
+        const view1 = await renderPrimaryView();
         const table = getBuffer(view1).getTagTable();
         expect(table.lookup("word_wrap") as Gtk.TextTag).toHaveObjectProperty("wrapMode", Gtk.WrapMode.WORD);
         expect(table.lookup("char_wrap") as Gtk.TextTag).toHaveObjectProperty("wrapMode", Gtk.WrapMode.CHAR);
@@ -197,16 +202,14 @@ describe("textviewDemo formatting tags", () => {
 
 describe("textviewDemo embedded content", () => {
     it("embeds two paintables and four child anchors in the buffer", async () => {
-        await renderDemo(textviewDemo);
-        const [view1] = await findTextViews();
+        const view1 = await renderPrimaryView();
         const { paintables, anchors } = countEmbeddedContent(getBuffer(view1));
         expect(paintables).toBe(2);
         expect(anchors).toBe(4);
     });
 
     it("rejects user edits inside the not_editable range but accepts them elsewhere", async () => {
-        await renderDemo(textviewDemo);
-        const [view1] = await findTextViews();
+        const view1 = await renderPrimaryView();
         const buffer = getBuffer(view1);
         const lockedBefore = readBufferText(view1);
         buffer.placeCursor(iterAtOffset(buffer, getOffset(view1, "locked down")));
@@ -282,10 +285,7 @@ describe("textviewDemo easter egg", () => {
         const source = buttons[0] as Gtk.Button;
         const beforeWindows = screen.queryAllByRole(Gtk.AccessibleRole.WINDOW).length;
         await userEvent.click(source);
-
-        await waitFor(() => {
-            expect(screen.queryAllByRole(Gtk.AccessibleRole.WINDOW).length).toBeGreaterThan(beforeWindows);
-        });
+        await expectWindowCountAbove(beforeWindows);
     });
 
     it("makes the easter-egg window modal and transient for the demo root window", async () => {

--- a/examples/gtk-demo/tests/demos/layout/fixed2.test.tsx
+++ b/examples/gtk-demo/tests/demos/layout/fixed2.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, it } from "vitest";
 import { fixed2Demo } from "../../../src/demos/layout/fixed2.js";
 import { renderDemo } from "../../test-utils.js";
 
+const renderFixed = async (): Promise<Gtk.Fixed> => {
+    await renderDemo(fixed2Demo);
+
+    return await screen.findByName("fixed", { as: Gtk.Fixed });
+};
+
 describe("fixed2Demo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(fixed2Demo.id).toBe("fixed2");
@@ -20,8 +26,7 @@ describe("fixed2Demo metadata", () => {
 
 describe("fixed2Demo structure", () => {
     it("renders the 'All fixed?' label inside the GtkFixed container", async () => {
-        await renderDemo(fixed2Demo);
-        const fixed = await screen.findByName("fixed", { as: Gtk.Fixed });
+        const fixed = await renderFixed();
 
         expect(within(fixed).getByRole(Gtk.AccessibleRole.LABEL, { name: "All fixed?" })).toHaveTextContent(
             "All fixed?",
@@ -40,24 +45,21 @@ describe("fixed2Demo structure", () => {
 
 describe("fixed2Demo configuration", () => {
     it("configures the GtkFixed with visible overflow and expand flags", async () => {
-        await renderDemo(fixed2Demo);
-        const fixed = await screen.findByName("fixed", { as: Gtk.Fixed });
+        const fixed = await renderFixed();
         expect(fixed).toHaveObjectProperty("overflow", Gtk.Overflow.VISIBLE);
         expect(fixed).toHaveObjectProperty("hexpand", true);
         expect(fixed).toHaveObjectProperty("vexpand", true);
     });
 
     it("renders exactly one fixed-label widget inside the GtkFixed", async () => {
-        await renderDemo(fixed2Demo);
-        const fixed = await screen.findByName("fixed", { as: Gtk.Fixed });
+        const fixed = await renderFixed();
         expect(within(fixed).getAllByName("fixed-label")).toHaveLength(1);
     });
 });
 
 describe("fixed2Demo animation tick", () => {
     it("mutates the label's child transform as the frame clock advances", async () => {
-        await renderDemo(fixed2Demo);
-        const fixed = await screen.findByName("fixed", { as: Gtk.Fixed });
+        const fixed = await renderFixed();
         const label = within(fixed).getByName("fixed-label", { as: Gtk.Label });
         const first = fixed.getChildTransform(label);
         expect(first).not.toBeNull();

--- a/examples/gtk-demo/tests/demos/layout/overlay-decorative.test.tsx
+++ b/examples/gtk-demo/tests/demos/layout/overlay-decorative.test.tsx
@@ -4,6 +4,16 @@ import { describe, expect, it } from "vitest";
 import { overlayDecorativeDemo } from "../../../src/demos/layout/overlay-decorative.js";
 import { renderDemo } from "../../test-utils.js";
 
+type MarginTargets = { scale: Gtk.Scale; textView: Gtk.TextView; topMarginTag: Gtk.TextTag };
+
+const renderMarginTargets = async (): Promise<MarginTargets> => {
+    await renderDemo(overlayDecorativeDemo);
+    const scale = await screen.findByName("margin-scale", { as: Gtk.Scale });
+    const textView = await screen.findByName("text-view", { as: Gtk.TextView });
+
+    return { scale, textView, topMarginTag: textView.getBuffer().getTagTable().lookup("top-margin") as Gtk.TextTag };
+};
+
 describe("overlayDecorativeDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(overlayDecorativeDemo.id).toBe("overlay-decorative");
@@ -64,10 +74,7 @@ describe("overlayDecorativeDemo scale behavior", () => {
     });
 
     it("syncs the TextView left margin and top-margin tag when the scale value changes", async () => {
-        await renderDemo(overlayDecorativeDemo);
-        const scale = await screen.findByName("margin-scale", { as: Gtk.Scale });
-        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-        const topMarginTag = textView.getBuffer().getTagTable().lookup("top-margin") as Gtk.TextTag;
+        const { scale, textView, topMarginTag } = await renderMarginTargets();
         expect(textView).toHaveObjectProperty("leftMargin", 100);
         expect(topMarginTag).toHaveObjectProperty("pixelsAboveLines", 100);
         await userEvent.slide(scale, 25);
@@ -76,10 +83,7 @@ describe("overlayDecorativeDemo scale behavior", () => {
     });
 
     it("rounds non-integer margins for both the left margin and the top-margin tag", async () => {
-        await renderDemo(overlayDecorativeDemo);
-        const scale = await screen.findByName("margin-scale", { as: Gtk.Scale });
-        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
-        const topMarginTag = textView.getBuffer().getTagTable().lookup("top-margin") as Gtk.TextTag;
+        const { scale, textView, topMarginTag } = await renderMarginTargets();
         await userEvent.slide(scale, 37.7);
         expect(textView).toHaveObjectProperty("leftMargin", 38);
         expect(topMarginTag).toHaveObjectProperty("pixelsAboveLines", 38);

--- a/examples/gtk-demo/tests/demos/layout/overlay.test.tsx
+++ b/examples/gtk-demo/tests/demos/layout/overlay.test.tsx
@@ -46,7 +46,7 @@ describe("overlayDemo entry behavior", () => {
     it("renders the entry with the placeholder text 'Your Lucky Number' and empty initial value", async () => {
         await renderDemo(overlayDemo);
         const entry = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.Entry });
-        expect(entry).toHavePlaceholderText("Your Lucky Number");
+        expect(screen.getByPlaceholderText("Your Lucky Number")).toBe(entry);
         expect(entry).toHaveDisplayValue("");
     });
 

--- a/examples/gtk-demo/tests/demos/layout/sizegroup.test.tsx
+++ b/examples/gtk-demo/tests/demos/layout/sizegroup.test.tsx
@@ -4,12 +4,18 @@ import { describe, expect, it } from "vitest";
 import { sizegroupDemo } from "../../../src/demos/layout/sizegroup.js";
 import { renderDemo } from "../../test-utils.js";
 
-const MNEMONIC_LABELS = ["_Foreground", "_Background", "_Dashing", "_Line ends"] as const;
+const MNEMONIC_LABELS = ["Foreground", "Background", "Dashing", "Line ends"] as const;
 
 const naturalWidths = (dropdowns: Gtk.Widget[]): number[] =>
     dropdowns.map((d) => d.measure(Gtk.Orientation.HORIZONTAL, -1)[1]);
 
 const areAllEqual = (values: number[]): boolean => values.every((v) => v === values[0]);
+
+const renderDropDowns = async (): Promise<Gtk.Widget[]> => {
+    await renderDemo(sizegroupDemo);
+
+    return await screen.findAllByRole(Gtk.AccessibleRole.COMBO_BOX);
+};
 
 describe("sizegroupDemo metadata", () => {
     it("exposes the expected metadata", () => {
@@ -33,8 +39,7 @@ describe("sizegroupDemo frames and labels", () => {
     });
 
     it("renders four GtkDropDowns - one per option row", async () => {
-        await renderDemo(sizegroupDemo);
-        const dropdowns = await screen.findAllByRole(Gtk.AccessibleRole.COMBO_BOX);
+        const dropdowns = await renderDropDowns();
         expect(dropdowns).toHaveLength(4);
     });
 
@@ -55,7 +60,7 @@ describe("sizegroupDemo frames and labels", () => {
 describe("sizegroupDemo check button", () => {
     it("starts with grouping enabled so every dropdown shares one requested width", async () => {
         await renderDemo(sizegroupDemo);
-        await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "_Enable grouping", checked: true });
+        await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Enable grouping", checked: true });
         const dropdowns = await screen.findAllByRole(Gtk.AccessibleRole.COMBO_BOX);
         const widths = naturalWidths(dropdowns);
         expect(widths.every((w) => w > 0)).toBe(true);
@@ -69,31 +74,29 @@ describe("sizegroupDemo check button", () => {
     });
 
     it("toggling the check button off switches the size group to NONE, unequalising widths", async () => {
-        await renderDemo(sizegroupDemo);
-        const dropdowns = await screen.findAllByRole(Gtk.AccessibleRole.COMBO_BOX);
+        const dropdowns = await renderDropDowns();
         const groupedWidths = naturalWidths(dropdowns);
         expect(areAllEqual(groupedWidths)).toBe(true);
 
         const check = await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, {
-            name: "_Enable grouping",
+            name: "Enable grouping",
             checked: true,
         });
 
         await userEvent.click(check);
-        await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "_Enable grouping", checked: false });
+        await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Enable grouping", checked: false });
         const ungroupedWidths = naturalWidths(dropdowns);
         expect(areAllEqual(ungroupedWidths)).toBe(false);
         expect(Math.max(...ungroupedWidths)).toBe(groupedWidths[0]);
         await userEvent.click(check);
-        await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "_Enable grouping", checked: true });
+        await screen.findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Enable grouping", checked: true });
         expect(areAllEqual(naturalWidths(dropdowns))).toBe(true);
     });
 });
 
 describe("sizegroupDemo dropdowns", () => {
     it("initialises each dropdown to the first option of its data set", async () => {
-        await renderDemo(sizegroupDemo);
-        const dropdowns = await screen.findAllByRole(Gtk.AccessibleRole.COMBO_BOX);
+        const dropdowns = await renderDropDowns();
         expect(dropdowns).toHaveLength(4);
 
         for (const dropdown of dropdowns) {

--- a/examples/gtk-demo/tests/demos/lists/listbox.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listbox.test.tsx
@@ -14,9 +14,27 @@ const findRow = async (index: number): Promise<Gtk.ListBoxRow> => {
 
 const findFirstRow = (): Promise<Gtk.ListBoxRow> => findRow(0);
 
+const findDetailsRevealer = (row: Gtk.ListBoxRow): Gtk.Revealer =>
+    within(row).getByName("details-revealer", { as: Gtk.Revealer });
+
 const revealActionButtons = async (row: Gtk.ListBoxRow): Promise<void> => {
     row.setStateFlags(Gtk.StateFlags.PRELIGHT, false);
     await fireEvent(row, "state-flags-changed", Gtk.StateFlags.NORMAL);
+};
+
+const expandFirstRow = async (): Promise<Gtk.ListBoxRow> => {
+    const firstRow = await findFirstRow();
+    await revealActionButtons(firstRow);
+    const expandButton = within(firstRow).getByName("expand-button", { as: Gtk.Button });
+    await userEvent.click(expandButton);
+
+    return firstRow;
+};
+
+const expectRowCount = async (row: Gtk.ListBoxRow, label: RegExp, count: string): Promise<void> => {
+    await waitFor(() => {
+        expect(within(row).getByText(label)).toHaveTextContent(count);
+    });
 };
 
 vi.setConfig({ testTimeout: 60_000 });
@@ -75,9 +93,8 @@ describe("listboxDemo resent-by rows", () => {
         await renderDemo(listboxDemo);
         const firstRow = await findFirstRow();
         const secondRow = await findRow(1);
-        const firstBox = (within(firstRow).getAllByText("Resent by")[0] as Gtk.Widget).getParent() as Gtk.Widget;
+        expect(within(firstRow).queryAllByText("Resent by")).toHaveLength(0);
         const secondBox = (within(secondRow).getAllByText("Resent by")[0] as Gtk.Widget).getParent() as Gtk.Widget;
-        expect(firstBox).not.toBeVisible();
         expect(secondBox).toBeVisible();
     });
 });
@@ -86,7 +103,7 @@ describe("listboxDemo row interaction", () => {
     it("toggles the message details revealer when a row is activated", async () => {
         await renderDemo(listboxDemo);
         const firstRow = await findFirstRow();
-        const revealer = within(firstRow).getByName("details-revealer", { as: Gtk.Revealer });
+        const revealer = findDetailsRevealer(firstRow);
         const isBefore = revealer.getRevealChild();
         await userEvent.click(firstRow);
 
@@ -98,7 +115,7 @@ describe("listboxDemo row interaction", () => {
     it("returns to the initial revealer state after a second activation", async () => {
         await renderDemo(listboxDemo);
         const firstRow = await findFirstRow();
-        const revealer = within(firstRow).getByName("details-revealer", { as: Gtk.Revealer });
+        const revealer = findDetailsRevealer(firstRow);
         const isInitial = revealer.getRevealChild();
         await userEvent.click(firstRow);
         await userEvent.click(firstRow);
@@ -114,7 +131,7 @@ describe("listboxDemo expand / hide button", () => {
         await renderDemo(listboxDemo);
         const firstRow = await findFirstRow();
         const expandButton = within(firstRow).getByName("expand-button", { as: Gtk.Button });
-        const revealer = within(firstRow).getByName("details-revealer", { as: Gtk.Revealer });
+        const revealer = findDetailsRevealer(firstRow);
         expect(expandButton).toHaveObjectProperty("label", "Expand");
         const isBefore = revealer.getRevealChild();
         await userEvent.click(expandButton);
@@ -131,12 +148,12 @@ describe("listboxDemo row state flags", () => {
     it("reveals the per-row action button box when the row gains prelight", async () => {
         await renderDemo(listboxDemo);
         const firstRow = await findFirstRow();
-        const replyLabel = within(firstRow).getAllByText("Reply")[0] as Gtk.Widget;
-        const actionBox = replyLabel.getParent()?.getParent() as Gtk.Widget;
-        expect(actionBox).not.toBeVisible();
+        expect(within(firstRow).queryAllByText("Reply")).toHaveLength(0);
         await revealActionButtons(firstRow);
 
         await waitFor(() => {
+            const replyLabel = within(firstRow).getAllByText("Reply")[0] as Gtk.Widget;
+            const actionBox = replyLabel.getParent()?.getParent() as Gtk.Widget;
             expect(actionBox).toBeVisible();
         });
     });
@@ -145,14 +162,8 @@ describe("listboxDemo row state flags", () => {
 describe("listboxDemo favorite and reshare actions", () => {
     it("increments the favorites count shown in the details revealer when Favorite is clicked", async () => {
         await renderDemo(listboxDemo);
-        const firstRow = await findFirstRow();
-        await revealActionButtons(firstRow);
-        const expandButton = within(firstRow).getByName("expand-button", { as: Gtk.Button });
-        await userEvent.click(expandButton);
-
-        await waitFor(() => {
-            expect(within(firstRow).getByText(/Favorites/)).toHaveTextContent("2");
-        });
+        const firstRow = await expandFirstRow();
+        await expectRowCount(firstRow, /Favorites/, "2");
 
         const favoriteButton = within(firstRow).getByRole(Gtk.AccessibleRole.BUTTON, {
             name: "Favorite",
@@ -160,22 +171,13 @@ describe("listboxDemo favorite and reshare actions", () => {
         });
 
         await userEvent.click(favoriteButton);
-
-        await waitFor(() => {
-            expect(within(firstRow).getByText(/Favorites/)).toHaveTextContent("3");
-        });
+        await expectRowCount(firstRow, /Favorites/, "3");
     });
 
     it("increments the reshares count shown in the details revealer when Reshare is clicked", async () => {
         await renderDemo(listboxDemo);
-        const firstRow = await findFirstRow();
-        await revealActionButtons(firstRow);
-        const expandButton = within(firstRow).getByName("expand-button", { as: Gtk.Button });
-        await userEvent.click(expandButton);
-
-        await waitFor(() => {
-            expect(within(firstRow).getByText(/Reshares/)).toHaveTextContent("1");
-        });
+        const firstRow = await expandFirstRow();
+        await expectRowCount(firstRow, /Reshares/, "1");
 
         const reshareButton = within(firstRow).getByRole(Gtk.AccessibleRole.BUTTON, {
             name: "Reshare",
@@ -183,9 +185,6 @@ describe("listboxDemo favorite and reshare actions", () => {
         });
 
         await userEvent.click(reshareButton);
-
-        await waitFor(() => {
-            expect(within(firstRow).getByText(/Reshares/)).toHaveTextContent("2");
-        });
+        await expectRowCount(firstRow, /Reshares/, "2");
     });
 });

--- a/examples/gtk-demo/tests/demos/lists/listview-applauncher.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-applauncher.test.tsx
@@ -17,9 +17,14 @@ const firstAppInfo = (): Gio.AppInfo => {
 
 const appInfoPrototype = (): Gio.AppInfo => Object.getPrototypeOf(firstAppInfo()) as Gio.AppInfo;
 
-const activateFirstRowAndExpectLaunch = async (launchSpy: ReturnType<typeof vi.spyOn>): Promise<void> => {
+const renderListView = async (): Promise<Gtk.ListView> => {
     await renderDemo(listviewApplauncherDemo);
-    const listView = await screen.findByName("list-view", { as: Gtk.ListView });
+
+    return await screen.findByName("list-view", { as: Gtk.ListView });
+};
+
+const activateFirstRowAndExpectLaunch = async (launchSpy: ReturnType<typeof vi.spyOn>): Promise<void> => {
+    const listView = await renderListView();
     await fireEvent(listView, "activate", 0);
 
     await waitFor(() => {
@@ -50,15 +55,13 @@ describe("listviewApplauncherDemo structure", () => {
     });
 
     it("uses single selection mode on the list view", async () => {
-        await renderDemo(listviewApplauncherDemo);
-        const listView = await screen.findByName("list-view", { as: Gtk.ListView });
+        const listView = await renderListView();
         const model = listView.getModel();
         expect(model).toBeInstanceOf(Gtk.SingleSelection);
     });
 
     it("moves the single selection to whichever row is chosen", async () => {
-        await renderDemo(listviewApplauncherDemo);
-        const listView = await screen.findByName("list-view", { as: Gtk.ListView });
+        const listView = await renderListView();
         const model = listView.getModel() as Gtk.SingleSelection;
         await userEvent.selectOptions(listView, 0);
         expect(model).toHaveObjectProperty("selected", 0);
@@ -69,8 +72,7 @@ describe("listviewApplauncherDemo structure", () => {
 
 describe("listviewApplauncherDemo rows", () => {
     it("renders one row per application returned by Gio.AppInfo.getAll", async () => {
-        await renderDemo(listviewApplauncherDemo);
-        const listView = await screen.findByName("list-view", { as: Gtk.ListView });
+        const listView = await renderListView();
         const model = listView.getModel();
         expect(model).not.toBeNull();
         const expectedCount = Gio.AppInfo.getAll().length;
@@ -106,8 +108,7 @@ describe("listviewApplauncherDemo rows", () => {
     });
 
     it("renders exactly one icon per label row through the list view factory", async () => {
-        await renderDemo(listviewApplauncherDemo);
-        const listView = await screen.findByName("list-view", { as: Gtk.ListView });
+        const listView = await renderListView();
         const images = within(listView).getAllByRole(Gtk.AccessibleRole.IMG);
         const labels = within(listView).getAllByRole(Gtk.AccessibleRole.LABEL);
         expect(images.length).toBeGreaterThan(0);

--- a/examples/gtk-demo/tests/demos/lists/listview-colors.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-colors.test.tsx
@@ -54,6 +54,20 @@ const leadingNames = (model: Gtk.MultiSelection): string[] =>
 const isAscending = (values: string[]): boolean =>
     values.every((value, index) => index === 0 || (values[index - 1] ?? "").localeCompare(value) <= 0);
 
+const renderSortableGrid = async (): Promise<{ model: Gtk.MultiSelection; sortDropdown: Gtk.DropDown }> => {
+    await renderDemo(listviewColorsDemo);
+    const model = await findGridModel();
+    const sortDropdown = await screen.findByName("sort-dropdown", { as: Gtk.DropDown });
+
+    return { model, sortDropdown };
+};
+
+const expectSelectionSize = async (model: Gtk.MultiSelection, size: number): Promise<void> => {
+    await waitFor(() => {
+        expect(Number(model.getSelection().getSize())).toBe(size);
+    });
+};
+
 vi.setConfig({ testTimeout: 30_000 });
 
 describe("listviewColorsDemo metadata", () => {
@@ -73,7 +87,7 @@ describe("listviewColorsDemo header bar", () => {
     it("hosts the refill button and the three drop-downs inside the header bar", async () => {
         await renderDemo(listviewColorsDemo);
         const headerBar = await screen.findByName("header-bar", { as: Gtk.HeaderBar });
-        const refill = await within(headerBar).findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Refill" });
+        const refill = await within(headerBar).findByRole(Gtk.AccessibleRole.BUTTON, { name: "Refill" });
         expect(refill).toBeInstanceOf(Gtk.Button);
         expect(await within(headerBar).findByName("limit-dropdown")).toBeInstanceOf(Gtk.DropDown);
         expect(await within(headerBar).findByName("sort-dropdown")).toBeInstanceOf(Gtk.DropDown);
@@ -112,6 +126,7 @@ describe("listviewColorsDemo grid view", () => {
         model.selectItem(0, true);
         model.selectItem(2, false);
         expect(Number(model.getSelection().getSize())).toBe(2);
+        await userEvent.click(await screen.findByName("selection-toggle", { as: Gtk.ToggleButton }));
         const sizeLabel = await screen.findByName("selection-size", { as: Gtk.Label });
 
         await waitFor(() => {
@@ -158,23 +173,14 @@ describe("listviewColorsDemo header actions", () => {
         const model = gridModel(grid);
         grid.grabFocus();
         await userEvent.keyboard(grid, "{ArrowDown} ");
-
-        await waitFor(() => {
-            expect(Number(model.getSelection().getSize())).toBe(1);
-        });
-
-        const refill = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Refill" });
+        await expectSelectionSize(model, 1);
+        const refill = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Refill" });
         await userEvent.click(refill);
-
-        await waitFor(() => {
-            expect(Number(model.getSelection().getSize())).toBe(0);
-        });
+        await expectSelectionSize(model, 0);
     });
 
     it("reorders the grid model when the sort dropdown selects Name", async () => {
-        await renderDemo(listviewColorsDemo);
-        const model = await findGridModel();
-        const sortDropdown = await screen.findByName("sort-dropdown", { as: Gtk.DropDown });
+        const { model, sortDropdown } = await renderSortableGrid();
         await userEvent.selectOptions(sortDropdown, 1);
 
         await waitFor(() => {
@@ -219,9 +225,7 @@ describe("listviewColorsDemo display modes", () => {
 
 describe("listviewColorsDemo sort modes", () => {
     it.each(sortModeCases)("orders the model per the $label compare function", async ({ index, field }) => {
-        await renderDemo(listviewColorsDemo);
-        const model = await findGridModel();
-        const sortDropdown = await screen.findByName("sort-dropdown", { as: Gtk.DropDown });
+        const { model, sortDropdown } = await renderSortableGrid();
         await userEvent.selectOptions(sortDropdown, index);
 
         await waitFor(() => {
@@ -231,9 +235,7 @@ describe("listviewColorsDemo sort modes", () => {
     });
 
     it("restores the generated order when switching back to unsorted", async () => {
-        await renderDemo(listviewColorsDemo);
-        const model = await findGridModel();
-        const sortDropdown = await screen.findByName("sort-dropdown", { as: Gtk.DropDown });
+        const { model, sortDropdown } = await renderSortableGrid();
         const original = leadingNames(model);
         await userEvent.selectOptions(sortDropdown, 1);
 

--- a/examples/gtk-demo/tests/demos/lists/listview-filebrowser.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-filebrowser.test.tsx
@@ -6,8 +6,12 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { listviewFilebrowserDemo } from "../../../src/demos/lists/listview-filebrowser.js";
 import { renderDemo } from "../../test-utils.js";
 
+type ScrollAxis = { adjustment: Gtk.Adjustment; isHorizontal: boolean };
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
 const originalCwd = process.cwd();
+const SCROLL_STEP = 200;
+const MAX_SCROLL_STEPS = 80;
 
 const waitForPopulatedModel = async (grid: Gtk.GridView): Promise<number> =>
     waitFor(() => {
@@ -17,10 +21,88 @@ const waitForPopulatedModel = async (grid: Gtk.GridView): Promise<number> =>
         return count;
     });
 
-const orderedNames = (grid: Gtk.GridView): string[] =>
+const findFilesGrid = async (): Promise<Gtk.GridView> => await screen.findByName("files-grid", { as: Gtk.GridView });
+
+const renderPopulatedGrid = async (): Promise<Gtk.GridView> => {
+    await renderDemo(listviewFilebrowserDemo);
+    const grid = await findFilesGrid();
+    await waitForPopulatedModel(grid);
+
+    return grid;
+};
+
+const selectViewMode = async (index: number): Promise<Gtk.ListView> => {
+    await renderDemo(listviewFilebrowserDemo);
+    const switcher = await screen.findByName("view-switcher", { as: Gtk.ListView });
+    await userEvent.selectOptions(switcher, index);
+
+    return switcher;
+};
+
+const visibleNames = (grid: Gtk.GridView): string[] =>
     within(grid)
         .getAllByRole(Gtk.AccessibleRole.LABEL, { as: Gtk.Label })
         .map((label) => label.getText());
+
+const findScrolledFiles = (): Promise<Gtk.ScrolledWindow> =>
+    screen.findByName("files-scrolled", { as: Gtk.ScrolledWindow });
+
+const isScrolledToEnd = (adjustment: Gtk.Adjustment): boolean =>
+    adjustment.getValue() >= adjustment.getUpper() - adjustment.getPageSize();
+
+const getScrollAxis = (scrolled: Gtk.ScrolledWindow): ScrollAxis => {
+    const horizontal = scrolled.getHadjustment();
+
+    if (horizontal.getUpper() > horizontal.getPageSize()) {
+        return { adjustment: horizontal, isHorizontal: true };
+    }
+
+    return { adjustment: scrolled.getVadjustment(), isHorizontal: false };
+};
+
+const scrollBy = async (scrolled: Gtk.ScrolledWindow, axis: ScrollAxis, amount: number): Promise<void> => {
+    await userEvent.scroll(scrolled, axis.isHorizontal ? { x: amount } : { y: amount });
+};
+
+const scrollThroughFiles = async (hasArrived: () => boolean): Promise<void> => {
+    const scrolled = await findScrolledFiles();
+    const axis = getScrollAxis(scrolled);
+    await scrollBy(scrolled, axis, -axis.adjustment.getUpper());
+
+    for (let step = 0; step < MAX_SCROLL_STEPS; step++) {
+        if (hasArrived() || isScrolledToEnd(axis.adjustment)) {
+            return;
+        }
+
+        await scrollBy(scrolled, axis, SCROLL_STEP);
+    }
+};
+
+const scrollToEntry = async (grid: Gtk.GridView, name: string): Promise<Gtk.Widget> => {
+    await scrollThroughFiles(() => within(grid).queryAllByText(name).length > 0);
+
+    return within(grid).findByText(name);
+};
+
+const collectNames = (names: string[], grid: Gtk.GridView): void => {
+    for (const name of visibleNames(grid)) {
+        if (!names.includes(name)) {
+            names.push(name);
+        }
+    }
+};
+
+const orderedNames = async (grid: Gtk.GridView): Promise<string[]> => {
+    const names: string[] = [];
+
+    await scrollThroughFiles(() => {
+        collectNames(names, grid);
+
+        return false;
+    });
+
+    return names;
+};
 
 beforeAll(() => {
     process.chdir(repoRoot);
@@ -73,23 +155,22 @@ describe("listviewFilebrowserDemo file grid", () => {
         const grid = within(sw).getByName("files-grid", { as: Gtk.GridView });
         expect(grid).toBeInstanceOf(Gtk.GridView);
         await waitForPopulatedModel(grid);
-        await within(grid).findByText("package.json");
+        await scrollToEntry(grid, "package.json");
     });
 
     it("populates the file grid with known entries from the working directory", async () => {
-        await renderDemo(listviewFilebrowserDemo);
-        const grid = await screen.findByName("files-grid", { as: Gtk.GridView });
-        await waitForPopulatedModel(grid);
-        expect(await within(grid).findByText("package.json")).toBeInstanceOf(Gtk.Label);
-        expect(within(grid).getByText("examples")).toBeInstanceOf(Gtk.Label);
-        expect(within(grid).getByText("packages")).toBeInstanceOf(Gtk.Label);
+        const grid = await renderPopulatedGrid();
+        expect(await scrollToEntry(grid, "package.json")).toBeInstanceOf(Gtk.Label);
+        expect(await scrollToEntry(grid, "examples")).toBeInstanceOf(Gtk.Label);
+        expect(await scrollToEntry(grid, "packages")).toBeInstanceOf(Gtk.Label);
     });
 
     it("sorts directories before files, alphabetically within each group", async () => {
-        await renderDemo(listviewFilebrowserDemo);
-        const grid = await screen.findByName("files-grid", { as: Gtk.GridView });
-        await waitForPopulatedModel(grid);
-        const names = orderedNames(grid);
+        const grid = await renderPopulatedGrid();
+        const names = await orderedNames(grid);
+        expect(names).toContain("examples");
+        expect(names).toContain("packages");
+        expect(names).toContain("package.json");
         expect(names.indexOf("examples")).toBeLessThan(names.indexOf("packages"));
         expect(names.indexOf("packages")).toBeLessThan(names.indexOf("package.json"));
     });
@@ -98,15 +179,13 @@ describe("listviewFilebrowserDemo file grid", () => {
 describe("listviewFilebrowserDemo view modes", () => {
     it("starts in list view orientation (horizontal)", async () => {
         await renderDemo(listviewFilebrowserDemo);
-        const grid = await screen.findByName("files-grid", { as: Gtk.GridView });
+        const grid = await findFilesGrid();
         expect(grid).toHaveObjectProperty("orientation", Gtk.Orientation.HORIZONTAL);
     });
 
     it("switches to grid view: vertical orientation, wrapped item labels, and switcher selection", async () => {
-        await renderDemo(listviewFilebrowserDemo);
-        const switcher = await screen.findByName("view-switcher", { as: Gtk.ListView });
-        await userEvent.selectOptions(switcher, 1);
-        const grid = await screen.findByName("files-grid", { as: Gtk.GridView });
+        const switcher = await selectViewMode(1);
+        const grid = await findFilesGrid();
 
         await waitFor(() => {
             expect(grid).toHaveObjectProperty("orientation", Gtk.Orientation.VERTICAL);
@@ -118,13 +197,11 @@ describe("listviewFilebrowserDemo view modes", () => {
     });
 
     it("switches to paged view mode rendering the folder and content-type labels", async () => {
-        await renderDemo(listviewFilebrowserDemo);
-        const switcher = await screen.findByName("view-switcher", { as: Gtk.ListView });
-        await userEvent.selectOptions(switcher, 2);
-        const grid = await screen.findByName("files-grid", { as: Gtk.GridView });
+        const switcher = await selectViewMode(2);
+        const grid = await findFilesGrid();
         await waitForPopulatedModel(grid);
         expect(switcher.getModel()).toHaveObjectProperty("selected", 2);
-        await within(grid).findByText("packages");
+        await scrollToEntry(grid, "packages");
         expect(within(grid).getAllByText("folder").length).toBeGreaterThan(0);
         expect(within(grid).getAllByText("inode/directory").length).toBeGreaterThan(0);
     });
@@ -132,21 +209,18 @@ describe("listviewFilebrowserDemo view modes", () => {
 
 describe("listviewFilebrowserDemo navigation", () => {
     it("navigates to the parent directory when the up button is clicked", async () => {
-        await renderDemo(listviewFilebrowserDemo);
-        const grid = await screen.findByName("files-grid", { as: Gtk.GridView });
-        await waitForPopulatedModel(grid);
+        const grid = await renderPopulatedGrid();
         const currentDirName = basename(process.cwd());
         expect(within(grid).queryByText(currentDirName)).toBeNull();
         const upButton = await screen.findByName("up-button", { as: Gtk.Button });
         await userEvent.click(upButton);
-        await within(grid).findByText(currentDirName);
+        await scrollToEntry(grid, currentDirName);
     });
 
     it("navigates into a directory when a directory entry is activated", async () => {
-        await renderDemo(listviewFilebrowserDemo);
-        const grid = await screen.findByName("files-grid", { as: Gtk.GridView });
-        await waitForPopulatedModel(grid);
-        const position = orderedNames(grid).indexOf("examples");
+        const grid = await renderPopulatedGrid();
+        const names = await orderedNames(grid);
+        const position = names.indexOf("examples");
         expect(position).toBeGreaterThanOrEqual(0);
         grid.grabFocus();
         await fireEvent(grid, "activate", position);

--- a/examples/gtk-demo/tests/demos/lists/listview-selections.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-selections.test.tsx
@@ -5,6 +5,14 @@ import { describe, expect, it } from "vitest";
 import { listviewSelectionsDemo } from "../../../src/demos/lists/listview-selections.js";
 import { renderDemo } from "../../test-utils.js";
 
+async function expectListedTwiceAfterOpening(dropdown: Gtk.DropDown, text: string): Promise<void> {
+    await userEvent.click(dropdown);
+
+    await waitFor(() => {
+        expect(within(dropdown).getAllByText(text)).toHaveLength(2);
+    });
+}
+
 async function findVerticalColumnSeparator() {
     const sep = await screen.findByName("column-separator", { as: Gtk.Separator });
     expect(sep).toBeInstanceOf(Gtk.Separator);
@@ -17,6 +25,26 @@ function rowLabelText(row: Gtk.Widget): string {
     const label = within(row).getAllByText(/.+/)[0] as Gtk.Label;
 
     return label.getText();
+}
+
+async function renderWordsEntry(): Promise<Gtk.Entry> {
+    await renderDemo(listviewSelectionsDemo);
+
+    return await screen.findByName("words-entry", { as: Gtk.Entry });
+}
+
+async function findFontSpin(): Promise<Gtk.SpinButton> {
+    return await screen.findByName("font-spin", { as: Gtk.SpinButton });
+}
+
+async function findFontsDropDown(): Promise<Gtk.DropDown> {
+    return await screen.findByName("fonts-dropdown", { as: Gtk.DropDown });
+}
+
+async function renderDirectoryEntry(): Promise<Gtk.Entry> {
+    await renderDemo(listviewSelectionsDemo);
+
+    return await screen.findByName("directory-entry", { as: Gtk.Entry });
 }
 
 async function findDropDowns() {
@@ -53,7 +81,7 @@ describe("listviewSelectionsDemo layout", () => {
 
     it("renders the fonts dropdown with search disabled and a column separator", async () => {
         await renderDemo(listviewSelectionsDemo);
-        const fonts = await screen.findByName("fonts-dropdown", { as: Gtk.DropDown });
+        const fonts = await findFontsDropDown();
         expect(fonts).toHaveObjectProperty("enableSearch", false);
         await findVerticalColumnSeparator();
     });
@@ -82,20 +110,18 @@ describe("listviewSelectionsDemo controls", () => {
         const check = await screen.findByName("enable-search-check", { as: Gtk.CheckButton });
         await userEvent.click(check);
         expect(check).toBeChecked();
-        const fonts = await screen.findByName("fonts-dropdown", { as: Gtk.DropDown });
+        const fonts = await findFontsDropDown();
         expect(fonts).toHaveObjectProperty("enableSearch", true);
     });
 
     it("updates the entry text when text is typed into the suggestion entry", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "GNOME");
         expect(entry).toHaveDisplayValue("GNOME");
     });
 
     it("clears the suggestion entry when cleared", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "TEXT");
         await userEvent.clear(entry);
         expect(entry).toHaveDisplayValue("");
@@ -103,7 +129,7 @@ describe("listviewSelectionsDemo controls", () => {
 
     it("increments the font-spin value on ArrowUp (rounds and clamps)", async () => {
         await renderDemo(listviewSelectionsDemo);
-        const spin = await screen.findByName("font-spin", { as: Gtk.SpinButton });
+        const spin = await findFontSpin();
         spin.grabFocus();
         await userEvent.keyboard(spin, "{ArrowUp}{ArrowUp}");
         expect(await screen.findByRole(Gtk.AccessibleRole.SPIN_BUTTON, { value: { now: 2 } })).toHaveValue(2);
@@ -121,7 +147,9 @@ describe("listviewSelectionsDemo dropdown selections", () => {
             expect(times).toHaveObjectProperty("selected", 2);
         });
 
-        expect(within(times).getAllByText("5 minutes")).toHaveLength(2);
+        expect(within(times).getAllByText("5 minutes")).toHaveLength(1);
+        expect(within(times).queryAllByText("1 minute")).toHaveLength(0);
+        await expectListedTwiceAfterOpening(times, "5 minutes");
         expect(within(times).getAllByText("1 minute")).toHaveLength(1);
     });
 
@@ -135,7 +163,8 @@ describe("listviewSelectionsDemo dropdown selections", () => {
             expect(timesSectioned).toHaveObjectProperty("selected", 5);
         });
 
-        expect(within(timesSectioned).getAllByText("20 minutes")).toHaveLength(2);
+        expect(within(timesSectioned).getAllByText("20 minutes")).toHaveLength(1);
+        await expectListedTwiceAfterOpening(timesSectioned, "20 minutes");
     });
 
     it("updates the Devices dropdown selection and its displayed device", async () => {
@@ -148,13 +177,14 @@ describe("listviewSelectionsDemo dropdown selections", () => {
             expect(devices).toHaveObjectProperty("selected", 1);
         });
 
-        expect(within(devices).getAllByText("Headphones")).toHaveLength(2);
+        expect(within(devices).getAllByText("Headphones")).toHaveLength(1);
+        await expectListedTwiceAfterOpening(devices, "Headphones");
     });
 
     it("syncs the font spin value when a font is chosen from the fonts dropdown", async () => {
         await renderDemo(listviewSelectionsDemo);
         const { fonts } = await findDropDowns();
-        const spin = await screen.findByName("font-spin", { as: Gtk.SpinButton });
+        const spin = await findFontSpin();
         expect(spin).toHaveObjectProperty("value", 0);
         await userEvent.selectOptions(fonts, 3);
 
@@ -168,8 +198,7 @@ describe("listviewSelectionsDemo dropdown selections", () => {
 
 describe("listviewSelectionsDemo suggestion popover", () => {
     it("opens the suggestion popover and renders matching rows after typing", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "gnom");
         const popover = await screen.findByName("words-entry-popover", { as: Gtk.Popover });
 
@@ -183,8 +212,7 @@ describe("listviewSelectionsDemo suggestion popover", () => {
     });
 
     it("selects the first suggestion row when the Down arrow is pressed", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "gnom");
         await userEvent.keyboard(entry, "{ArrowDown}");
         const selected = await screen.findByRole(Gtk.AccessibleRole.LIST_ITEM, { selected: true });
@@ -192,8 +220,7 @@ describe("listviewSelectionsDemo suggestion popover", () => {
     });
 
     it("wraps to the last suggestion row on Down then Up", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "tot");
         await userEvent.keyboard(entry, "{ArrowDown}");
         await userEvent.keyboard(entry, "{ArrowUp}");
@@ -204,8 +231,7 @@ describe("listviewSelectionsDemo suggestion popover", () => {
 
 describe("listviewSelectionsDemo suggestion acceptance", () => {
     it("writes the selected suggestion into the entry when Enter is pressed", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "GNOM");
         await userEvent.keyboard(entry, "{ArrowDown}{Enter}");
 
@@ -215,8 +241,7 @@ describe("listviewSelectionsDemo suggestion acceptance", () => {
     });
 
     it("writes a suggestion into the entry when its row is clicked", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "gnom");
         const rows = screen.getAllByRole(Gtk.AccessibleRole.LIST_ITEM);
         await userEvent.click(rows[1] as Gtk.Widget);
@@ -227,8 +252,7 @@ describe("listviewSelectionsDemo suggestion acceptance", () => {
     });
 
     it("hides the suggestion popover when Escape is pressed", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "tot");
         const popover = await screen.findByName("words-entry-popover", { as: Gtk.Popover });
 
@@ -246,8 +270,7 @@ describe("listviewSelectionsDemo suggestion acceptance", () => {
 
 describe("listviewSelectionsDemo suggestion clearing", () => {
     it("clears the suggestion list when the entry is cleared after typing", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.type(entry, "ttt");
         await userEvent.clear(entry);
         expect(entry).toHaveDisplayValue("");
@@ -258,8 +281,7 @@ describe("listviewSelectionsDemo suggestion clearing", () => {
     });
 
     it("ignores Down arrow keypress when there are no current suggestions", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("words-entry", { as: Gtk.Entry });
+        const entry = await renderWordsEntry();
         await userEvent.keyboard(entry, "{ArrowDown}");
         expect(entry).toHaveDisplayValue("");
     });
@@ -280,15 +302,13 @@ describe("listviewSelectionsDemo second suggestion entry", () => {
 
 describe("listviewSelectionsDemo directory suggestion entry", () => {
     it("updates the directory entry text when text is typed", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("directory-entry", { as: Gtk.Entry });
+        const entry = await renderDirectoryEntry();
         await userEvent.type(entry, "hello");
         expect(entry).toHaveDisplayValue("hello");
     });
 
     it("fills the directory entry with a directory name when a suggestion button is clicked", async () => {
-        await renderDemo(listviewSelectionsDemo);
-        const entry = await screen.findByName("directory-entry", { as: Gtk.Entry });
+        const entry = await renderDirectoryEntry();
         const menuButton = await screen.findByName("directory-menu-button", { as: Gtk.MenuButton });
         const popover = menuButton.getPopover() as Gtk.Popover;
         popover.popup();
@@ -310,8 +330,8 @@ describe("listviewSelectionsDemo directory suggestion entry", () => {
 describe("listviewSelectionsDemo font spin button", () => {
     it("moves the fonts dropdown selection when the spin button value increases", async () => {
         await renderDemo(listviewSelectionsDemo);
-        const spin = await screen.findByName("font-spin", { as: Gtk.SpinButton });
-        const fonts = await screen.findByName("fonts-dropdown", { as: Gtk.DropDown });
+        const spin = await findFontSpin();
+        const fonts = await findFontsDropDown();
         expect(fonts).toHaveObjectProperty("selected", 0);
         spin.grabFocus();
         await userEvent.keyboard(spin, "{ArrowUp}");
@@ -324,8 +344,8 @@ describe("listviewSelectionsDemo font spin button", () => {
 
     it("ignores spin button values out of range", async () => {
         await renderDemo(listviewSelectionsDemo);
-        const spin = await screen.findByName("font-spin", { as: Gtk.SpinButton });
-        const fonts = await screen.findByName("fonts-dropdown", { as: Gtk.DropDown });
+        const spin = await findFontSpin();
+        const fonts = await findFontsDropDown();
         spin.grabFocus();
         await userEvent.keyboard(spin, "{ArrowDown}");
         await screen.findByRole(Gtk.AccessibleRole.SPIN_BUTTON, { value: { now: -1 } });

--- a/examples/gtk-demo/tests/demos/lists/listview-settings.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-settings.test.tsx
@@ -3,7 +3,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { screen, userEvent, waitFor, within } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
 import { listviewSettingsDemo } from "../../../src/demos/lists/listview-settings.js";
-import { findInactiveSearchToggle, renderDemo } from "../../test-utils.js";
+import { collectWidgets, findInactiveSearchToggle, openSearchEntry, renderDemo } from "../../test-utils.js";
 
 type FilteredToZeroState = {
     columnView: Gtk.ColumnView;
@@ -36,27 +36,21 @@ const readColumns = (cv: Gtk.ColumnView): Map<string, Gtk.ColumnViewColumn> => {
     return out;
 };
 
-const collectEditableLabels = (widget: Gtk.Widget, out: Gtk.EditableLabel[] = []): Gtk.EditableLabel[] => {
-    if (widget instanceof Gtk.EditableLabel) {
-        out.push(widget);
-    }
-
-    let child = widget.getFirstChild();
-
-    while (child) {
-        collectEditableLabels(child, out);
-        child = child.getNextSibling();
-    }
-
-    return out;
-};
-
 const itemCount = (cv: Gtk.ColumnView): number => (cv.getModel())?.getNItems() ?? 0;
+
+const findColumnView = async (): Promise<Gtk.ColumnView> =>
+    await screen.findByName("column-view", { as: Gtk.ColumnView });
+
+const renderColumnView = async (): Promise<Gtk.ColumnView> => {
+    await renderDemo(listviewSettingsDemo);
+
+    return await findColumnView();
+};
 
 const selectFirstSchemaWithKeys = async (): Promise<Gtk.ColumnView> => {
     const sidebar = await screen.findByName("sidebar", { as: Gtk.ListView });
     await userEvent.selectOptions(sidebar, 0);
-    const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+    const columnView = await findColumnView();
 
     await waitFor(() => {
         expect(itemCount(columnView)).toBeGreaterThan(0);
@@ -66,12 +60,12 @@ const selectFirstSchemaWithKeys = async (): Promise<Gtk.ColumnView> => {
 };
 
 const booleanEditableIn = (columnView: Gtk.ColumnView): Gtk.EditableLabel | undefined =>
-    collectEditableLabels(columnView).find((e) => e.getText() === "true" || e.getText() === "false");
+    collectWidgets(columnView, Gtk.EditableLabel).find((e) => e.getText() === "true" || e.getText() === "false");
 
 const booleanEditableAtRow = async (sidebar: Gtk.ListView, index: number): Promise<Gtk.EditableLabel | undefined> => {
     await userEvent.selectOptions(sidebar, index);
 
-    return booleanEditableIn(await screen.findByName("column-view", { as: Gtk.ColumnView }));
+    return booleanEditableIn(await findColumnView());
 };
 
 const selectSchemaWithBooleanKey = async (): Promise<Gtk.EditableLabel> => {
@@ -89,23 +83,11 @@ const selectSchemaWithBooleanKey = async (): Promise<Gtk.EditableLabel> => {
     throw new Error("No GSettings schema installed on this system exposes a boolean-valued key");
 };
 
-const openKeySearch = async (): Promise<Gtk.SearchEntry> => {
-    const toggle = await screen.findByName("search-toggle", { as: Gtk.ToggleButton });
-    await userEvent.click(toggle);
-    const searchBar = await screen.findByName("search-bar", { as: Gtk.SearchBar });
-
-    await waitFor(() => {
-        expect(searchBar).toHaveObjectProperty("searchModeEnabled", true);
-    });
-
-    return screen.findByName("search-entry", { as: Gtk.SearchEntry });
-};
-
 const filterKeysToZero = async (): Promise<FilteredToZeroState> => {
     await renderDemo(listviewSettingsDemo);
     const columnView = await selectFirstSchemaWithKeys();
     const full = itemCount(columnView);
-    const entry = await openKeySearch();
+    const entry = await openSearchEntry();
     await userEvent.type(entry, "zzqqxx");
 
     await waitFor(() => {
@@ -157,15 +139,15 @@ describe("listviewSettingsDemo layout", () => {
         await renderDemo(listviewSettingsDemo);
         const searchBar = await screen.findByName("search-bar", { as: Gtk.SearchBar });
         expect(searchBar).toHaveObjectProperty("searchModeEnabled", false);
-        const searchEntry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+        expect(screen.queryByName("search-entry")).toBeNull();
+        const searchEntry = await openSearchEntry();
         expect(searchEntry).toHaveObjectProperty("text", "");
     });
 });
 
 describe("listviewSettingsDemo column view", () => {
     it("renders a GtkColumnView with the expected columns", async () => {
-        await renderDemo(listviewSettingsDemo);
-        const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+        const columnView = await renderColumnView();
 
         expect(readColumns(columnView).keys().toArray()).toEqual([
             "Name",
@@ -178,8 +160,7 @@ describe("listviewSettingsDemo column view", () => {
     });
 
     it("hides the Summary and Description columns by default", async () => {
-        await renderDemo(listviewSettingsDemo);
-        const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+        const columnView = await renderColumnView();
         const byTitle = readColumns(columnView);
         expect(byTitle.get("Summary")).toHaveObjectProperty("visible", false);
         expect(byTitle.get("Description")).toHaveObjectProperty("visible", false);
@@ -187,8 +168,7 @@ describe("listviewSettingsDemo column view", () => {
     });
 
     it("attaches a selection model to the column view", async () => {
-        await renderDemo(listviewSettingsDemo);
-        const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+        const columnView = await renderColumnView();
 
         await waitFor(() => {
             expect(columnView.getModel()).toBeInstanceOf(Gtk.SelectionModel);
@@ -196,8 +176,7 @@ describe("listviewSettingsDemo column view", () => {
     });
 
     it("exposes the column view's column count once the React commit settles", async () => {
-        await renderDemo(listviewSettingsDemo);
-        const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+        const columnView = await renderColumnView();
 
         await waitFor(() => {
             expect(columnView.getColumns()).toHaveObjectProperty("nItems", 6);
@@ -207,8 +186,7 @@ describe("listviewSettingsDemo column view", () => {
 
 describe("listviewSettingsDemo column header menus", () => {
     it("attaches a header menu only to the four toggleable columns", async () => {
-        await renderDemo(listviewSettingsDemo);
-        const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+        const columnView = await renderColumnView();
 
         await waitFor(
             () => {
@@ -229,8 +207,7 @@ describe("listviewSettingsDemo column header menus", () => {
     });
 
     it("shows a column when its visibility menu action is activated", async () => {
-        await renderDemo(listviewSettingsDemo);
-        const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+        const columnView = await renderColumnView();
         expect(readColumns(columnView).get("Summary")).toHaveObjectProperty("visible", false);
         columnView.activateAction("columnview.show-summary", null);
 
@@ -249,7 +226,7 @@ describe("listviewSettingsDemo schema interactions", () => {
 
     it("opens the key search bar when the titlebar toggle is activated", async () => {
         await renderDemo(listviewSettingsDemo);
-        await openKeySearch();
+        await openSearchEntry();
         const searchBar = await screen.findByName("search-bar", { as: Gtk.SearchBar });
         expect(searchBar).toHaveObjectProperty("searchModeEnabled", true);
     });
@@ -307,7 +284,7 @@ describe("listviewSettingsDemo value editing", () => {
         try {
             await renderDemo(listviewSettingsDemo);
             const columnView = await selectFirstSchemaWithKeys();
-            const [target] = collectEditableLabels(columnView);
+            const [target] = collectWidgets(columnView, Gtk.EditableLabel);
             expect(target).toBeDefined();
             const editable = target as Gtk.EditableLabel;
             const errorBellSpy = vi.spyOn(editable, "errorBell");

--- a/examples/gtk-demo/tests/demos/lists/listview-settings2.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-settings2.test.tsx
@@ -2,7 +2,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { screen, userEvent, waitFor, within } from "@gtkx/testing";
 import { describe, expect, it } from "vitest";
 import { listviewSettings2Demo } from "../../../src/demos/lists/listview-settings2.js";
-import { renderDemo } from "../../test-utils.js";
+import { activateSearchBar, openSearchEntry, renderDemo } from "../../test-utils.js";
 
 const listModel = async (): Promise<Gtk.SelectionModel> => {
     const listView = await screen.findByName("list-view", { as: Gtk.ListView });
@@ -16,23 +16,11 @@ const schemaHeaderLabels = (): string[] =>
         .map((l) => l.getLabel())
         .filter((text) => !text.includes(" "));
 
-async function activateSearch(): Promise<{ toggle: Gtk.ToggleButton; bar: Gtk.SearchBar }> {
-    const toggle = await screen.findByName("search-toggle", { as: Gtk.ToggleButton });
-    await userEvent.click(toggle);
-    const bar = await screen.findByName("search-bar", { as: Gtk.SearchBar });
+const renderListModel = async (): Promise<Gtk.SelectionModel> => {
+    await renderDemo(listviewSettings2Demo);
 
-    await waitFor(() => {
-        expect(bar).toHaveObjectProperty("searchModeEnabled", true);
-    });
-
-    return { toggle, bar };
-}
-
-async function openSearchEntry(): Promise<Gtk.SearchEntry> {
-    await activateSearch();
-
-    return screen.findByName("search-entry", { as: Gtk.SearchEntry });
-}
+    return await listModel();
+};
 
 describe("listviewSettings2Demo metadata", () => {
     it("exposes the expected metadata", () => {
@@ -76,7 +64,8 @@ describe("listviewSettings2Demo layout", () => {
     it("places the search entry inside the search bar", async () => {
         await renderDemo(listviewSettings2Demo);
         const bar = await screen.findByName("search-bar", { as: Gtk.SearchBar });
-        const entry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+        expect(within(bar).queryByName("search-entry")).toBeNull();
+        const entry = await openSearchEntry();
         await within(bar).findByName("search-entry");
         expect(entry).toBeInstanceOf(Gtk.SearchEntry);
     });
@@ -92,13 +81,12 @@ describe("listviewSettings2Demo layout", () => {
 describe("listviewSettings2Demo search and editing", () => {
     it("enables the search bar when the titlebar search toggle is activated", async () => {
         await renderDemo(listviewSettings2Demo);
-        const { bar } = await activateSearch();
+        const { bar } = await activateSearchBar();
         expect(bar).toHaveObjectProperty("searchModeEnabled", true);
     });
 
     it("narrows the list model to the matching schema when the search term matches a subset", async () => {
-        await renderDemo(listviewSettings2Demo);
-        const model = await listModel();
+        const model = await renderListModel();
         const initial = model.getNItems();
         const headers = schemaHeaderLabels();
         expect(headers.length).toBeGreaterThan(0);
@@ -117,8 +105,7 @@ describe("listviewSettings2Demo search and editing", () => {
     });
 
     it("clears the list model to zero when the search text matches no key", async () => {
-        await renderDemo(listviewSettings2Demo);
-        const model = await listModel();
+        const model = await renderListModel();
         const entry = await openSearchEntry();
         await userEvent.type(entry, "zzqxnomatchforanyschemaorkey");
 
@@ -130,8 +117,7 @@ describe("listviewSettings2Demo search and editing", () => {
 
 describe("listviewSettings2Demo search reset and editing", () => {
     it("restores the full list model when stop-search is emitted", async () => {
-        await renderDemo(listviewSettings2Demo);
-        const model = await listModel();
+        const model = await renderListModel();
         const initial = model.getNItems();
         const entry = await openSearchEntry();
         await userEvent.type(entry, "zzqxnomatchforanyschemaorkey");
@@ -149,7 +135,7 @@ describe("listviewSettings2Demo search reset and editing", () => {
 
     it("turns the search bar off when the search toggle is deactivated", async () => {
         await renderDemo(listviewSettings2Demo);
-        const { toggle, bar } = await activateSearch();
+        const { toggle, bar } = await activateSearchBar();
         await userEvent.click(toggle);
 
         await waitFor(() => {

--- a/examples/gtk-demo/tests/demos/lists/listview-ucd.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-ucd.test.tsx
@@ -4,6 +4,15 @@ import { describe, expect, it, vi } from "vitest";
 import { listviewUcdDemo } from "../../../src/demos/lists/listview-ucd.js";
 import { renderDemo } from "../../test-utils.js";
 
+const SCROLL_STEP = 200;
+const MAX_SCROLL_STEPS = 40;
+
+const scrollToGlyph = async (columnView: Gtk.ColumnView, glyph: string): Promise<void> => {
+    for (let step = 0; step < MAX_SCROLL_STEPS && screen.queryAllByText(glyph).length === 0; step++) {
+        await userEvent.scroll(columnView, { y: SCROLL_STEP });
+    }
+};
+
 const codepointCells = (): Gtk.Inscription[] =>
     screen.queryAllByText(/^0x[0-9a-f]{4,6}$/, { as: Gtk.Inscription });
 
@@ -67,7 +76,8 @@ describe("listviewUcdDemo column view", () => {
 
     it("renders the glyph for a printable character in the Char column", async () => {
         await renderDemo(listviewUcdDemo);
-        await screen.findByName("column-view");
+        const columnView = await screen.findByName("column-view", { as: Gtk.ColumnView });
+        await scrollToGlyph(columnView, "!");
         expect(await screen.findByText("!")).toHaveTextContent("!");
     });
 });

--- a/examples/gtk-demo/tests/demos/lists/listview-weather.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-weather.test.tsx
@@ -17,6 +17,12 @@ const WEATHER_ICON_NAMES = new Set([
     "weather-storm-symbolic",
 ]);
 
+const renderListView = async (): Promise<Gtk.ListView> => {
+    await renderDemo(listviewWeatherDemo);
+
+    return await screen.findByName("list-view", { as: Gtk.ListView });
+};
+
 describe("listviewWeatherDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(listviewWeatherDemo.id).toBe("listview-weather");
@@ -32,21 +38,18 @@ describe("listviewWeatherDemo metadata", () => {
 
 describe("listviewWeatherDemo list view", () => {
     it("renders a horizontal GtkListView with separators and no selection", async () => {
-        await renderDemo(listviewWeatherDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await renderListView();
         expect(lv).toHaveObjectProperty("orientation", Gtk.Orientation.HORIZONTAL);
         expect(lv).toHaveObjectProperty("showSeparators", true);
     });
 
     it("uses a no-selection model", async () => {
-        await renderDemo(listviewWeatherDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await renderListView();
         expect(lv.getModel()).toBeInstanceOf(Gtk.NoSelection);
     });
 
     it("keeps the selection empty when a cell is clicked", async () => {
-        await renderDemo(listviewWeatherDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await renderListView();
         const model = lv.getModel() as Gtk.SelectionModel;
         expect(Number(model.getSelection().getSize())).toBe(0);
         const cell = within(lv).getAllByRole(Gtk.AccessibleRole.LIST_ITEM)[0] as Gtk.Widget;
@@ -55,8 +58,7 @@ describe("listviewWeatherDemo list view", () => {
     });
 
     it("populates the list view with the full deterministic hourly dataset", async () => {
-        await renderDemo(listviewWeatherDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await renderListView();
         const model = lv.getModel() as Gtk.SelectionModel;
         expect(model).toHaveObjectProperty("nItems", EXPECTED_ITEM_COUNT);
     });
@@ -71,8 +73,7 @@ describe("listviewWeatherDemo cell content", () => {
     });
 
     it("maps each weather type to a known symbolic weather icon", async () => {
-        await renderDemo(listviewWeatherDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await renderListView();
         const images = within(lv).getAllByRole(Gtk.AccessibleRole.IMG, { as: Gtk.Image });
         expect(images.length).toBeGreaterThan(0);
 
@@ -83,8 +84,7 @@ describe("listviewWeatherDemo cell content", () => {
     });
 
     it("renders the first hour cell at midnight and temperature labels in materialized cells", async () => {
-        await renderDemo(listviewWeatherDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await renderListView();
         const hourLabels = within(lv).getAllByText(/^\d{2}:\d{2}$/, { as: Gtk.Label });
         const tempLabels = within(lv).getAllByText(/^-?\d+°$/);
         expect(hourLabels.map((label) => label.getText())).toContain("00:00");

--- a/examples/gtk-demo/tests/demos/lists/listview-words.test.tsx
+++ b/examples/gtk-demo/tests/demos/lists/listview-words.test.tsx
@@ -6,15 +6,20 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listviewWordsDemo } from "../../../src/demos/lists/listview-words.js";
-import { renderDemo } from "../../test-utils.js";
+import { findOpenButton, renderDemo } from "../../test-utils.js";
 
 const tempDirRef = { path: "" };
 
 async function renderDemoAndClickOpen() {
     await renderDemo(listviewWordsDemo);
-    const openButton = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Open", as: Gtk.Button });
+    const openButton = await findOpenButton();
     await userEvent.click(openButton);
 }
+
+const findListView = async (): Promise<Gtk.ListView> => await screen.findByName("list-view", { as: Gtk.ListView });
+
+const findSearchEntry = async (): Promise<Gtk.SearchEntry> =>
+    await screen.findByName("search-entry", { as: Gtk.SearchEntry });
 
 const wordsFile = (words: string[]): string => {
     const wordsPath = join(tempDirRef.path, "words.txt");
@@ -47,25 +52,25 @@ describe("listviewWordsDemo metadata", () => {
 describe("listviewWordsDemo layout", () => {
     it("installs a header bar with an Open button", async () => {
         await renderDemo(listviewWordsDemo);
-        const openButton = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Open", as: Gtk.Button });
+        const openButton = await findOpenButton();
         expect(openButton).toHaveObjectProperty("useUnderline", true);
     });
 
     it("renders a GtkSearchEntry with the configured placeholder", async () => {
         await renderDemo(listviewWordsDemo);
         const entry = await screen.findByPlaceholderText("Search words...");
-        expect(entry).toHavePlaceholderText("Search words...");
+        expect(entry).toBeInstanceOf(Gtk.SearchEntry);
     });
 
     it("renders a GtkListView with NONE selection", async () => {
         await renderDemo(listviewWordsDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await findListView();
         expect(lv.getModel()).toBeInstanceOf(Gtk.NoSelection);
     });
 
     it("populates the list view from the loaded word list", async () => {
         await renderDemo(listviewWordsDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+        const lv = await findListView();
         expect((lv.getModel() as Gtk.SelectionModel).getNItems()).toBeGreaterThan(0);
     });
 
@@ -79,7 +84,7 @@ describe("listviewWordsDemo layout", () => {
 describe("listviewWordsDemo search interactions", () => {
     it("updates the search entry text when text is typed", async () => {
         await renderDemo(listviewWordsDemo);
-        const entry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+        const entry = await findSearchEntry();
         await userEvent.type(entry, "lorem");
         expect(await screen.findByDisplayValue("lorem")).toBe(entry);
     });
@@ -91,7 +96,7 @@ describe("listviewWordsDemo search interactions", () => {
 
         try {
             await renderDemoAndClickOpen();
-            const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+            const lv = await findListView();
 
             await waitFor(() => {
                 expect(lv.getModel()).toHaveObjectProperty("nItems", 4);
@@ -101,7 +106,7 @@ describe("listviewWordsDemo search interactions", () => {
                 await screen.findByText(word);
             }
 
-            const entry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+            const entry = await findSearchEntry();
             await userEvent.type(entry, "gamma");
 
             await waitFor(() => {
@@ -119,8 +124,8 @@ describe("listviewWordsDemo search interactions", () => {
 describe("listviewWordsDemo search filtering", () => {
     it("filters the list view to zero matches when the search text matches nothing", async () => {
         await renderDemo(listviewWordsDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
-        const entry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+        const lv = await findListView();
+        const entry = await findSearchEntry();
         await userEvent.type(entry, "qqqzzz");
 
         await waitFor(() => {
@@ -130,7 +135,7 @@ describe("listviewWordsDemo search filtering", () => {
 
     it("clears the search entry when cleared", async () => {
         await renderDemo(listviewWordsDemo);
-        const entry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+        const entry = await findSearchEntry();
         await userEvent.type(entry, "abc");
         await userEvent.clear(entry);
         expect(screen.queryByDisplayValue("abc")).toBeNull();
@@ -138,8 +143,8 @@ describe("listviewWordsDemo search filtering", () => {
 
     it("restores the full word count when the search entry is cleared after filtering", async () => {
         await renderDemo(listviewWordsDemo);
-        const lv = await screen.findByName("list-view", { as: Gtk.ListView });
-        const entry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+        const lv = await findListView();
+        const entry = await findSearchEntry();
         const initial = (lv.getModel() as Gtk.SelectionModel).getNItems();
         await userEvent.type(entry, "z");
 
@@ -169,14 +174,14 @@ describe("listviewWordsDemo Open button", () => {
                 expect(dialogSpy).toHaveBeenCalled();
             });
 
-            const lv = await screen.findByName("list-view", { as: Gtk.ListView });
+            const lv = await findListView();
 
             await waitFor(() => {
                 expect(lv.getModel()).toHaveObjectProperty("nItems", 4);
             });
 
             await screen.findByRole(Gtk.AccessibleRole.WINDOW, { name: "4 lines" });
-            const entry = await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+            const entry = await findSearchEntry();
             await userEvent.type(entry, "gamma");
 
             await waitFor(() => {

--- a/examples/gtk-demo/tests/demos/media/video-player.test.tsx
+++ b/examples/gtk-demo/tests/demos/media/video-player.test.tsx
@@ -3,11 +3,21 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { act, screen, userEvent, waitFor } from "@gtkx/testing";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, type MockInstance, vi } from "vitest";
 import { videoPlayerDemo } from "../../../src/demos/media/video-player.js";
 import { findOpenButton, renderDemo } from "../../test-utils.js";
 
+type SetFileSpy = MockInstance<Gtk.Video["setFile"]>;
+
 const FAKE_VIDEO_PATH = join(tmpdir(), "fake-video.webm");
+
+const findAppliedFile = async (fileSpy: SetFileSpy): Promise<Gio.File> => {
+    await waitFor(() => {
+        expect(fileSpy).toHaveBeenCalled();
+    });
+
+    return fileSpy.mock.calls.at(-1)?.[0] as Gio.File;
+};
 
 const renderAndClickOpenButton = async (): Promise<void> => {
     await renderDemo(videoPlayerDemo);
@@ -113,12 +123,7 @@ describe("videoPlayerDemo video and actions", () => {
             await renderDemo(videoPlayerDemo);
             const logoButton = await screen.findByName("logo-button", { as: Gtk.Button });
             await userEvent.click(logoButton);
-
-            await waitFor(() => {
-                expect(setFileSpy).toHaveBeenCalled();
-            });
-
-            const file = setFileSpy.mock.calls.at(-1)?.[0] as Gio.File;
+            const file = await findAppliedFile(setFileSpy);
             expect(file.getUri()).toMatch(/gtk-logo\.webm$/);
         } finally {
             setFileSpy.mockRestore();
@@ -151,12 +156,7 @@ describe("videoPlayerDemo remote media", () => {
             await renderDemo(videoPlayerDemo);
             const bbbButton = await screen.findByName("bbb-button", { as: Gtk.Button });
             await userEvent.click(bbbButton);
-
-            await waitFor(() => {
-                expect(setFileSpy).toHaveBeenCalled();
-            });
-
-            const file = setFileSpy.mock.calls.at(-1)?.[0] as Gio.File;
+            const file = await findAppliedFile(setFileSpy);
             expect(file.getUri()).toBe("https://download.blender.org/peach/trailer/trailer_400p.ogg");
         } finally {
             setFileSpy.mockRestore();
@@ -178,11 +178,7 @@ describe("videoPlayerDemo open dialog", () => {
                 expect(openSpy).toHaveBeenCalled();
             });
 
-            await waitFor(() => {
-                expect(setFileSpy).toHaveBeenCalled();
-            });
-
-            const file = setFileSpy.mock.calls.at(-1)?.[0] as Gio.File;
+            const file = await findAppliedFile(setFileSpy);
             expect(file.getPath()).toBe(FAKE_VIDEO_PATH);
         } finally {
             openSpy.mockRestore();

--- a/examples/gtk-demo/tests/demos/navigation/revealer.test.tsx
+++ b/examples/gtk-demo/tests/demos/navigation/revealer.test.tsx
@@ -2,7 +2,7 @@ import * as Gtk from "@gtkx/gi/gtk";
 import { act, screen, waitFor } from "@gtkx/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { revealerDemo } from "../../../src/demos/navigation/revealer.js";
-import { renderDemo } from "../../test-utils.js";
+import { collectWidgets, renderDemo } from "../../test-utils.js";
 
 const REVEALER_COUNT = 9;
 
@@ -40,18 +40,6 @@ const findAllRevealers = async (): Promise<Gtk.Revealer[]> => {
     return revealers;
 };
 
-const collectGridRevealers = (grid: Gtk.Grid): Gtk.Revealer[] => {
-    const revealers: Gtk.Revealer[] = [];
-
-    for (let child = grid.getFirstChild(); child; child = child.getNextSibling()) {
-        if (child instanceof Gtk.Revealer) {
-            revealers.push(child);
-        }
-    }
-
-    return revealers;
-};
-
 describe("revealerDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(revealerDemo.id).toBe("revealer");
@@ -68,7 +56,7 @@ describe("revealerDemo structure", () => {
     it("renders exactly nine GtkRevealer widgets initially hidden", async () => {
         await renderDemo(revealerDemo);
         const grid = await screen.findByName("revealer-grid", { as: Gtk.Grid });
-        const revealers = collectGridRevealers(grid);
+        const revealers = collectWidgets(grid, Gtk.Revealer);
         expect(revealers).toHaveLength(REVEALER_COUNT);
         expect(revealers.some((revealer) => revealer.getRevealChild())).toBe(false);
         expect(revealers.every((revealer) => revealer.getTransitionDuration() === 2000)).toBe(true);
@@ -78,15 +66,6 @@ describe("revealerDemo structure", () => {
         await renderDemo(revealerDemo);
         const revealers = await findAllRevealers();
         expect(revealers.map((revealer) => revealer.getTransitionType())).toEqual(EXPECTED_TRANSITIONS);
-    });
-
-    it("places each revealer's child as a GtkImage with the cool-face icon", async () => {
-        await renderDemo(revealerDemo);
-        const images = await screen.findAllByRole(Gtk.AccessibleRole.IMG, { as: Gtk.Image });
-        expect(images).toHaveLength(REVEALER_COUNT);
-        expect(images.every((image) => image instanceof Gtk.Image)).toBe(true);
-        const iconNames = images.map((image) => image.getIconName());
-        expect(iconNames.every((name) => name === "face-cool-symbolic")).toBe(true);
     });
 
     it("places each revealer at its configured grid cell forming the cross layout", async () => {
@@ -105,6 +84,21 @@ describe("revealerDemo reveal sequence", () => {
 
     afterEach(() => {
         vi.useRealTimers();
+    });
+
+    it("shows each revealer's child as a GtkImage with the cool-face icon once it is revealed", async () => {
+        await renderDemo(revealerDemo);
+        expect(screen.queryAllByRole(Gtk.AccessibleRole.IMG)).toHaveLength(0);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(690 * 9);
+        });
+
+        const images = await screen.findAllByRole(Gtk.AccessibleRole.IMG, { as: Gtk.Image });
+        expect(images).toHaveLength(REVEALER_COUNT);
+        expect(images.every((image) => image instanceof Gtk.Image)).toBe(true);
+        const iconNames = images.map((image) => image.getIconName());
+        expect(iconNames.every((name) => name === "face-cool-symbolic")).toBe(true);
     });
 
     it("reveals every revealer after nine timer ticks", async () => {

--- a/examples/gtk-demo/tests/demos/navigation/sidebar.test.tsx
+++ b/examples/gtk-demo/tests/demos/navigation/sidebar.test.tsx
@@ -19,6 +19,18 @@ const PAGE_TITLES = [
 const findStack = async (): Promise<Gtk.Stack> => screen.findByName("stack", { as: Gtk.Stack });
 const findSidebar = async (): Promise<Gtk.StackSidebar> => screen.findByName("sidebar", { as: Gtk.StackSidebar });
 
+const renderSidebarAndStack = async (): Promise<{ sidebar: Gtk.StackSidebar; stack: Gtk.Stack }> => {
+    await renderDemo(sidebarDemo);
+    const sidebar = await findSidebar();
+    const stack = await findStack();
+
+    return { sidebar, stack };
+};
+
+const clickPageRow = async (sidebar: Gtk.StackSidebar, name: string): Promise<void> => {
+    await userEvent.click(within(sidebar).getByRole(Gtk.AccessibleRole.LIST_ITEM, { name }));
+};
+
 describe("sidebarDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(sidebarDemo.id).toBe("sidebar");
@@ -41,9 +53,7 @@ describe("sidebarDemo structure", () => {
     });
 
     it("binds the GtkStackSidebar to the stack", async () => {
-        await renderDemo(sidebarDemo);
-        const sidebar = await findSidebar();
-        const stack = await findStack();
+        const { sidebar, stack } = await renderSidebarAndStack();
         expect(sidebar).toHaveObjectProperty("stack", stack);
     });
 
@@ -63,8 +73,9 @@ describe("sidebarDemo structure", () => {
     });
 
     it("uses a plain GtkLabel for non-welcome pages", async () => {
-        await renderDemo(sidebarDemo);
-        const stack = await findStack();
+        const { sidebar, stack } = await renderSidebarAndStack();
+        expect(within(stack).queryByRole(Gtk.AccessibleRole.LABEL, { name: "Scrolling" })).toBeNull();
+        await clickPageRow(sidebar, "Scrolling");
         const label = await within(stack).findByRole(Gtk.AccessibleRole.LABEL, { name: "Scrolling" });
         expect(label).toBeInstanceOf(Gtk.Label);
     });
@@ -72,25 +83,23 @@ describe("sidebarDemo structure", () => {
 
 describe("sidebarDemo navigation", () => {
     it("switches the stack to the page whose sidebar row is activated", async () => {
-        await renderDemo(sidebarDemo);
-        const sidebar = await findSidebar();
-        const stack = await findStack();
+        const { sidebar, stack } = await renderSidebarAndStack();
         expect(stack).toHaveObjectProperty("visibleChildName", "Welcome to GTK");
         within(sidebar).getByRole(Gtk.AccessibleRole.LIST_ITEM, { name: "Welcome to GTK", selected: true });
-        await userEvent.click(within(sidebar).getByRole(Gtk.AccessibleRole.LIST_ITEM, { name: "Scrolling" }));
+        await clickPageRow(sidebar, "Scrolling");
 
         await waitFor(() => {
             expect(stack).toHaveObjectProperty("visibleChildName", "Scrolling");
         });
 
         within(sidebar).getByRole(Gtk.AccessibleRole.LIST_ITEM, { name: "Scrolling", selected: true });
-        await userEvent.click(within(sidebar).getByRole(Gtk.AccessibleRole.LIST_ITEM, { name: "Page 9" }));
+        await clickPageRow(sidebar, "Page 9");
 
         await waitFor(() => {
             expect(stack).toHaveObjectProperty("visibleChildName", "Page 9");
         });
 
-        await userEvent.click(within(sidebar).getByRole(Gtk.AccessibleRole.LIST_ITEM, { name: "Welcome to GTK" }));
+        await clickPageRow(sidebar, "Welcome to GTK");
 
         await waitFor(() => {
             expect(stack).toHaveObjectProperty("visibleChildName", "Welcome to GTK");

--- a/examples/gtk-demo/tests/demos/navigation/stack.test.tsx
+++ b/examples/gtk-demo/tests/demos/navigation/stack.test.tsx
@@ -6,6 +6,16 @@ import { renderDemo } from "../../test-utils.js";
 
 const findStack = async (): Promise<Gtk.Stack> => screen.findByName("stack", { as: Gtk.Stack });
 
+const renderStack = async (): Promise<Gtk.Stack> => {
+    await renderDemo(stackDemo);
+
+    return await findStack();
+};
+
+const clickTab = async (name: string): Promise<void> => {
+    await userEvent.click(await screen.findByRole(Gtk.AccessibleRole.TAB, { name }));
+};
+
 describe("stackDemo metadata", () => {
     it("exposes the expected metadata", () => {
         expect(stackDemo.id).toBe("stack");
@@ -31,16 +41,14 @@ describe("stackDemo structure", () => {
     });
 
     it("uses crossfade as the stack transition", async () => {
-        await renderDemo(stackDemo);
-        const stack = await findStack();
+        const stack = await renderStack();
         expect(stack).toHaveObjectProperty("transitionType", Gtk.StackTransitionType.CROSSFADE);
     });
 });
 
 describe("stackDemo pages", () => {
     it("declares pages with the expected titles and ids", async () => {
-        await renderDemo(stackDemo);
-        const stack = await findStack();
+        const stack = await renderStack();
         const page1Child = stack.getChildByName("page1");
         const page2Child = stack.getChildByName("page2");
         const page3Child = stack.getChildByName("page3");
@@ -58,8 +66,9 @@ describe("stackDemo pages", () => {
     });
 
     it("renders the Page 2 check button inside the stack", async () => {
-        await renderDemo(stackDemo);
-        const stack = await findStack();
+        const stack = await renderStack();
+        expect(within(stack).queryByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Page 2" })).toBeNull();
+        await clickTab("Page 2");
         const checkButton = await within(stack).findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Page 2" });
         expect(checkButton).toBeInstanceOf(Gtk.CheckButton);
     });
@@ -67,15 +76,13 @@ describe("stackDemo pages", () => {
 
 describe("stackDemo switching", () => {
     it("starts with the first page visible", async () => {
-        await renderDemo(stackDemo);
-        const stack = await findStack();
+        const stack = await renderStack();
         expect(stack).toHaveObjectProperty("visibleChildName", "page1");
     });
 
     it("changes the visible page when a different switcher tab is clicked", async () => {
-        await renderDemo(stackDemo);
-        const stack = await findStack();
-        await userEvent.click(await screen.findByRole(Gtk.AccessibleRole.TAB, { name: "Page 2" }));
+        const stack = await renderStack();
+        await clickTab("Page 2");
 
         await waitFor(() => {
             expect(stack).toHaveObjectProperty("visibleChildName", "page2");
@@ -103,15 +110,14 @@ describe("stackDemo switching", () => {
 
 describe("stackDemo page interaction", () => {
     it("returns to the first page when the Page 1 tab is clicked", async () => {
-        await renderDemo(stackDemo);
-        const stack = await findStack();
-        await userEvent.click(await screen.findByRole(Gtk.AccessibleRole.TAB, { name: "Page 2" }));
+        const stack = await renderStack();
+        await clickTab("Page 2");
 
         await waitFor(() => {
             expect(stack).toHaveObjectProperty("visibleChildName", "page2");
         });
 
-        await userEvent.click(await screen.findByRole(Gtk.AccessibleRole.TAB, { name: "Page 1" }));
+        await clickTab("Page 1");
 
         await waitFor(() => {
             expect(stack).toHaveObjectProperty("visibleChildName", "page1");
@@ -121,9 +127,8 @@ describe("stackDemo page interaction", () => {
     });
 
     it("activates the Page 2 check button via userEvent.click", async () => {
-        await renderDemo(stackDemo);
-        const stack = await findStack();
-        await userEvent.click(await screen.findByRole(Gtk.AccessibleRole.TAB, { name: "Page 2" }));
+        const stack = await renderStack();
+        await clickTab("Page 2");
         const checkButton = await within(stack).findByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Page 2" });
         expect(within(stack).queryByRole(Gtk.AccessibleRole.CHECKBOX, { name: "Page 2", checked: true })).toBeNull();
         await userEvent.click(checkButton);

--- a/examples/gtk-demo/tests/demos/opengl/gears.test.tsx
+++ b/examples/gtk-demo/tests/demos/opengl/gears.test.tsx
@@ -1,3 +1,4 @@
+import * as Gdk from "@gtkx/gi/gdk";
 import * as Gtk from "@gtkx/gi/gtk";
 import { screen, userEvent, waitFor } from "@gtkx/testing";
 import { describe, expect, it } from "vitest";
@@ -20,7 +21,7 @@ describe("gearsDemo", () => {
     it("renders a GtkGLArea configured with an ES context and a depth buffer", async () => {
         await renderDemo(gearsDemo);
         const glArea = await screen.findByName("gl-area", { as: Gtk.GLArea });
-        expect(glArea).toHaveObjectProperty("useEs", true);
+        expect(glArea).toHaveObjectProperty("allowedApis", Gdk.GLAPI.GLES);
         expect(glArea).toHaveObjectProperty("hasDepthBuffer", true);
     });
 

--- a/examples/gtk-demo/tests/demos/opengl/shadertoy.test.tsx
+++ b/examples/gtk-demo/tests/demos/opengl/shadertoy.test.tsx
@@ -1,3 +1,4 @@
+import * as Gdk from "@gtkx/gi/gdk";
 import * as Gtk from "@gtkx/gi/gtk";
 import { screen, userEvent, waitFor } from "@gtkx/testing";
 import { describe, expect, it, vi } from "vitest";
@@ -6,9 +7,17 @@ import { renderDemo } from "../../test-utils.js";
 
 const PRESET_NAMES = ["Alien Planet", "Mandelbrot", "Neon", "Cogs", "Glowing Stars"];
 
+const findButton = async (name: string): Promise<Gtk.Button> =>
+    screen.findByRole(Gtk.AccessibleRole.BUTTON, { name, as: Gtk.Button });
+
 const clickPreset = async (name: string): Promise<void> => {
-    const button = await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name, as: Gtk.Button });
-    await userEvent.click(button);
+    await userEvent.click(await findButton(name));
+};
+
+const renderAndFindSourceView = async (): Promise<Gtk.TextView> => {
+    await renderDemo(shadertoyDemo);
+
+    return screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
 };
 
 vi.setConfig({ testTimeout: 30_000 });
@@ -29,15 +38,14 @@ describe("shadertoyDemo", () => {
         const glArea = await screen.findByName("shadertoy-gl-area", { as: Gtk.GLArea });
 
         await waitFor(() => {
-            expect(glArea.getAllocatedWidth()).toBeGreaterThan(0);
+            expect(glArea.getWidth()).toBeGreaterThan(0);
         });
 
-        expect(glArea).toHaveObjectProperty("useEs", true);
+        expect(glArea).toHaveObjectProperty("allowedApis", Gdk.GLAPI.GLES);
     });
 
     it("seeds the source editor with the Alien Planet fragment shader", async () => {
-        await renderDemo(shadertoyDemo);
-        const sourceView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX);
+        const sourceView = await renderAndFindSourceView();
         expect(await screen.findByDisplayValue(/MAX_DISTANCE/)).toBe(sourceView);
         expect(sourceView).toHaveDisplayValue(/mountainColor/);
         expect(sourceView).toHaveDisplayValue(/void mainImage/);
@@ -47,32 +55,19 @@ describe("shadertoyDemo", () => {
 describe("shadertoyDemo shader presets", () => {
     it("exposes Restart, Clear, and one button per shader preset", async () => {
         await renderDemo(shadertoyDemo);
-
-        expect(await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Restart the demo" })).toBeInstanceOf(
-            Gtk.Button,
-        );
-
-        expect(await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Clear the text view" })).toBeInstanceOf(
-            Gtk.Button,
-        );
+        expect(await findButton("Restart the demo")).toBeInstanceOf(Gtk.Button);
+        expect(await findButton("Clear the text view")).toBeInstanceOf(Gtk.Button);
 
         for (const presetName of PRESET_NAMES) {
-            expect(await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: presetName })).toBeInstanceOf(Gtk.Button);
+            expect(await findButton(presetName)).toBeInstanceOf(Gtk.Button);
         }
     });
 });
 
 describe("shadertoyDemo editor", () => {
     it("clears the editor buffer when the Clear button is activated", async () => {
-        await renderDemo(shadertoyDemo);
-        expect(await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX)).toHaveDisplayValue(/void mainImage/);
-
-        const clear = await screen.findByRole(Gtk.AccessibleRole.BUTTON, {
-            name: "Clear the text view",
-            as: Gtk.Button,
-        });
-
-        await userEvent.click(clear);
+        expect(await renderAndFindSourceView()).toHaveDisplayValue(/void mainImage/);
+        await userEvent.click(await findButton("Clear the text view"));
 
         await waitFor(() => {
             expect(screen.queryByDisplayValue(/.+/)).toBeNull();
@@ -80,8 +75,7 @@ describe("shadertoyDemo editor", () => {
     });
 
     it("loads each preset shader into the buffer when its button is activated", async () => {
-        await renderDemo(shadertoyDemo);
-        await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX);
+        await renderAndFindSourceView();
         await screen.findByDisplayValue(/MAX_DISTANCE/);
         await clickPreset("Mandelbrot");
         await screen.findByDisplayValue(/MANDELBROT_ITER/);
@@ -101,8 +95,7 @@ describe("shadertoyDemo editor", () => {
     });
 
     it("propagates user edits to the buffer", async () => {
-        await renderDemo(shadertoyDemo);
-        const sourceView = await screen.findByRole(Gtk.AccessibleRole.TEXT_BOX, { as: Gtk.TextView });
+        const sourceView = await renderAndFindSourceView();
         await userEvent.clear(sourceView);
         await userEvent.type(sourceView, "// custom shader");
         expect(await screen.findByDisplayValue("// custom shader")).toBe(sourceView);

--- a/examples/gtk-demo/tests/render-app.tsx
+++ b/examples/gtk-demo/tests/render-app.tsx
@@ -1,0 +1,20 @@
+import * as Gio from "@gtkx/gi/gio";
+import { GtkApplication } from "@gtkx/jsx/gtk";
+import { rootElement } from "@gtkx/react";
+import { render, type RenderResult } from "@gtkx/testing";
+import { Demo } from "../src/app.js";
+import { createApplicationIdFactory } from "./test-utils.js";
+
+const createAppRenderer = (prefix: string): () => Promise<RenderResult> => {
+    const nextApplicationId = createApplicationIdFactory(prefix);
+
+    return async () =>
+        await render(
+            <GtkApplication applicationId={nextApplicationId()} flags={Gio.ApplicationFlags.NON_UNIQUE}>
+                <Demo />
+            </GtkApplication>,
+            { container: rootElement },
+        );
+};
+
+export { createAppRenderer };

--- a/examples/gtk-demo/tests/smoke.test.tsx
+++ b/examples/gtk-demo/tests/smoke.test.tsx
@@ -1,13 +1,10 @@
-import * as Gio from "@gtkx/gi/gio";
 import * as Gtk from "@gtkx/gi/gtk";
-import { GtkApplication } from "@gtkx/jsx/gtk";
-import { rootElement } from "@gtkx/react";
-import { configure, fireEvent, render, screen, userEvent, waitFor, within } from "@gtkx/testing";
+import { configure, fireEvent, screen, userEvent, waitFor, within } from "@gtkx/testing";
 import { afterEach, beforeAll, describe, expect, it, type MockInstance, vi } from "vitest";
-import { Demo } from "../src/app.js";
 import { parseTitle } from "../src/context/demo-context.js";
 import { demos } from "../src/demos/index.js";
-import { createApplicationIdFactory } from "./test-utils.js";
+import { createAppRenderer } from "./render-app.js";
+import { findWidget } from "./test-utils.js";
 
 type PrintOperationRunSpy = MockInstance<Gtk.PrintOperation["run"]>;
 
@@ -29,15 +26,7 @@ type DemoSweep = {
     tally: DemoTally;
 };
 
-const nextApplicationId = createApplicationIdFactory("org.gtkx.gtkdemoe2e");
-
-const renderApp = () =>
-    render(
-        <GtkApplication applicationId={nextApplicationId()} flags={Gio.ApplicationFlags.NON_UNIQUE}>
-            <Demo />
-        </GtkApplication>,
-        { container: rootElement },
-    );
+const renderApp = createAppRenderer("org.gtkx.gtkdemoe2e");
 
 const toplevelWindows = async (): Promise<Gtk.Window[]> =>
     await screen.findAllByRole(Gtk.AccessibleRole.WINDOW, { as: Gtk.Window });
@@ -55,26 +44,6 @@ const requireOnlyDemoWindow = (windows: Gtk.Window[], title: string): Gtk.Window
     }
 
     return win;
-};
-
-const firstMatching = (root: Gtk.Widget, isMatch: (w: Gtk.Widget) => boolean): Gtk.Widget | null => {
-    if (isMatch(root)) {
-        return root;
-    }
-
-    let child = root.getFirstChild();
-
-    while (child) {
-        const found = firstMatching(child, isMatch);
-
-        if (found) {
-            return found;
-        }
-
-        child = child.getNextSibling();
-    }
-
-    return null;
 };
 
 const getActionName = (widget: Gtk.Widget): string | null => {
@@ -106,7 +75,7 @@ const closeDemoWindow = async (window: Gtk.Window): Promise<void> => {
         return;
     }
 
-    const closeButton = firstMatching(window, (w) => getActionName(w) === "window.close");
+    const closeButton = findWidget(window, Gtk.Widget, (w) => getActionName(w) === "window.close");
 
     if (closeButton) {
         await userEvent.click(closeButton);
@@ -118,7 +87,7 @@ const closeDemoWindow = async (window: Gtk.Window): Promise<void> => {
 };
 
 const dismissDialog = async (dialog: Gtk.Widget): Promise<void> => {
-    const close = firstMatching(dialog, (w) => w.getCssClasses().includes("close"));
+    const close = findWidget(dialog, Gtk.Widget, (w) => w.getCssClasses().includes("close"));
 
     if (!close) {
         throw new Error("dialog has no close button");

--- a/examples/gtk-demo/tests/test-utils.tsx
+++ b/examples/gtk-demo/tests/test-utils.tsx
@@ -4,18 +4,14 @@ import * as GObject from "@gtkx/gi/gobject";
 import * as Gtk from "@gtkx/gi/gtk";
 import { GtkApplication, GtkApplicationWindow } from "@gtkx/jsx/gtk";
 import { rootElement } from "@gtkx/react";
-import { render, type RenderResult, screen } from "@gtkx/testing";
+import { render, type RenderResult, screen, userEvent, waitFor, type WidgetType } from "@gtkx/testing";
 import { type ComponentType, createRef, type ReactNode, type RefObject, useCallback, useState } from "react";
 import { expect, vi } from "vitest";
 import type { Demo, DemoProps, DemoProviderProps } from "../src/demos/types.js";
 import { DemoProvider, useDemo } from "../src/context/demo-context.js";
 
-type ComponentOrDemo = ComponentType<DemoProps> | Demo;
-
 type RenderDemoOptions = {
     onClose?: () => void;
-    titlebar?: ComponentType<DemoProps>;
-    provider?: ComponentType<DemoProviderProps>;
 };
 
 type WrapperArgs = {
@@ -23,7 +19,7 @@ type WrapperArgs = {
     onClose: () => void;
     Provider: ComponentType<DemoProviderProps>;
     Titlebar: ComponentType<DemoProps> | undefined;
-    demo: Demo | undefined;
+    demo: Demo;
 };
 
 type DemoShellProps = WrapperArgs & {
@@ -66,12 +62,18 @@ const makeIntValue = (n: number): GObject.Value => {
     return value;
 };
 
-const makeRgbaValue = (r: number, g: number, b: number, a: number): GObject.Value => {
+const makeRgba = (r: number, g: number, b: number, a: number): Gdk.RGBA => {
     const rgba = new Gdk.RGBA();
     rgba.red = r;
     rgba.green = g;
     rgba.blue = b;
     rgba.alpha = a;
+
+    return rgba;
+};
+
+const makeRgbaValue = (r: number, g: number, b: number, a: number): GObject.Value => {
+    const rgba = makeRgba(r, g, b, a);
     const value = new GObject.Value();
     value.init(GObject.typeFromName("GdkRGBA"));
     value.setBoxed(rgba);
@@ -88,23 +90,52 @@ const makeFileValue = (path: string): GObject.Value => {
     return value;
 };
 
-const isDemo = (value: ComponentOrDemo): value is Demo => typeof value === "object" && "id" in value;
 const PassthroughProvider: ComponentType<DemoProviderProps> = ({ children }) => children;
+
+const findWidget = <T extends Gtk.Widget>(
+    root: Gtk.Widget,
+    as: WidgetType<T>,
+    isMatch: (candidate: T) => boolean = () => true,
+): T | null => {
+    if (root instanceof as && isMatch(root)) {
+        return root;
+    }
+
+    for (let child = root.getFirstChild(); child; child = child.getNextSibling()) {
+        const found = findWidget(child, as, isMatch);
+
+        if (found) {
+            return found;
+        }
+    }
+
+    return null;
+};
+
+const collectWidgets = <T extends Gtk.Widget>(root: Gtk.Widget, as: WidgetType<T>): T[] => {
+    const found: T[] = root instanceof as ? [root] : [];
+
+    for (let child = root.getFirstChild(); child; child = child.getNextSibling()) {
+        found.push(...collectWidgets(child, as));
+    }
+
+    return found;
+};
 
 function assignWindowRef(windowRef: RefObject<Gtk.Window | null>, widget: Gtk.Widget | null): void {
     (windowRef as { current: Gtk.Window | null }).current = (widget as Gtk.Window | null) ?? null;
 }
 
-function demoShellTitle(demo: Demo | undefined, windowTitle: string | null): string | undefined {
-    return windowTitle ?? demo?.windowTitle;
+function demoShellTitle(demo: Demo, windowTitle: string | null): string | undefined {
+    return windowTitle ?? demo.windowTitle;
 }
 
-function demoShellSizing(demo: Demo | undefined): DemoShellSizing {
+function demoShellSizing(demo: Demo): DemoShellSizing {
     return {
-        defaultWidth: demo?.defaultWidth ?? 800,
-        defaultHeight: demo?.defaultHeight ?? 600,
-        isResizable: demo?.isResizable ?? true,
-        isDeletable: demo?.isDeletable ?? true,
+        defaultWidth: demo.defaultWidth ?? 800,
+        defaultHeight: demo.defaultHeight ?? 600,
+        isResizable: demo.isResizable ?? true,
+        isDeletable: demo.isDeletable ?? true,
     };
 }
 
@@ -136,7 +167,7 @@ const DemoShell = ({ windowRef, onClose, Provider, Titlebar, demo, children }: D
                     defaultHeight={sizing.defaultHeight}
                     resizable={sizing.isResizable}
                     deletable={sizing.isDeletable}
-                    cssClasses={demo?.windowCssClasses}
+                    cssClasses={demo.windowCssClasses}
                     defaultWidget={defaultWidget}
                     titlebar={titlebar}
                 >
@@ -148,7 +179,7 @@ const DemoShell = ({ windowRef, onClose, Provider, Titlebar, demo, children }: D
 };
 
 const buildWrapper = (args: WrapperArgs): ComponentType<{ children: ReactNode }> => ({ children }) => (
-    <DemoProvider demos={args.demo ? [args.demo] : []}>
+    <DemoProvider demos={[args.demo]}>
         <DemoShell
             windowRef={args.windowRef}
             onClose={args.onClose}
@@ -161,46 +192,20 @@ const buildWrapper = (args: WrapperArgs): ComponentType<{ children: ReactNode }>
     </DemoProvider>
 );
 
-function resolveDemo(componentOrDemo: ComponentOrDemo): Demo | undefined {
-    return isDemo(componentOrDemo) ? componentOrDemo : undefined;
-}
-
-function resolveComponent(componentOrDemo: ComponentOrDemo): ComponentType<DemoProps> | undefined {
-    return isDemo(componentOrDemo) ? componentOrDemo.component : componentOrDemo;
-}
-
-function resolveTitlebar(
-    componentOrDemo: ComponentOrDemo,
-    options: RenderDemoOptions,
-): ComponentType<DemoProps> | undefined {
-    return options.titlebar ?? resolveDemo(componentOrDemo)?.titlebar;
-}
-
-function resolveProvider(
-    componentOrDemo: ComponentOrDemo,
-    options: RenderDemoOptions,
-): ComponentType<DemoProviderProps> {
-    return options.provider ?? resolveDemo(componentOrDemo)?.provider ?? PassthroughProvider;
-}
-
-const renderDemo = async (
-    componentOrDemo: ComponentOrDemo,
-    options: RenderDemoOptions = {},
-): Promise<RenderResult> => {
+const renderDemo = async (demo: Demo, options: RenderDemoOptions = {}): Promise<RenderResult> => {
     const windowRef = createRef<Gtk.Window | null>();
     const onClose = options.onClose ?? vi.fn();
-    const Component = resolveComponent(componentOrDemo);
-    expect(Component, "renderDemo: demo has no component").toBeTypeOf("function");
-    const ResolvedComponent = Component as ComponentType<DemoProps>;
+    expect(demo.component, "renderDemo: demo has no component").toBeTypeOf("function");
+    const ResolvedComponent = demo.component as ComponentType<DemoProps>;
 
     return await render(<ResolvedComponent window={windowRef} onClose={onClose} />, {
         container: rootElement,
         wrapper: buildWrapper({
             windowRef,
             onClose,
-            Provider: resolveProvider(componentOrDemo, options),
-            Titlebar: resolveTitlebar(componentOrDemo, options),
-            demo: resolveDemo(componentOrDemo),
+            Provider: demo.provider ?? PassthroughProvider,
+            Titlebar: demo.titlebar,
+            demo,
         }),
     });
 };
@@ -214,7 +219,7 @@ const findInactiveSearchToggle = async (): Promise<Gtk.ToggleButton> => {
 };
 
 const findOpenButton = async (): Promise<Gtk.Button> =>
-    await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "_Open", as: Gtk.Button });
+    await screen.findByRole(Gtk.AccessibleRole.BUTTON, { name: "Open", as: Gtk.Button });
 
 const readBufferText = (view: Gtk.TextView): string => {
     const buffer = view.getBuffer();
@@ -241,6 +246,57 @@ const hasBufferTag = (view: Gtk.TextView, tagName: string): boolean => {
     return false;
 };
 
+const findCssLoadedOnMount = async (demo: Demo, needle: string): Promise<string | undefined> => {
+    const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
+
+    try {
+        await renderDemo(demo);
+
+        return loadSpy.mock.calls
+            .map(([css]) => css)
+            .find((css) => typeof css === "string" && css.includes(needle));
+    } finally {
+        loadSpy.mockRestore();
+    }
+};
+
+const expectCssReloadedOnEdit = async (demo: Demo, edit: string, needle: string): Promise<void> => {
+    const loadSpy = vi.spyOn(Gtk.CssProvider.prototype, "loadFromString");
+
+    try {
+        await renderDemo(demo);
+        const textView = await screen.findByName("text-view", { as: Gtk.TextView });
+        loadSpy.mockClear();
+        await userEvent.clear(textView);
+        await userEvent.type(textView, edit);
+
+        await waitFor(() => {
+            const loaded = loadSpy.mock.calls.find(([css]) => typeof css === "string" && css.includes(needle));
+            expect(loaded, "expected the buffer edit to be loaded into a CssProvider").toBeDefined();
+        });
+    } finally {
+        loadSpy.mockRestore();
+    }
+};
+
+const activateSearchBar = async (): Promise<{ toggle: Gtk.ToggleButton; bar: Gtk.SearchBar }> => {
+    const toggle = await screen.findByName("search-toggle", { as: Gtk.ToggleButton });
+    await userEvent.click(toggle);
+    const bar = await screen.findByName("search-bar", { as: Gtk.SearchBar });
+
+    await waitFor(() => {
+        expect(bar).toHaveObjectProperty("searchModeEnabled", true);
+    });
+
+    return { toggle, bar };
+};
+
+const openSearchEntry = async (): Promise<Gtk.SearchEntry> => {
+    await activateSearchBar();
+
+    return await screen.findByName("search-entry", { as: Gtk.SearchEntry });
+};
+
 const getChildren = (widget: Gtk.Widget): Gtk.Widget[] => {
     const children: Gtk.Widget[] = [];
 
@@ -252,15 +308,22 @@ const getChildren = (widget: Gtk.Widget): Gtk.Widget[] => {
 };
 
 export {
+    activateSearchBar,
+    collectWidgets,
     createApplicationIdFactory,
+    expectCssReloadedOnEdit,
+    findCssLoadedOnMount,
     findInactiveSearchToggle,
     findOpenButton,
+    findWidget,
     getChildren,
     hasBufferTag,
     makeFileValue,
     makeIntValue,
+    makeRgba,
     makeRgbaValue,
     makeStringValue,
+    openSearchEntry,
     readBufferText,
     renderDemo,
     type RenderDemoOptions,


### PR DESCRIPTION
The demo test suites: the dedup pass introducing renderDemo, findWidget, collectWidgets and the css assertion helpers, on top of which the accessibility updates sit (access keys stripped from computed names, hidden popovers and offscreen rows asserted absent, scroll-until-visible loops) along with the matcher replacements the realignment forces.

Part 13 of 15 in the v1.0.0 release stack, based on `gtk-demo-source-cleanup`. Merge in order.

### Areas touched

- `examples/gtk-demo` (63)
