### PR TITLE
feat(create-gtkx): support bun as a package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Scaffold a new app with the `create-gtkx` initializer:
 npm create gtkx
 ```
 
-The same command works with other package managers: `pnpm create gtkx` or `yarn create gtkx`.
+The same command works with other package managers: `pnpm create gtkx`, `yarn create gtkx`, or `bun create gtkx`.
 
 Then run your new app:
 

--- a/packages/create-gtkx/src/build-allowance.ts
+++ b/packages/create-gtkx/src/build-allowance.ts
@@ -27,6 +27,12 @@ const writeYarnAllowance = (root: string): void => {
     });
 };
 
+const writeBunAllowance = (root: string): void => {
+    updateManifest(root, (manifest) => {
+        manifest.trustedDependencies = [...BUILT_DEPENDENCIES];
+    });
+};
+
 const writeBuildAllowance = (root: string, packageManager: PackageManager): void => {
     if (packageManager === "pnpm") {
         writePnpmAllowance(root);
@@ -36,6 +42,12 @@ const writeBuildAllowance = (root: string, packageManager: PackageManager): void
 
     if (packageManager === "yarn") {
         writeYarnAllowance(root);
+
+        return;
+    }
+
+    if (packageManager === "bun") {
+        writeBunAllowance(root);
 
         return;
     }

--- a/packages/create-gtkx/src/package-managers.ts
+++ b/packages/create-gtkx/src/package-managers.ts
@@ -4,6 +4,7 @@ const PACKAGE_MANAGERS = [
     { value: "pnpm", label: "pnpm", devCommand: "pnpm dev", addCommand: "pnpm add", isRecommended: true },
     { value: "npm", label: "npm", devCommand: "npm run dev", addCommand: "npm install", isRecommended: false },
     { value: "yarn", label: "yarn", devCommand: "yarn dev", addCommand: "yarn add", isRecommended: false },
+    { value: "bun", label: "bun", devCommand: "bun run dev", addCommand: "bun add", isRecommended: false },
 ] as const;
 
 const PACKAGE_MANAGER_VALUES: PackageManager[] = PACKAGE_MANAGERS.map((manager) => manager.value);

--- a/packages/create-gtkx/tests/create-project.ts
+++ b/packages/create-gtkx/tests/create-project.ts
@@ -28,7 +28,7 @@ type Workspace = { root: string; binDir: string; logPath: string };
 const WORKSPACE_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 const CLI_ENTRY = join(WORKSPACE_ROOT, "packages", "create-gtkx", "src", "cli.ts");
 const CLI_ARGV = ["--conditions=source", "--import", "tsx", CLI_ENTRY];
-const PACKAGE_MANAGERS = ["corepack", "pnpm", "npm", "yarn"];
+const PACKAGE_MANAGERS = ["corepack", "pnpm", "npm", "yarn", "bun"];
 const PROJECT_NAME = "my-app";
 const APPLICATION_ID = "com.example.myapp";
 const COVERAGE_SLOWDOWN = 3;

--- a/packages/create-gtkx/tests/scaffold.test.ts
+++ b/packages/create-gtkx/tests/scaffold.test.ts
@@ -109,6 +109,18 @@ describe("create-gtkx and the package manager it scaffolds for", () => {
             removeRun(yarnRun);
         }
     });
+
+    it("records the build allowance bun understands and installs through bun", () => {
+        const run = runCreate({ args: ["--no-interactive", "--application-id", APPLICATION_ID, "-p", "bun"] });
+
+        try {
+            expect(run.status).toBe(0);
+            expect(readManifest(run).trustedDependencies).toEqual(["@swc/core", "esbuild"]);
+            expect(run.installs.join("\n")).toContain("bun add");
+        } finally {
+            removeRun(run);
+        }
+    });
 });
 
 describe("create-gtkx and a directory that already holds files", () => {
@@ -158,7 +170,7 @@ describe("create-gtkx refusing to scaffold", () => {
 
     it("fails on a package manager it does not know", () => {
         const run = runCreate({
-            args: ["--no-interactive", "--application-id", APPLICATION_ID, "--package-manager", "bun"],
+            args: ["--no-interactive", "--application-id", APPLICATION_ID, "--package-manager", "deno"],
         });
 
         try {


### PR DESCRIPTION
`bun create gtkx` now offers bun as a package manager option (plus `--package-manager bun`), so bun users get the same scaffold flow as pnpm/npm/yarn users.

Flatpak source-mode deploy stays npm/pnpm/yarn-only — `flatpak-node-generator` can't read bun lockfiles. Doesn't affect local dev or deb/rpm/appimage.